### PR TITLE
Fe v3/Edit Button Update

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/EditButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/EditButton.tsx
@@ -5,6 +5,10 @@ import {
   faCircleCheck,
 } from "@fortawesome/free-regular-svg-icons";
 import styled from "@emotion/styled";
+import {
+  axiosUpdateCabinetMemo,
+  axiosUpdateCabinetTitle,
+} from "../../../network/axios/axios.custom";
 
 const Button = styled.button`
   display: flex;
@@ -23,21 +27,40 @@ const Button = styled.button`
 `;
 
 interface EditButtonProps {
+  contentType: "title" | "memo";
   isToggle: boolean;
   setIsToggle: Dispatch<SetStateAction<boolean>>;
-  value: string;
+  inputValue: string;
+  setTextValue: Dispatch<SetStateAction<string>>;
 }
 
 const EditButton = (props: EditButtonProps): JSX.Element => {
-  const { isToggle, setIsToggle, value } = props;
+  const { isToggle, setIsToggle, inputValue, contentType, setTextValue } =
+    props;
   const handleEditButtonClick = (): void => {
     setIsToggle(true);
   };
   const handleSaveButtonClick = (): void => {
     setIsToggle(false);
-    // TODO: gyuwlee
-    // value를 이용해 서버에 저장하는 로직 추가
-    // 버튼을 눌렀을 때 서버에 저장하는 로직이 실행되고 나서, value를 새로 저장된 값으로 업데이트하도록 다시 API를 호출해야 할 것 같습니다.
+    if (contentType === "title") {
+      axiosUpdateCabinetTitle(inputValue)
+        .then(() => {
+          setTextValue(inputValue);
+        })
+        .catch((error) => {
+          console.error(error);
+          alert("🚨 수정에 실패했습니다 🚨");
+        });
+    } else {
+      axiosUpdateCabinetMemo(inputValue)
+        .then(() => {
+          setTextValue(inputValue);
+        })
+        .catch((error) => {
+          console.error(error);
+          alert("🚨 수정에 실패했습니다 🚨");
+        });
+    }
   };
 
   return isToggle === false ? (

--- a/frontend_v3/src/components/atoms/buttons/EditButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/EditButton.tsx
@@ -31,12 +31,21 @@ interface EditButtonProps {
   isToggle: boolean;
   setIsToggle: Dispatch<SetStateAction<boolean>>;
   inputValue: string;
+  textValue: string;
   setTextValue: Dispatch<SetStateAction<string>>;
+  setInputValue: Dispatch<SetStateAction<string>>;
 }
 
 const EditButton = (props: EditButtonProps): JSX.Element => {
-  const { isToggle, setIsToggle, inputValue, contentType, setTextValue } =
-    props;
+  const {
+    isToggle,
+    setIsToggle,
+    inputValue,
+    textValue,
+    contentType,
+    setTextValue,
+    setInputValue,
+  } = props;
   const handleEditButtonClick = (): void => {
     setIsToggle(true);
   };
@@ -50,6 +59,7 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
         .catch((error) => {
           console.error(error);
           alert("🚨 수정에 실패했습니다 🚨");
+          setInputValue(textValue);
         });
     } else {
       axiosUpdateCabinetMemo(inputValue)
@@ -59,6 +69,7 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
         .catch((error) => {
           console.error(error);
           alert("🚨 수정에 실패했습니다 🚨");
+          setInputValue(textValue);
         });
     }
   };

--- a/frontend_v3/src/components/atoms/inputs/TestTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/TestTextField.tsx
@@ -12,24 +12,35 @@ const Container = styled.div`
   align-items: center;
 `;
 
-const TestTextField = (): JSX.Element => {
-  // TODO: gyuwlee(?)
-  // value 의 초기 값을 빈 문자열이 아닌 '서버에서 받아온 값'으로 설정해야 합니다.
-  const [value, setValue] = useState("");
+interface TestTextFieldProps {
+  contentType: "title" | "memo";
+  currentContent: string;
+}
+
+const TestTextField = (props: TestTextFieldProps): JSX.Element => {
+  const { contentType, currentContent } = props;
+  const [textValue, setTextValue] = useState(currentContent);
+  const [inputValue, setInputValue] = useState(textValue);
   const [isToggle, setIsToggle] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    setValue(e.target.value);
+    setInputValue(e.target.value);
   };
 
   return (
     <Container>
       {isToggle === false ? (
-        <p>{value}</p>
+        <p>{textValue}</p>
       ) : (
         <input type="text" onChange={handleChange} />
       )}
-      <EditButton isToggle={isToggle} setIsToggle={setIsToggle} value={value} />
+      <EditButton
+        isToggle={isToggle}
+        setIsToggle={setIsToggle}
+        contentType={contentType}
+        inputValue={inputValue}
+        setTextValue={setTextValue}
+      />
     </Container>
   );
 };

--- a/frontend_v3/src/components/atoms/inputs/TestTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/TestTextField.tsx
@@ -32,14 +32,16 @@ const TestTextField = (props: TestTextFieldProps): JSX.Element => {
       {isToggle === false ? (
         <p>{textValue}</p>
       ) : (
-        <input type="text" onChange={handleChange} />
+        <input type="text" value={inputValue} onChange={handleChange} />
       )}
       <EditButton
         isToggle={isToggle}
         setIsToggle={setIsToggle}
         contentType={contentType}
         inputValue={inputValue}
+        textValue={textValue}
         setTextValue={setTextValue}
+        setInputValue={setInputValue}
       />
     </Container>
   );

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -81,3 +81,24 @@ export const axiosReturnInfo = async (): Promise<any> => {
     throw error;
   }
 };
+
+// TODO: my_lent_info API 분리 후 업데이트
+const axiosUpdateCabinetMemoURL = "/api/";
+export const axiosUpdateCabinetMemo = async (memo: string): Promise<any> => {
+  try {
+    const response = await instance.patch(axiosUpdateCabinetMemoURL, memo);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosUpdateCabinetTitleURL = "/api/";
+export const axiosUpdateCabinetTitle = async (title: string): Promise<any> => {
+  try {
+    const response = await instance.patch(axiosUpdateCabinetTitleURL, title);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
- `axios.custom.ts`에 `axiosUpdateCabinetMemo` 및 `axiosUpdateCabinetTitle` 추가했습니다.
  - API 분리됨에 따라 URL 업데이트 필요합니다.
- `TestTextFieldProps`에서 contentType으로 title인지 memo인지 구분했습니다.
  - `p`태그로 보여지는 값과 `input`태그로 입력되는 값을 각각 `textValue`, `inputValue`로 구분했습니다.
- `EditButton.tsx`에서 axios 사용하여 patch 성공 시 사용자가 변경한 값으로 `textValue`가 변경됩니다.