### PR TITLE
fe_v3/cabinetAction

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/FloorButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/FloorButton.tsx
@@ -1,35 +1,36 @@
-import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
-import React, { useState } from "react";
+import Button from "@mui/material/Button";
+import React from "react";
 import { useAppSelector } from "../../../redux/hooks";
 
-const FloorButton = () => {
-  // XXX:
-  // 로그인 시 최초 API 호출로 4중 배열 불러오고, 버튼에서는 내부 커스텀 액션으로 필요한 정보만 나눠서 가져오기
-  const info = useAppSelector((state) => state.cabinet);
+// XXX:
+// 로그인 시 최초 API 호출로 4중 배열 불러오고, 버튼에서는 내부 커스텀 액션으로 필요한 정보만 나눠서 가져오기
+// TODO:
+// 1. 현재 건물 위치 알려주는 l_idx 변수명 더 구체적으로 변경하면 좋을 것 같습니다
+// 2. location 변경 시 setLidx 함수를 통해 l_idx가 변경되고 있어,
+// 버튼이 아닌 다른 컴포넌트에서 이 상태를 관리하도록 변경하는 게 좋을 것 같습니다
+//   const [l_idx, setLidx] = useState<number>(0);
+//   // TODO:
+//   // 3. info 업데이트하기 위해 axios API 및 dispatch 호출
+//   // TODO:
+//   // 4. handleClick 이벤트 핸들러 구현
 
-  // TODO:
-  // 1. 현재 건물 위치 알려주는 l_idx 변수명 더 구체적으로 변경하면 좋을 것 같습니다
-  // 2. location 변경 시 setLidx 함수를 통해 l_idx가 변경되고 있어,
-  // 버튼이 아닌 다른 컴포넌트에서 이 상태를 관리하도록 변경하는 게 좋을 것 같습니다
-  const [l_idx, setLidx] = useState<number>(0);
+interface FloorButtonProps {
+  setFloor: (floor: number) => void;
+}
 
-  // TODO:
-  // 3. info 업데이트하기 위해 axios API 및 dispatch 호출
-
-  // TODO:
-  // 4. handleClick 이벤트 핸들러 구현
-  const handleClick = (
-    e: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>
-  ): void => {
-    console.log("clicked");
+const FloorButton = (props: FloorButtonProps): JSX.Element => {
+  const { setFloor } = props;
+  const floors = useAppSelector((state) => state.cabinet.floor);
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    const getFloor: string | null = e.currentTarget.getAttribute("button-key");
+    if (getFloor) setFloor(parseInt(getFloor, 10));
   };
-
   return (
     <ButtonGroup variant="contained" color="primary">
-      {info.floor[l_idx].map((floor: number) => {
+      {floors?.[0].map((floor: number) => {
         return (
-          <Button key={floor} onClick={handleClick}>
+          <Button key={floor} button-key={floor} onClick={handleClick}>
             {floor}F
           </Button>
         );

--- a/frontend_v3/src/components/atoms/buttons/LocationButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/LocationButton.tsx
@@ -4,6 +4,7 @@ import { faSortDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
+import { useAppSelector } from "../../../redux/hooks";
 
 const Button = styled.button`
   display: flex;
@@ -17,7 +18,14 @@ const Button = styled.button`
   background-color: transparent;
 `;
 
-const BuildingButton = (): JSX.Element => {
+interface LocationButtonProps {
+  currentLocation: string;
+  setCurrentLocation: (location: string) => void;
+}
+
+const LocationButton = (props: LocationButtonProps): JSX.Element => {
+  const { currentLocation, setCurrentLocation } = props;
+  const locations = useAppSelector((state) => state.cabinet.location);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -25,10 +33,10 @@ const BuildingButton = (): JSX.Element => {
     setAnchorEl(event.currentTarget);
   };
 
-  // todo : seuan
-  // 차후 새롬관, 마루관에 따라 다르게 보여줘야할 경우 건물의 정보를 받아와야합니다.
-  // 현재는 새롬관(default)만 존재하므로 고려하지 않아도 됩니다.
-  const handleBuilding = (): void => {
+  const handleBuilding = (e: any): void => {
+    const getLocation: string | null =
+      e.currentTarget.getAttribute("button-key");
+    if (getLocation) setCurrentLocation(getLocation);
     setAnchorEl(null);
   };
 
@@ -36,14 +44,23 @@ const BuildingButton = (): JSX.Element => {
     <div>
       <Button onClick={handleClick}>
         <FontAwesomeIcon icon={faSortDown} />
-        &nbsp;새롬관
+        &nbsp;{currentLocation}
       </Button>
       <Menu anchorEl={anchorEl} open={open} onClose={handleBuilding}>
-        <MenuItem onClick={handleBuilding}>새롬관</MenuItem>
-        <MenuItem onClick={handleBuilding}>마루관</MenuItem>
+        {locations?.map((location: string) => {
+          return (
+            <MenuItem
+              button-key={location}
+              key={location}
+              onClick={handleBuilding}
+            >
+              {location}
+            </MenuItem>
+          );
+        })}
       </Menu>
     </div>
   );
 };
 
-export default BuildingButton;
+export default LocationButton;

--- a/frontend_v3/src/components/templates/CabinetTemplate.tsx
+++ b/frontend_v3/src/components/templates/CabinetTemplate.tsx
@@ -1,11 +1,14 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import HomeButton from "../atoms/buttons/HomeButton";
-import BuildingButton from "../atoms/buttons/BuildingButton";
+import LocationButton from "../atoms/buttons/LocationButton";
 import MenuButton from "../atoms/buttons/MenuButton";
-// import FloorButton from "../atoms/buttons/FloorButton";
+import FloorButton from "../atoms/buttons/FloorButton";
 import QuestionButton from "../atoms/buttons/QustionButton";
 import Carousel from "../organisms/Carousel";
+import { axiosCabinetInfo } from "../../network/axios/axios.custom";
+import { cabinetAll } from "../../redux/slices/cabinetSlice";
 
 const MainSection = styled.section`
   height: 100%;
@@ -23,6 +26,9 @@ const MainNavSection = styled.div`
   height: 5%;
   padding: 0.5rem 0.7rem 0 0.7rem;
 `;
+
+const MainFloorSection = styled.div``;
+
 const MainCarouselSection = styled.div`
   color: #333;
   height: 90%;
@@ -38,13 +44,58 @@ const MainQuestionSection = styled.div`
 // slide 개수를 건물, 층에 따라 계산하여 Carousel의 인자로 넘겨줘야 함.
 
 const CabinetTemplate = (): JSX.Element => {
+  // 기존 API
+  const dispatch = useAppDispatch();
+  const [currentLocation, setCurrentLocation] = useState<string>("새롬관");
+  const [currentFloor, setCurrentFloor] = useState<number>(2);
+  useEffect(() => {
+    axiosCabinetInfo()
+      .then((response) => {
+        dispatch(cabinetAll(response.data));
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, []);
+
+  interface cabinetInfo {
+    cabinet_id: number;
+    cabinet_num: number;
+    location: string;
+    floor: number;
+    section: string;
+    activation: boolean;
+  }
+
+  const cabinets = useAppSelector((state) => state.cabinet.cabinet);
+  const target: Array<cabinetInfo> = [];
+  cabinets?.[0].forEach((e) => {
+    e.forEach((e) => {
+      e.forEach((cabinetInfo: cabinetInfo) => {
+        if (
+          cabinetInfo.location === currentLocation &&
+          cabinetInfo.floor === currentFloor
+        )
+          target.push(cabinetInfo);
+      });
+    });
+  });
+  console.log(`Current location: ${currentLocation} floor: ${currentFloor}`);
+  console.log(target);
+
   return (
     <MainSection>
       <MainNavSection>
         <HomeButton />
-        <BuildingButton />
+        <LocationButton
+          currentLocation={currentLocation}
+          setCurrentLocation={setCurrentLocation}
+        />
         <MenuButton />
       </MainNavSection>
+      <MainFloorSection>
+        <FloorButton setFloor={setCurrentFloor} />
+      </MainFloorSection>
       <MainCarouselSection>
         <Carousel slideCount={3} />
       </MainCarouselSection>

--- a/frontend_v3/src/main.tsx
+++ b/frontend_v3/src/main.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { ThemeProvider } from "@mui/material/styles";
+import { Provider } from "react-redux";
+import store from "./redux/store";
 import muiCustomPaletteTheme from "./themes/muiCustomPaletteTheme.tsx";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <ThemeProvider theme={muiCustomPaletteTheme}>
-      <App />
-    </ThemeProvider>
+    <Provider store={store}>
+      <ThemeProvider theme={muiCustomPaletteTheme}>
+        <App />
+      </ThemeProvider>
+    </Provider>
   </React.StrictMode>
 );

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -73,6 +73,23 @@ export const axiosCabinetInfo = async (): Promise<any> => {
   }
 };
 
+// TODO API 변경 후 적용사항
+// location, floor에 따른 cabinets 반환
+const axiosCabinetLocationInfoURL = "/api/cabinet_info/";
+export const axiosCabinetLocationInfo = async (
+  location: string,
+  floor: number
+): Promise<any> => {
+  try {
+    const response = await instance.get(
+      `${axiosCabinetLocationInfoURL}${location}/${floor}`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const axiosReturnInfoURL = "/api/return_info";
 export const axiosReturnInfo = async (): Promise<any> => {
   try {


### PR DESCRIPTION
## CabinetTemplate
## 변경 사항 요약 (Key changes)
- /src/components/templates/CabinetTemplate.tsx
    - axiosCabinetInfo API 호출 및 cabinetAll Action 실행 
- src/components/organisms/CarouselInfo.tsx
  - useAppSelector(cabinet.cabinet)
  - currLocation, currFloor에 해당되는 것만 4중 배열에서 뽑아낸 후 prop으로 전달
- /src/components/atoms/buttons/FloorButton.tsx
  - useAppSelector (cabinet.floor)
- /src/components/atoms/buttons/LocationButton.tsx
  - 기존 BuildingButton -> LocationButton으로 rename
  - useAppSelector (cabinet.location)
- /src/network/axios/axios.custom.ts 
    - axiosCabinetLocationInfo 추가 (새 API에 사용 예정)

## TEST
- frontend, backend 서버 실행 후 localhost/main
## 피드백
- CabinetTemplate에서 axiosCabinetInfo axios 요청이 처리되기 전에 state를 undefined 값으로 참조하지 않도록 optional chaining으로 구현하였습니다.
- CabinetTemplate에서 현재 location, floor를 state로 가지고, 값이 바뀔 때마다 CarouselInfo 내 4중 배열에서 조건에 맞는 object만 Array에 push하고 반환하도록 구현하였습니다.
- 두 항목에 대한 피드백 부탁드립니다!!