### PR TITLE
fix: carousel render on safari

### DIFF
--- a/frontend_v3/src/components/organisms/Carousel.tsx
+++ b/frontend_v3/src/components/organisms/Carousel.tsx
@@ -55,7 +55,7 @@ const Carousel = (props: CarouselProps): JSX.Element => {
 
   useEffect(() => {
     if (slideRef.current != null) {
-      slideRef.current.style.transition = "all 0.5s ease-in-out";
+      slideRef.current.style.transition = "transform 0.5s ease-in-out";
       slideRef.current.style.transform = `translateX(-${
         (currentSlide * 100) / (lastSlide + 1)
       }%)`; // 백틱을 사용하여 슬라이드로 이동하는 에니메이션을 만듭니다.


### PR DESCRIPTION
#333 

## 이슈 원인
carousel 내 모든 property 변경에 대해 transition 속성이 적용되어 있었습니다.

## 해결 방법
carousel 내 슬라이드 이동을 위한 transform property에 대해서만 transition 속성이 적용되도록 변경하였습니다.

## 추가 사항
transition은 브라우저마다 호환가능한 버전이 모두 상이합니다.
transition을 사용하는 경우 모두 확인해봐야 할 듯 합니다.
![스크린샷 2022-10-02 오후 10 24 42](https://user-images.githubusercontent.com/62418146/193456444-ade6ce5b-63bf-4714-9f55-21e54f5b9380.png)
