### PR TITLE
fe_v3/Question Button

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/QuestionTestModal.tsx
+++ b/frontend_v3/src/components/atoms/buttons/QuestionTestModal.tsx
@@ -1,0 +1,103 @@
+/* eslint-disable */
+import * as React from "react";
+import Button from "@mui/material/Button";
+import { styled } from "@mui/material/styles";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import Typography from "@mui/material/Typography";
+
+// TODO: gyuwlee(?)
+// 본 테스트 모달 제거하고, QuestionButton 눌렀을 때 나올 모달창 구현
+
+const BootstrapDialog = styled(Dialog)(({ theme }) => ({
+  "& .MuiDialogContent-root": {
+    padding: theme.spacing(2),
+  },
+  "& .MuiDialogActions-root": {
+    padding: theme.spacing(1),
+  },
+}));
+
+export interface DialogTitleProps {
+  id: string;
+  children?: React.ReactNode;
+  onClose: () => void;
+}
+
+const BootstrapDialogTitle = (props: DialogTitleProps) => {
+  const { children, onClose, ...other } = props;
+
+  return (
+    <DialogTitle sx={{ m: 0, p: 2 }} {...other}>
+      {children}
+      {onClose ? (
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+            color: (theme) => theme.palette.grey[500],
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+      ) : null}
+    </DialogTitle>
+  );
+};
+
+interface TestModalProps {
+  open: boolean;
+  handleClick: () => void;
+}
+
+export default function TestModal(props: TestModalProps) {
+  return (
+    <BootstrapDialog
+      onClose={props.handleClick}
+      aria-labelledby="customized-dialog-title"
+      open={props.open}
+    >
+      <BootstrapDialogTitle
+        id="customized-dialog-title"
+        onClose={props.handleClick}
+      >
+        🗄 42cabi 이용 안내서
+      </BootstrapDialogTitle>
+      <DialogContent dividers>
+        <Typography gutterBottom>
+          - 1인 당 1개의 사물함을 대여할 수 있고, 대여기간 동안 자유롭게 사용할
+          수 있습니다.
+        </Typography>
+        <Typography gutterBottom>
+          - 대여기간은 대여한 날로 부터 +30일 입니다.
+        </Typography>
+        <Typography gutterBottom>
+          - 반납 시 두고가는 소지품이 없는 지 확인해주세요!
+        </Typography>
+        <Typography gutterBottom>
+          - 대여하신 사물함의 비밀번호는 저장하지 않으니 따로 기록해주세요.
+        </Typography>
+        <Typography gutterBottom>
+          - 사물함에 상할 수 있는 음식물이나 사물함이 오염 될 수 있는 물품
+          보관은 자제해주세요.
+        </Typography>
+        <Typography gutterBottom>
+          - 대여한 사물함이 잠겨 있거나 비밀번호를 분실하셨다면 프론트의 Staff
+          혹은 42cabi 슬랙 채널로 문의해주세요.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button autoFocus onClick={props.handleClick}>
+          OK! 알았어요!
+        </Button>
+      </DialogActions>
+    </BootstrapDialog>
+  );
+}

--- a/frontend_v3/src/components/atoms/buttons/QustionButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/QustionButton.tsx
@@ -1,0 +1,48 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleQuestion } from "@fortawesome/free-regular-svg-icons";
+import { useState } from "react";
+import styled from "@emotion/styled";
+import TestModal from "./QuestionTestModal";
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  outline: 0;
+  &:focus,
+  &:hover {
+    border: 0;
+    outline: 0;
+  }
+`;
+
+// XXX: 모달과 버튼 분리 여부
+// 본 버튼의 이름이 QuestionButton이긴 하지만 기능상 하나의 모달을 열어주는 버튼에 가까운 것 같습니다.
+// 그래서 이 버튼 컴포넌트는 모달을 열어주는 버튼의 역할만 하고, 모달은 따로 관리하는 것이 좋을 것 같습니다.
+// 그렇게 되면, 모달의 open 상태를 버튼과 모달 중 어느 컴포넌트에서 관리해야 할까요..? 우선은 버튼에 두었습니다.
+// 의견을 부탁드립니다.. @->---
+const QuestionButton = (): JSX.Element => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClick = (): void => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  return (
+    <Button onClick={handleClick}>
+      <FontAwesomeIcon icon={faCircleQuestion} />
+      {/* TODO: gyuwlee */}
+      {/* TestModal 제거 */}
+      {isModalOpen && (
+        <TestModal open={isModalOpen} handleClick={handleClick} />
+      )}
+    </Button>
+  );
+};
+
+export default QuestionButton;


### PR DESCRIPTION
#204 
**styled** 및 **fontAwesomeIcon** 사용하여 **우측 하단 이용안내 버튼** 구현했습니다.

아래는 구현 과정에서 생긴 질문입니다(`QuestionButton.tsx` 파일의 `line 24` 주석에 동일하게 기재되어 있습니다):
- 모달의 `open` 상태를 버튼과 모달 중 어느 컴포넌트에서 관리해야 할까요??
  - 우선은 모달 컴포넌트를 버튼과 분리해서 따로 관리하고, 버튼 컴포넌트 내부에서 import해서 사용하도록 구현하여 `open` 상태 역시 버튼에서 관리하도록 만들었습니다
  - 그런데 이렇게 만들면 컴포넌트를 충분히 독립적으로 추상화시킨 게 맞는지 모르겠습니다. 차라리 `open` 상태를 redux로 관리하는 게 맞을까요?