### PR TITLE
fe_v3/reactCookie

### DIFF
--- a/frontend_v3/package.json
+++ b/frontend_v3/package.json
@@ -22,6 +22,7 @@
     "@reduxjs/toolkit": "^1.8.5",
     "axios": "^0.27.2",
     "react": "^18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0"

--- a/frontend_v3/src/network/react-cookie/cookie.ts
+++ b/frontend_v3/src/network/react-cookie/cookie.ts
@@ -1,0 +1,11 @@
+import { Cookies } from "react-cookie";
+
+const cookies = new Cookies();
+
+export const setCookie = (name: string, value: string, option?: any): void => {
+  return cookies.set(name, value, { ...option });
+};
+
+export const getCookie = (name: string): string => {
+  return cookies.get(name);
+};

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -1,16 +1,24 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { Cookies } from "react-cookie";
 import LoginTemplate from "../components/templates/LoginTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import ContentTemplate from "../components/templates/ContentTemplate";
-import { useAppSelector } from "../redux/hooks";
+import { useAppSelector, useAppDispatch } from "../redux/hooks";
+import { getCookie } from "../network/react-cookie/cookie";
+import { userInfoInitialize } from "../redux/slices/userSlice";
 
 const Login = (): JSX.Element => {
   const user = useAppSelector((state) => state.user);
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   console.log(user.intra_id);
   useEffect(() => {
+    const token = getCookie("accessToken");
+    if (!token) {
+      dispatch(userInfoInitialize());
+    }
     if (!(user.intra_id === "default")) {
       navigate("/main");
     }


### PR DESCRIPTION
## 문제상황
- 로그아웃 없이 바로 브라우저(탭이 아닌 브라우저 전체)를 종료했을 때 token은 삭제되지만 localStorage의 리덕스 정보는 삭제되지 않는 문제
- token이 없으므로 로그아웃 및 반납 불가, login 페이지에서 리덕스 정보를 바탕으로 main 페이지로 바로 리다이렉트 시키므로 로그인도 불가

## 해결
- react-cookie 사용하여 accessToken 값이 들어있는지 확인하고, 없다면 기존에 있던 리덕스의 유저 정보도 우선 초기화되도록 변경