### PR TITLE
:bug: fix nodejs version outdated in docker and merge docker-compose …

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,11 @@ RUN		apt-get update -y; \
 
 WORKDIR /
 
+RUN		apt install curl -y
+RUN		npm cache clean -f
+RUN		npm install -g n
+RUN		n latest
+
 RUN		mkdir -p /initial-setting/config
 
 COPY	./initial-setting/* /initial-setting/

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -15,4 +15,10 @@ services:
       - "3307:3306"
     tty:
       true
-
+  gateway:
+    container_name: nginx_gateway
+    image: nginx:latest
+    ports:
+      - '80:80'
+    volumes:
+      - ../dev/:/etc/nginx/conf.d/


### PR DESCRIPTION
mariadb 컨테이너에서 nodejs 버전이 12 이하로 설치되는 문제를 latest로 설치하도록 하여 수정했습니다.
또한 도커 컴포즈 파일을 하나로 통일해서 backend 디렉토리에 넣어뒀습니다.