### PR TITLE
fe_v3/carousel

### DIFF
--- a/frontend_v3/src/App.tsx
+++ b/frontend_v3/src/App.tsx
@@ -5,6 +5,7 @@ import GlobalStyle from "./styles/GlobalStyle";
 import Login from "./pages/Login";
 import Main from "./pages/Main";
 import Lent from "./pages/Lent";
+import Carousel from "./sample/Carousel/Carousel";
 
 // 기존 .App 설정
 const AppDiv = styled.div`
@@ -26,6 +27,7 @@ function App(): JSX.Element {
             <Route path="/" element={<Login />} />
             <Route path="/main" element={<Main />} />
             <Route path="/Lent" element={<Lent />} />
+            <Route path="/Carousel" element={<Carousel />} />
             <Route path="/*" element={<Login />} />
           </Routes>
         </Section>

--- a/frontend_v3/src/sample/Carousel/Box.tsx
+++ b/frontend_v3/src/sample/Carousel/Box.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+const BoxComponent = styled.div`
+  display: inline-block;
+  width: 48px;
+  height: 48px;
+  border: 1px solid ${(props) => (props ? props.color : `black`)};
+`;
+
+interface BoxProps {
+  index: number;
+  color: string;
+}
+const Box = (props: BoxProps): JSX.Element => {
+  const { index, color } = props;
+  return <BoxComponent color={color}>{index}</BoxComponent>;
+};
+
+export default Box;

--- a/frontend_v3/src/sample/Carousel/ButtonArea.tsx
+++ b/frontend_v3/src/sample/Carousel/ButtonArea.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "@emotion/styled";
+import SlideButton from "./SlideButton";
+
+const ButtonAreaComponent = styled.div`
+  display: flex;
+  justify-content: space-around;
+  flex-direction: row;
+`;
+
+interface ButtonAreaProps {
+  lastSlide: number;
+  currentSlide: number;
+  setCurrentSlide: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const ButtonArea = (props: ButtonAreaProps): JSX.Element => {
+  const { lastSlide, currentSlide, setCurrentSlide } = props;
+  return (
+    <ButtonAreaComponent>
+      <SlideButton
+        direction="left"
+        currentSlide={currentSlide}
+        setCurrentSlide={setCurrentSlide}
+        lastSlide={lastSlide}
+      />
+      <SlideButton
+        direction="right"
+        currentSlide={currentSlide}
+        setCurrentSlide={setCurrentSlide}
+        lastSlide={lastSlide}
+      />
+    </ButtonAreaComponent>
+  );
+};
+
+export default ButtonArea;

--- a/frontend_v3/src/sample/Carousel/Carousel.tsx
+++ b/frontend_v3/src/sample/Carousel/Carousel.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef, useState } from "react";
+import styled from "@emotion/styled";
+import SlideContainer from "./SlideContainer";
+import ButtonArea from "./ButtonArea";
+
+const CarouselComponent = styled.div`
+  width: 150px;
+  margin: auto;
+  overflow: hidden;
+`;
+
+const Carousel = () => {
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const slideRef = useRef(null);
+  const lastSlide = 2;
+
+  useEffect(() => {
+    slideRef.current.style.transition = "all 0.5s ease-in-out";
+    slideRef.current.style.transform = `translateX(-${currentSlide}00%)`; // 백틱을 사용하여 슬라이드로 이동하는 에니메이션을 만듭니다.
+  }, [currentSlide]);
+
+  return (
+    <CarouselComponent>
+      <SlideContainer slideRef={slideRef} />
+      <ButtonArea
+        currentSlide={currentSlide}
+        setCurrentSlide={setCurrentSlide}
+        lastSlide={lastSlide}
+      />
+    </CarouselComponent>
+  );
+};
+
+export default Carousel;

--- a/frontend_v3/src/sample/Carousel/Slide.tsx
+++ b/frontend_v3/src/sample/Carousel/Slide.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Box from "./Box";
+
+const SlideComponent = styled.div`
+  width: 150px;
+  height: 480px;
+  margin: auto;
+  -webkit-overflow-scrolling: auto;
+`;
+
+const BoxLineComponet = styled.div`
+  display: flex;
+`;
+
+interface SlideProps {
+  color: string;
+}
+
+const Slide = (props: SlideProps): JSX.Element => {
+  const { color } = props;
+
+  const countOneRow = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5,
+    6, 7, 8, 9, 10,
+  ];
+
+  const BoxesOneRow = (): JSX.Element[] => {
+    const list: JSX.Element[] = [];
+    for (let index = 0; index < countOneRow.length / 3; index += 1) {
+      const temp: JSX.Element[] = [];
+      for (let idx = 0; idx < 3; idx += 1) {
+        if (countOneRow[index * 3 + idx])
+          temp.push(<Box key={idx} index={index * 3 + idx} color={color} />);
+      }
+      list.push(<BoxLineComponet key={index}>{temp}</BoxLineComponet>);
+    }
+    return list;
+    /*
+    return countOneRow.map((item: number, index: number) => {
+      return <Box key={index} index={index} color={color} />;
+    });
+    */
+  };
+
+  const count = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+    [1, 2, 3],
+    [4, 5, 6],
+  ];
+  const Boxes = (): JSX.Element[] => {
+    return count.map((items: number[], index: number) => {
+      return (
+        <BoxLineComponet key={index}>
+          {items.map((item, idx: number) => {
+            return <Box key={idx} index={idx + index * 3} color={color} />;
+          })}
+        </BoxLineComponet>
+      );
+    });
+  };
+  return <SlideComponent>{BoxesOneRow()}</SlideComponent>;
+};
+
+export default Slide;

--- a/frontend_v3/src/sample/Carousel/SlideButton.tsx
+++ b/frontend_v3/src/sample/Carousel/SlideButton.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+const SlideButtonComponent = styled.button`
+  width: 70px;
+  height: 20px;
+  border: 1px solid blue;
+  padding: 0;
+`;
+
+interface SlideButtonProps {
+  direction: string;
+  lastSlide: number;
+  currentSlide: number;
+  setCurrentSlide: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const SlideButton = (props: SlideButtonProps): JSX.Element => {
+  const { direction, lastSlide, currentSlide, setCurrentSlide } = props;
+  const clickHandler = (): void => {
+    if (direction === "left") {
+      if (currentSlide === 0) setCurrentSlide(lastSlide);
+      else setCurrentSlide(currentSlide - 1);
+    } else if (currentSlide === lastSlide) setCurrentSlide(0);
+    else setCurrentSlide(currentSlide + 1);
+  };
+  return (
+    <div>
+      {direction === "left" ? (
+        <SlideButtonComponent onClick={clickHandler}>LEFT</SlideButtonComponent>
+      ) : (
+        <SlideButtonComponent onClick={clickHandler}>
+          RIGHT
+        </SlideButtonComponent>
+      )}
+    </div>
+  );
+};
+
+export default SlideButton;

--- a/frontend_v3/src/sample/Carousel/SlideContainer.tsx
+++ b/frontend_v3/src/sample/Carousel/SlideContainer.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "@emotion/styled";
+import Slide from "./Slide";
+
+const SlideContainerComponent = styled.div`
+  display: flex;
+  width: 150px;
+  height: 480px;
+  margin: 10px auto;
+`;
+
+interface SlideContainerProps {
+  slideRef: any;
+}
+
+const SlideContainer = (props: SlideContainerProps): JSX.Element => {
+  const { slideRef } = props;
+  return (
+    <SlideContainerComponent ref={slideRef}>
+      <Slide color="red" />
+      <Slide color="green" />
+      <Slide color="blue" />
+    </SlideContainerComponent>
+  );
+};
+
+export default SlideContainer;


### PR DESCRIPTION
Carousel 컴포넌트
아래와 같은 이슈가 있는 상태입니다.

1. 스크롤 옵션
2. 캐비넷 정보를 섹션별로 1차원 배열로 받아 렌더 시, row마다 래핑이 필요합니다.
    래핑 없이 사용하면 inline-block 옵션을 통해 다른 슬라이드에서 보여줄 데이터가 합쳐져 보여집니다.