### PR TITLE
Content Template

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/LoginButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/LoginButton.tsx
@@ -1,11 +1,13 @@
 import style from "@emotion/styled";
 
 const Button = style.a`
+  display: block;
+  width: 30%;
   color: white;
   font-weight: bolder;
   border: white 0.2rem solid;
   border-radius: 1rem;
-  padding: 0.8rem 5rem;
+  padding: 0.8rem 3rem;
 `;
 
 const LoginButton = (): JSX.Element => {

--- a/frontend_v3/src/components/atoms/buttons/ReturnButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/ReturnButton.tsx
@@ -3,12 +3,13 @@ import styled from "@emotion/styled";
 import { axiosReturn } from "../../../network/axios/axios.custom";
 
 const Button = styled.button`
+  position: absolute;
   display: flex;
   color: #6667ab;
   font-size: 1.2rem;
   justify-content: center;
   align-items: center;
-  width: 50vw;
+  width: 50%;
   height: 3rem;
   padding: 0.5rem;
   border: 0.2rem #6667ab solid;

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { LentDto } from "../../types/dto/lent.dto";
 import { UserDto } from "../../types/dto/user.dto";
-import EditInput from "./EditInput";
+import TestTextField from "../atoms/inputs/TestTextField";
 
 const Content = styled.div`
   display: flex;
@@ -62,9 +62,15 @@ const LentInfo = (prop: LentInfoProps): JSX.Element => {
   return (
     <Content>
       {cabinetInfo()}
-      <EditInput />
+      <TestTextField
+        contentType="title"
+        currentContent="방 제목을 설정해주세요!"
+      />
       {userInfo()}
-      <EditInput />
+      <TestTextField
+        contentType="memo"
+        currentContent="아직 사용자가 없습니다!"
+      />
     </Content>
   );
 };

--- a/frontend_v3/src/components/templates/CabinetTemplate.tsx
+++ b/frontend_v3/src/components/templates/CabinetTemplate.tsx
@@ -6,8 +6,8 @@ import MenuButton from "../atoms/buttons/MenuButton";
 import QuestionButton from "../atoms/buttons/QustionButton";
 
 const MainSection = styled.section`
-  height: 90vh;
-  width: 25rem;
+  height: 100%;
+  width: 100%;
   background-color: #ffffffec;
   border-radius: 1rem;
 

--- a/frontend_v3/src/components/templates/ContentTemplate.tsx
+++ b/frontend_v3/src/components/templates/ContentTemplate.tsx
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { PropsWithChildren } from "react";
+
+const ContentSection = styled.section`
+  height: 90vh;
+  width: 90vw;
+  max-width: 25rem;
+  text-align: center;
+`;
+
+const ContentTemplate = ({ children }: PropsWithChildren): JSX.Element => {
+  return <ContentSection id="content">{children}</ContentSection>;
+};
+
+export default ContentTemplate;

--- a/frontend_v3/src/components/templates/LentTemplate.tsx
+++ b/frontend_v3/src/components/templates/LentTemplate.tsx
@@ -8,14 +8,23 @@ import LentInfo from "../organisms/LentInfo";
 import { axiosMyLentInfo } from "../../network/axios/axios.custom";
 import { MyCabinetInfoResponseDto } from "../../types/dto/cabinet.dto";
 
+// const LentSection = styled.section`
+//   position: absolute;
+//   left: 5vw;
+//   top: 5vw;
+//   background-color: #f4f3f8;
+//   border-radius: 1rem;
+//   width: 90vw;
+//   height: calc(90vh - 10vw);
+// `;
+
 const LentSection = styled.section`
-  position: absolute;
+  width: 100%;
+  height: 100%;
   left: 5vw;
   top: 5vw;
   background-color: #f4f3f8;
   border-radius: 1rem;
-  width: 90vw;
-  height: calc(90vh - 10vw);
 `;
 
 const LentNavSection = styled.div`
@@ -30,14 +39,16 @@ const LentInfoSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 80%;
+  height: 75%;
 `;
 
 const LentReturnSection = styled.div`
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
   height: 10%;
+  margin-top: 5%;
 `;
 
 const LentTemplate = (): JSX.Element => {
@@ -59,7 +70,7 @@ const LentTemplate = (): JSX.Element => {
   }, []);
 
   return (
-    <LentSection>
+    <LentSection id="test">
       <LentNavSection>
         <HomeButton />
         <MenuButton />

--- a/frontend_v3/src/components/templates/LoginTemplate.tsx
+++ b/frontend_v3/src/components/templates/LoginTemplate.tsx
@@ -2,13 +2,19 @@ import styled from "@emotion/styled";
 import LoginButton from "../atoms/buttons/LoginButton";
 
 const LoginSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   height: 100%;
+  overflow: hidden;
   text-align: center;
 
   > img {
-    height: 24%;
-    object-fit: scale-down;
-    padding: 10rem 0;
+    width: 100%;
+    height: auto;
+    display: block;
+    margin-bottom: 5rem;
   }
 
   > a:hover,

--- a/frontend_v3/src/components/templates/LoginTemplate.tsx
+++ b/frontend_v3/src/components/templates/LoginTemplate.tsx
@@ -2,11 +2,11 @@ import styled from "@emotion/styled";
 import LoginButton from "../atoms/buttons/LoginButton";
 
 const LoginSection = styled.section`
-  height: 90vh;
+  height: 100%;
   text-align: center;
 
   > img {
-    height: 13rem;
+    height: 24%;
     object-fit: scale-down;
     padding: 10rem 0;
   }

--- a/frontend_v3/src/index.css
+++ b/frontend_v3/src/index.css
@@ -28,7 +28,6 @@ body {
   margin: 0;
   display: flex;
   place-items: center;
-  min-width: 320px;
   min-height: 100vh;
 }
 

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -87,7 +87,7 @@ const axiosMyLentInfoURL = "/api/my_lent_info";
 export const axiosMyLentInfo = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosMyLentInfoURL);
-      return response;
+    return response;
   } catch (error) {
     throw error;
   }

--- a/frontend_v3/src/pages/Lent.tsx
+++ b/frontend_v3/src/pages/Lent.tsx
@@ -1,11 +1,14 @@
 import LentTemplate from "../components/templates/LentTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import Carousel from "../sample/Carousel/Carousel";
+import ContentTemplate from "../components/templates/ContentTemplate";
 
 const Lent = (): JSX.Element => {
   return (
     <>
-      <LentTemplate />
+      <ContentTemplate>
+        <LentTemplate />
+      </ContentTemplate>
       <FooterTemplate />
     </>
   );

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -1,10 +1,13 @@
 import LoginTemplate from "../components/templates/LoginTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
+import ContentTemplate from "../components/templates/ContentTemplate";
 
 const Login = (): JSX.Element => {
   return (
     <>
-      <LoginTemplate />
+      <ContentTemplate>
+        <LoginTemplate />
+      </ContentTemplate>
       <FooterTemplate />
     </>
   );

--- a/frontend_v3/src/pages/Main.tsx
+++ b/frontend_v3/src/pages/Main.tsx
@@ -1,6 +1,7 @@
 import CabinetTemplate from "../components/templates/CabinetTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import CabinetBoxButton from "../components/atoms/buttons/CabinetBoxButton";
+import ContentTemplate from "../components/templates/ContentTemplate";
 
 /*
 interface UserDto {
@@ -82,7 +83,9 @@ const Main = (): JSX.Element => {
           />
         </div>
   */}
-      <CabinetTemplate />
+      <ContentTemplate>
+        <CabinetTemplate />
+      </ContentTemplate>
       <FooterTemplate />
     </>
   );

--- a/frontend_v3/src/styles/GlobalStyle.tsx
+++ b/frontend_v3/src/styles/GlobalStyle.tsx
@@ -19,8 +19,10 @@ const style = css`
     background: -webkit-linear-gradient(to bottom, #6667ab, #6c337d);
     background: linear-gradient(to bottom, #6667ab, #6c337d);
     justify-content: center;
+    box-sizing: border-box;
     height: 100vh;
     margin: 0;
+    padding: 0 1rem;
     font-family: "EliceDigitalBaeum_Regular";
   }
 `;


### PR DESCRIPTION
## Draft

- ContentTemplate 구현해서 적용했습니다
- Login 페이지가 가로 해상도 390px 이하부터는 깨지는데, 아직 원인을 못 찾았습니다 😭
  - 위와 같은 이유로 우선 Draft로 올렸습니다.

## Open

- LoginSection에 display: flex 추가 및 내부 img 태그에서 display, width 속성 수정하여 해결했습니다.
- 가로 해상도를 줄이면 이미지는 함께 줄어드는데 a태그(버튼) 사이즈는 그대로인 문제가 남아있습니다.