### PR TITLE
블랙홀에 빠진 유저 예외 처리 완료

### DIFF
--- a/backend/src/blackhole/repository/blackhole.repository.ts
+++ b/backend/src/blackhole/repository/blackhole.repository.ts
@@ -6,4 +6,13 @@ export abstract class IBlackholeRepository {
    * @return void
    */
   abstract deleteBlackholedUser(user_id: number): Promise<void>;
+
+  /**
+   * 블랙홀에 빠진 유저의 정보를 업데이트 한다.
+   * @param user_id
+   * 1. log_user 테이블에서 user_id를 음수로, intra_id를 [BLACKHOLED]${intra_id}로 업데이트
+   * 2. ban_user 테이블에서 user_id를 음수로 업데이트
+   * 3. user 테이블에서 user_id를 음수로, intra_id를 [BLACKHOLED]${intra_id}로 업데이트
+   */
+   abstract updateBlackholedUser(user_id: number, intra_id: string): Promise<void>;
 }

--- a/backend/src/blackhole/repository/rawquery.blackhole.repository.ts
+++ b/backend/src/blackhole/repository/rawquery.blackhole.repository.ts
@@ -1,12 +1,14 @@
-import { Inject } from '@nestjs/common';
+import { Inject, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IBlackholeRepository } from './blackhole.repository';
 import * as mariadb from 'mariadb';
 
 export class RawqueryBlackholeRepository implements IBlackholeRepository {
-  private pool;
+  private pool: mariadb.Pool;
+  private logger: Logger;
 
   constructor(@Inject(ConfigService) private configService: ConfigService) {
+    this.logger = new Logger(RawqueryBlackholeRepository.name);
     this.pool = mariadb.createPool({
       host: this.configService.get<string>('database.host'),
       user: this.configService.get<string>('database.user'),
@@ -14,9 +16,11 @@ export class RawqueryBlackholeRepository implements IBlackholeRepository {
       password: this.configService.get<string>('database.password'),
       database: this.configService.get<string>('database.database'),
       dateStrings: true,
+      multipleStatements: true,
     });
   }
 
+  // FIXME: 여러모로 유저를 삭제하는건 문제가 될 수 있어 사용하지 않게될 것 같습니다.
   async deleteBlackholedUser(user_id: number): Promise<void> {
     const connection = await this.pool.getConnection();
     const content = `
@@ -37,6 +41,64 @@ export class RawqueryBlackholeRepository implements IBlackholeRepository {
     `;
     await connection.query(content3).catch((err: any) => {
       throw new Error(`deleteBlackholedUser Error - ${err}`);
+    });
+    if (connection) connection.end();
+  }
+
+  async updateBlackholedUser(user_id: number, intra_id: string): Promise<void> {
+    const connection = await this.pool.getConnection()
+    .catch((err: any) => {
+      throw new Error(`updateBlackholedUser Error - ${err}`);
+    });
+
+    const content = `
+    SET @MIN_ID := (SELECT MIN(user_id) from user);
+    update lent_log set log_user_id = (
+      SELECT
+        IF(@MIN_ID > 0, -2, @MIN_ID - 1)
+    ) WHERE log_user_id = ${user_id};
+    `;
+    await connection.query(content)
+    .then(() => {
+      this.logger.warn(`Update lent_log info of ${intra_id}`)
+    })
+    .catch((err: any) => {
+      throw new Error(`updateBlackholedUser Error - ${err}`);
+    });
+
+    const content2 = `
+    SET @MIN_ID := (SELECT MIN(user_id) from user);
+    update ban_user SET user_id = (
+        SELECT
+            IF(@MIN_ID > 0, -2, @MIN_ID - 1)
+        ),
+        intra_id = CONCAT('[BLACKHOLED]', intra_id)
+    WHERE user_id = ${user_id};
+    `;
+    await connection.query(content2)
+    .then(() => {
+      this.logger.warn(`Update ban info of ${intra_id}`)
+    })
+    .catch((err: any) => {
+      throw new Error(`updateBlackholedUser Error - ${err}`);
+    });
+
+    const content3 = `
+    SET @MIN_ID := (SELECT MIN(user_id) from user);
+    update user SET user_id = (
+        SELECT
+            IF(@MIN_ID > 0, -2, @MIN_ID - 1)
+        ),
+        intra_id = CONCAT('[BLACKHOLED]', intra_id),
+        auth = 2
+    WHERE user_id = ${user_id};
+    `;
+    await connection.query(content3)
+    .then(() => {
+      this.logger.warn(`Update user info of ${intra_id}`)
+    })
+    .catch((err: any) => {
+      throw new Error(`updateBlackholedUser Error - ${err}`);
     });
     if (connection) connection.end();
   }


### PR DESCRIPTION
# 추가 기능
- 블랙홀에 빠진 유저를 삭제하는 대신 user_id를 음수로 바꾸고, intra_id 앞에 [BLACKHOLED]를 붙히도록 수정했습니다.

# 주석 처리된 기능
- user 한명 한명을 검사하는 도중 토큰이 만료됐을 때를 대비한 코드는 무한 루프의 가능성이 있을 것 같아 주석처리했습니다.

# 잠재적 문제점
당장은 문제가 없으나 추후 문제가 생길 가능성이 있는 부분입니다.
- 1시간당 intra에 보낼 수 있는 Request의 수는 최대 1200번 입니다.
- 그래서 만약 블랙홀에 빠지지 않고 Cabi DB에 정보가 등록된 유저가 1200명이 넘어서면 1200명 이후부터는 검사가 진행되지 않을 수 있는 문제가 존재합니다.
