### PR TITLE
fe_v3:React.Fragment to div

### DIFF
--- a/frontend_v3/src/components/organisms/EditInput.tsx
+++ b/frontend_v3/src/components/organisms/EditInput.tsx
@@ -4,10 +4,10 @@ import Input from "../atoms/inputs/Input";
 
 const EditInput = (): JSX.Element => {
   return (
-    <>
+    <div>
       <Input />
       <Button />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
edit input이 React.Fragment 태그로 감싸져 있었는데, 해당 컴포넌트를 다른 컴포넌트에서 사용할 때, React.Fragment가 사라지는 경우가 있어 div태그로 바꿨습니다