### PR TITLE
fe_v3/UpdateAPIs

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/EditButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/EditButton.tsx
@@ -52,7 +52,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
   const handleSaveButtonClick = (): void => {
     setIsToggle(false);
     if (contentType === "title") {
-      axiosUpdateCabinetTitle(inputValue)
+      const cabinet_title = inputValue;
+      axiosUpdateCabinetTitle({ cabinet_title })
         .then(() => {
           setTextValue(inputValue);
         })
@@ -62,7 +63,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
           setInputValue(textValue);
         });
     } else {
-      axiosUpdateCabinetMemo(inputValue)
+      const cabinet_memo = inputValue;
+      axiosUpdateCabinetMemo({ cabinet_memo })
         .then(() => {
           setTextValue(inputValue);
         })

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -79,7 +79,7 @@ const LentInfo = (prop: LentInfoProps): JSX.Element => {
       {userInfo()}
       <LentTextField
         contentType="memo"
-        currentContent="아직 사용자가 없습니다!"
+        currentContent="필요한 내용을 메모해주세요!"
       />
     </Content>
   );

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -83,9 +83,9 @@ export const axiosReturnInfo = async (): Promise<any> => {
   }
 };
 
-const axiosUpdateCabinetMemoURL = "/v3/api/lent/update_cabinet_memo/";
+const axiosUpdateCabinetMemoURL = "/v3/api/lent/update_cabinet_memo";
 export const axiosUpdateCabinetMemo = async (
-  cabinet_memo: string
+  cabinet_memo: object
 ): Promise<any> => {
   try {
     const response = await instance.patch(
@@ -98,9 +98,9 @@ export const axiosUpdateCabinetMemo = async (
   }
 };
 
-const axiosUpdateCabinetTitleURL = "/v3/api/lent/update_cabinet_title/";
+const axiosUpdateCabinetTitleURL = "/v3/api/lent/update_cabinet_title";
 export const axiosUpdateCabinetTitle = async (
-  cabinet_title: string
+  cabinet_title: object
 ): Promise<any> => {
   try {
     const response = await instance.patch(


### PR DESCRIPTION
- 캐비닛 타이틀, 메모 업데이트하는 API의 인자 타입 및 EditButton 코드에서의 axios 호출 인자 타입 수정했습니다.
  - 해당 API에 객체 데이터를 넘겨야 해서, dto와 변수명 일치시킨 후 문자열을 객체로 감싸 넘기도록 수정했습니다.
  - API 코드 (axios.custom.ts)에서 cabinet_memo 및 cabinet_title 타입을 string에서 object로 수정했습니다.