### PR TITLE
fix: carousel slide issue

### DIFF
--- a/frontend_v3/src/components/organisms/Carousel.tsx
+++ b/frontend_v3/src/components/organisms/Carousel.tsx
@@ -54,6 +54,10 @@ const Carousel = (props: CarouselProps): JSX.Element => {
   const lastSlide = slideCount ? slideCount - 1 : 0; // slideCount에 1 더해지지 않은 상태 입니다.
 
   useEffect(() => {
+    setCurrentSlide(0);
+  }, [cabinets]);
+
+  useEffect(() => {
     if (slideRef.current != null) {
       slideRef.current.style.transition = "all 0.5s ease-in-out";
       slideRef.current.style.transform = `translateX(-${
@@ -92,6 +96,7 @@ const Carousel = (props: CarouselProps): JSX.Element => {
     setTochedX(e.changedTouches[0].pageX);
     setTochedY(e.changedTouches[0].pageY);
   };
+
   const onTouchEnd = (e: React.TouchEvent): void => {
     const distanceX = tochedX - e.changedTouches[0].pageX;
     const distanceY = tochedY - e.changedTouches[0].pageY;


### PR DESCRIPTION
#366 

## 이슈 원인
캐러셀을 구현하며 슬라이드가 움직이는 경우, [현재 슬라이드 인덱스 * 100 / (슬라이드 개수)]% 만큼 움직이게 되어 있습니다.
따라서 슬라이드가 5개인 2F에서는 20%씩 움직이고, 슬라이드가 4개인 4F, 5F에서는 25%씩 움직입니다.
층이 바뀌는 경우, 첫 렌더 시에 이 비율이 바뀌지 않은 채로 적용이 됩니다.
ex) 2F에서 40%만큼 움직여 있는 경우, 4F으로 바꾸어도 40%만큼 움직인 상태
- 4F는 슬라이드 개수가 4개라서 0%, 25%, 50%, 75%에서 정상 화면으로 보입니다.

## 해결 방법
캐비넷 정보가 바뀌는 경우에 현재 위치를 0%로 이동시켜 각 층의 맨 첫 슬라이드로 이동하도록 수정하여 해결했습니다.