### PR TITLE
fix: carousel size

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/SlideButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/SlideButton.tsx
@@ -6,6 +6,7 @@ const Button = styled.button`
   width: 1.5rem;
   height: 3rem;
   padding: 0;
+  margin: 0.5rem;
   background-color: transparent;
   color: #c0c0c0;
 `;

--- a/frontend_v3/src/components/organisms/Carousel.tsx
+++ b/frontend_v3/src/components/organisms/Carousel.tsx
@@ -8,10 +8,13 @@ const CarouselComponent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100%;
+  margin: 0;
 `;
 const CarouselArea = styled.div`
   width: 270px;
-  margin: auto;
+  height: 100%;
+  margin: 0;
   overflow: hidden;
 `;
 
@@ -25,6 +28,7 @@ const SectionButtonArea = styled.div`
 
 const RowDiv = styled.div`
   display: flex;
+  height: calc(100% - 2rem);
   flex-direction: row;
   align-items: center;
 `;

--- a/frontend_v3/src/components/organisms/Slide.tsx
+++ b/frontend_v3/src/components/organisms/Slide.tsx
@@ -12,9 +12,11 @@ const SlideComponent = styled.div`
   align-content: flex-start;
   overflow: hidden auto;
   width: 270px;
-  height: 480px;
+  height: 100%;
   margin: auto;
-  -webkit-overflow-scrolling: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 interface SlideProps {

--- a/frontend_v3/src/components/organisms/SlideContainer.tsx
+++ b/frontend_v3/src/components/organisms/SlideContainer.tsx
@@ -9,7 +9,7 @@ const SlideContainerComponent = styled.div`
   flex-direction: row;
   width: ${(props) => (props.results ? `${props.results * 270}px` : `270px`)};
   height: 100%;
-  margin: 10px auto;
+  margin: 0;
 `;
 
 interface SlideContainerProps {

--- a/frontend_v3/src/components/templates/CabinetTemplate.tsx
+++ b/frontend_v3/src/components/templates/CabinetTemplate.tsx
@@ -26,19 +26,25 @@ const MainNavSection = styled.div`
   display: flex;
   justify-content: space-between;
   height: 5%;
+  max-height: 2rem;
   padding: 0.5rem 0.7rem 0 0.7rem;
 `;
 
-const MainFloorSection = styled.div``;
+const MainFloorSection = styled.div`
+  height: 5%;
+  max-height: 2rem;
+`;
 
 const MainCarouselSection = styled.div`
   color: #333;
-  height: 90%;
+  height: 100%;
+  max-height: calc(100% - 6.7rem);
 `;
 const MainQuestionSection = styled.div`
   display: flex;
   justify-content: flex-end;
   height: 5%;
+  max-height: 2rem;
   padding: 0 0.7rem;
 `;
 

--- a/frontend_v3/src/mock/CabinetBoxButton.mock.ts
+++ b/frontend_v3/src/mock/CabinetBoxButton.mock.ts
@@ -290,4 +290,580 @@ MockDatas[16] = {
   user: "seuan3",
 };
 
+MockDatas[17] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 1,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 12,
+      intra_id: "hybae",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "hybae",
+};
+
+MockDatas[18] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 2,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 13,
+      intra_id: "seuan",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan",
+};
+
+MockDatas[19] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 3,
+  is_expired: true,
+  lender: [
+    {
+      user_id: 134,
+      intra_id: "seuan2",
+    },
+  ],
+  status: CabinetStatus.EXPIRED,
+  user: "seuan2",
+};
+
+MockDatas[20] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 4,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.AVAILABLE,
+  user: "",
+};
+
+MockDatas[4] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 5,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan3",
+};
+
+MockDatas[21] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 6,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan4",
+};
+
+MockDatas[22] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 7,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 16,
+      intra_id: "hybae2",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "hybae2",
+};
+
+MockDatas[23] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 8,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+  ],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan3",
+};
+MockDatas[24] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 9,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[25] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 10,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[26] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 11,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.BANNED,
+  user: "seuan3",
+};
+
+MockDatas[27] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 12,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.BROKEN,
+  user: "seuan3",
+};
+
+MockDatas[12] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 13,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[28] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 14,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[29] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 15,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[30] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 16,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[31] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 17,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[32] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 1,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 12,
+      intra_id: "hybae",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "hybae",
+};
+
+MockDatas[33] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 2,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 13,
+      intra_id: "seuan",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan",
+};
+
+MockDatas[34] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 3,
+  is_expired: true,
+  lender: [
+    {
+      user_id: 134,
+      intra_id: "seuan2",
+    },
+  ],
+  status: CabinetStatus.EXPIRED,
+  user: "seuan2",
+};
+
+MockDatas[35] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 4,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.AVAILABLE,
+  user: "",
+};
+
+MockDatas[36] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 5,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan3",
+};
+
+MockDatas[37] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 6,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan4",
+};
+
+MockDatas[38] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 7,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 16,
+      intra_id: "hybae2",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "hybae2",
+};
+
+MockDatas[7] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 8,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+  ],
+  status: CabinetStatus.AVAILABLE,
+  user: "seuan3",
+};
+MockDatas[39] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 9,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[40] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 10,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[41] = {
+  cabinet_type: CabinetType.PRIVATE,
+  cabinet_number: 11,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.BANNED,
+  user: "seuan3",
+};
+
+MockDatas[42] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 12,
+  is_expired: false,
+  lender: [],
+  status: CabinetStatus.BROKEN,
+  user: "seuan3",
+};
+
+MockDatas[43] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 13,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[44] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 14,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[45] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 15,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[46] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 16,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[47] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 17,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
+MockDatas[48] = {
+  cabinet_type: CabinetType.SHARE,
+  cabinet_number: 17,
+  is_expired: false,
+  lender: [
+    {
+      user_id: 14,
+      intra_id: "seuan3",
+    },
+    {
+      user_id: 15,
+      intra_id: "seuan4",
+    },
+    {
+      user_id: 16,
+      intra_id: "seuan4",
+    },
+  ],
+  status: CabinetStatus.FULL,
+  user: "seuan3",
+};
+
 export default MockDatas;


### PR DESCRIPTION
1. mobile, desktop 환경에서 carousel 내 영역이 %로 정해져 부자연스러운 높이가 지정되는 것을 방지하기 위해 각 영역에 max-height 적용
2. desktop 환경에서 캐비넷 박스가 많아지는 경우, overflow-y의 scroll 영역으로 인해 3열로 정렬되던 캐비넷이 2열로 정렬되는 문제 발생하여 scroll-display: none으로 변경