### PR TITLE
fe_v3/Check Button

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/CheckButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/CheckButton.tsx
@@ -1,0 +1,37 @@
+import Button from "@mui/material/Button";
+
+interface CheckButtonProps {
+  color: "primary" | "secondary" | "error" | "info" | "success" | "warning";
+  variant: "text" | "outlined" | "contained";
+  content: string;
+  isChecked?: boolean;
+  onClick: () => void;
+}
+
+const CheckButton = (props: CheckButtonProps): JSX.Element => {
+  const { color, variant, isChecked, onClick, content } = props;
+
+  // TODO: 상위 컴포넌트에 isChecked 상태 관리하는 이벤트 핸들러 구현 필요
+  return (
+    <Button
+      color={color}
+      variant={variant}
+      disabled={!isChecked}
+      onClick={onClick}
+      sx={{
+        "&:focus": {
+          border: 0,
+          outline: 0,
+        },
+      }}
+    >
+      {content}
+    </Button>
+  );
+};
+
+CheckButton.defaultProps = {
+  isChecked: true,
+};
+
+export default CheckButton;

--- a/frontend_v3/src/main.tsx
+++ b/frontend_v3/src/main.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { ThemeProvider } from "@mui/material/styles";
+import muiCustomPaletteTheme from "./themes/muiCustomPaletteTheme.tsx";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={muiCustomPaletteTheme}>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/frontend_v3/src/themes/muiCustomPaletteTheme.tsx.tsx
+++ b/frontend_v3/src/themes/muiCustomPaletteTheme.tsx.tsx
@@ -1,0 +1,14 @@
+import { createTheme } from "@mui/material/styles";
+
+const muiCustomPaletteTheme = createTheme({
+  palette: {
+    primary: {
+      main: "#5657a5",
+      // light: main값을 통해 계산됨
+      // dark: main값을 통해 계산됨
+      // contrastText: main값을 통해 계산됨
+    },
+  },
+});
+
+export default muiCustomPaletteTheme;


### PR DESCRIPTION
#204 
Mui `Button`으로 확인 및 취소 등에 사용되는 버튼 구현하였습니다.

- `Variant` : contained, outlined 등 3종류
- `color` : primary 등 7종류
  - type이 “primary” | “secondary” 등 7개로 고정돼 있음
  - 색상을 props로 받느라 인터페이스로 지정
    - 인터페이스에 color: string으로 하면 타입 에러 발생
      - mui에서 아예 고정되어있는 듯..?
- 그래서 primary 색상을 아예 보라색으로 바꾸기 위해 createTheme과 ThemeProvider 임포트 및 사용
  - GlobalStyle과 같이 /src/App.tsx 에서 사용하려고 했으나, App tree의 root에서 사용하는 것을 권장한다는 에러가 떠서 /src/main.tsx에서 <App />을 감싸도록 적용함
- `Disabled`:  props.isChecked 값으로 제어
  - `isChecked` 상태는 상위 컴포넌트에서 제어
- `onClick` : 버튼 사용 맥락에 따른 이벤트 핸들러로 상위 컴포넌트로부터 넘겨받음