### PR TITLE
fe_v3/LentAlertMessage

### DIFF
--- a/frontend_v3/src/components/atoms/modals/LentBox.tsx
+++ b/frontend_v3/src/components/atoms/modals/LentBox.tsx
@@ -85,8 +85,25 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
         navigate("/Lent");
       })
       .catch((error) => {
-        console.error(error);
-        alert("🚨 대여에 실패했습니다 🚨");
+        switch (error.response.status) {
+          case 400:
+            alert("🚨 이미 대여중인 사물함이 있습니다 🚨");
+            break;
+          case 403:
+            alert(
+              "🚨 해당 사물함은 임시로 밴 되었거나, 고장난 사물함입니다 🚨"
+            );
+            break;
+          case 409:
+            alert("🚨 해당 사물함에 잔여 자리가 없습니다 🚨");
+            break;
+          case 418:
+            alert("🚨 해당 사물함은 동아리 전용 사물함입니다 🚨");
+            break;
+          default:
+            alert("🚨 대여에 실패했습니다 🚨");
+            break;
+        }
       });
     handleClose();
   };


### PR DESCRIPTION
#335 

- `/v3/api/lent/{cabinet_id}` 호출의 응답 status에 따라 다른 alert 창이 표시되도록 수정했습니다.
  - Swagger 명세에 나와있는대로 400, 403, 409, 418 응답에 대해 switch문으로 작성했습니다.
    - 403(임시 밴 또는 고장 사물함)의 경우 애초에 클릭하면 다른 모달이 보여지고 있긴 한데, 일단 response 명세에 있어서 처리해두었습니다..