### PR TITLE
fe_v3/LentLogout

### DIFF
--- a/frontend_v3/src/pages/Lent.tsx
+++ b/frontend_v3/src/pages/Lent.tsx
@@ -3,14 +3,28 @@ import { useEffect } from "react";
 import LentTemplate from "../components/templates/LentTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import ContentTemplate from "../components/templates/ContentTemplate";
-import { useAppSelector } from "../redux/hooks";
+import { getCookie } from "../network/react-cookie/cookie";
+import { useAppSelector, useAppDispatch } from "../redux/hooks";
+import { userAll } from "../redux/slices/userSlice";
+import { axiosMyInfo } from "../network/axios/axios.custom";
 
 const Lent = (): JSX.Element => {
+  const token = getCookie("accessToken");
   const user = useAppSelector((state) => state.user);
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (user.intra_id === "default" || user.cabinet_id === -1) navigate("/");
+    if (token && user.intra_id === "default") {
+      axiosMyInfo()
+        .then((response) => {
+          dispatch(userAll(response.data));
+        })
+        .catch((error) => {
+          navigate("/");
+        });
+    } else if (user.intra_id === "default" || user.cabinet_id === -1)
+      navigate("/");
   }, []);
 
   return (


### PR DESCRIPTION
#341 

- 캐비닛 대여 후 로그아웃할 경우, 다음 번 로그인 때 lent 페이지로 리다이렉트 되지 않는 문제 해결했습니다.
  - `lent` 페이지는 리덕스의 `user` state를 조건으로 접근을 허용하는데, 캐비닛을 이미 대여한 사용자의 경우 로그인 시 `main` 을 거치지 않고 바로 `lent` 페이지로 리다이렉트 되기 때문에 곧바로 다시 `/` 경로로 튕겨져나오는 문제가 있었습니다.
  - 따라서 로그인 되었지만(`token`) 현재 리덕스에 유저 정보가 없는 경우(`user.intra_id === "default"`), 로그인 후 바로 `lent` 페이지로 리다이렉트된 유저이므로 `axiosMyInfo` 를 호출하여 유저 정보를 받고 리덕스에 저장합니다.


### 논의점
- 이 문제의 근본적인 원인은 로그인 시 백엔드에서 리다이렉트 해주는 경로가 대여 여부에 따라 둘로 나뉘기 때문인 것 같습니다.
- 백엔드는 무조건 `main` 페이지로 리다이렉트하고, `main` 페이지가 마운트될 때 불러오는 유저 정보를 바탕으로 `cabinet_id !== -1` 이라면 lent 페이지로 바로 navigate 되도록 하는 방식은 어떻게 생각하시는지 궁금합니당. 
  - 지금처럼 main과 lent 페이지 둘 다에서 token을 검사할 필요가 없어지기도 하고요 🤔