### PR TITLE
fix: edit cabinet title and memo

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/EditButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/EditButton.tsx
@@ -55,7 +55,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
       const cabinet_title = inputValue;
       axiosUpdateCabinetTitle({ cabinet_title })
         .then(() => {
-          setTextValue(inputValue);
+          if (inputValue === "") setTextValue("방 제목을 입력해주세요");
+          else setTextValue(inputValue);
         })
         .catch((error) => {
           console.error(error);
@@ -66,7 +67,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
       const cabinet_memo = inputValue;
       axiosUpdateCabinetMemo({ cabinet_memo })
         .then(() => {
-          setTextValue(inputValue);
+          if (inputValue === "") setTextValue("필요한 내용을 메모해주세요");
+          else setTextValue(inputValue);
         })
         .catch((error) => {
           console.error(error);

--- a/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import EditButton from "../buttons/EditButton";
 
@@ -8,20 +8,42 @@ import EditButton from "../buttons/EditButton";
 
 const Container = styled.div`
   display: flex;
-  justify-content: left;
+  width: 70%;
+  height: 2rem;
+  justify-content: space-between;
   align-items: center;
 `;
 
 interface LentTextFieldProps {
   contentType: "title" | "memo";
-  currentContent: string;
+  currentContent: string | undefined;
 }
 
 const LentTextField = (props: LentTextFieldProps): JSX.Element => {
   const { contentType, currentContent } = props;
-  const [textValue, setTextValue] = useState(currentContent);
+  const [textValue, setTextValue] = useState<string>(
+    currentContent || contentType === "title"
+      ? "방 제목을 입력해주세요"
+      : "필요한 내용을 메모해주세요"
+  );
   const [inputValue, setInputValue] = useState(textValue);
   const [isToggle, setIsToggle] = useState(false);
+
+  useEffect(() => {
+    if (currentContent) {
+      setTextValue(currentContent);
+    } else {
+      setTextValue(
+        contentType === "title"
+          ? "방 제목을 입력해주세요"
+          : "필요한 내용을 메모해주세요"
+      );
+    }
+  }, [currentContent]);
+
+  useEffect(() => {
+    setInputValue(textValue);
+  }, [textValue]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setInputValue(e.target.value);

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { axiosMyLentInfo } from "../../network/axios/axios.custom";
+import { MyCabinetInfoResponseDto } from "../../types/dto/cabinet.dto";
 import { LentDto } from "../../types/dto/lent.dto";
-import { UserDto } from "../../types/dto/user.dto";
 import LentTextField from "../atoms/inputs/LentTextField";
 
 const Content = styled.div`
@@ -13,56 +15,42 @@ const Content = styled.div`
 `;
 
 interface LentInfoProps {
-  location: string | undefined; // 사물함 건물
-  floor: number | undefined; // 사물함 층수
-  section?: string | undefined; // 사물함의 섹션 종류 (오아시스 등)
-  cabinet_memo: string | undefined; // 사물함 비밀번호와 관련된 메모
-  cabinet_id: number | undefined; // 캐비넷 고유 ID
-  cabinet_num?: number; // 사물함에 붙어있는 숫자
-  lent_type?: string | undefined; // 사물함의 종류 (개인, 공유, 동아리)
-  cabinet_title: string | undefined; // 공유/동아리 사물함인 경우 사물함에 대한 설명
-  max_user?: number | undefined; // 해당 사물함을 대여할 수 있는 최대 유저 수
-  lent_info: LentDto[] | undefined;
-  // lent_info: LentDto | undefined;
+  cabinet_data: MyCabinetInfoResponseDto | null;
 }
 
-const LentInfo = (prop: LentInfoProps): JSX.Element => {
-  const {
-    location,
-    floor,
-    section,
-    cabinet_memo,
-    cabinet_id,
-    cabinet_num,
-    lent_type,
-    cabinet_title,
-    max_user,
-    lent_info,
-  } = prop;
+const LentInfo = (): JSX.Element => {
+  const [myLentInfo, setMyLentInfo] = useState<MyCabinetInfoResponseDto | null>(
+    null
+  );
+  useEffect(() => {
+    // TODO (seuan)
+    // 대여, 반납 후 cabinetId에 대한 state 적용이 완료된 후 사용할 것.
+    // if (cabinetId === -1) navigate("/main");
+    axiosMyLentInfo()
+      .then((response) => {
+        setMyLentInfo(response.data);
+      })
+      .then(() => console.log(myLentInfo))
+      .catch((error) => {
+        console.error(error);
+        // navigate("/main");
+      });
+  }, []);
 
   const cabinetInfo = (): JSX.Element => {
     return (
       <>
-        <p>
-          {location} {floor}F {cabinet_num}
-        </p>
+        <h2>
+          {myLentInfo?.location} {myLentInfo?.floor}F {myLentInfo?.cabinet_num}
+        </h2>
         <p>{/* lent_info.expire_time */}</p>
       </>
     );
   };
 
-  // const userInfo = (): JSX.Element[] | null => {
-  //   if (lent_info) {
-  //     return lent_info.users.map((user: UserDto) => {
-  //       return <p key={user.user_id}>{user.intra_id}</p>;
-  //     });
-  //   }
-  //   return null;
-  // };
-
   const userInfo = (): JSX.Element[] | null => {
-    if (lent_info) {
-      return lent_info.map((user: LentDto) => {
+    if (myLentInfo?.lent_info) {
+      return myLentInfo.lent_info.map((user: LentDto) => {
         return <p key={user.user_id}>{user.intra_id}</p>;
       });
     }
@@ -74,13 +62,13 @@ const LentInfo = (prop: LentInfoProps): JSX.Element => {
       {cabinetInfo()}
       <LentTextField
         contentType="title"
-        currentContent="방 제목을 설정해주세요!"
+        currentContent={myLentInfo?.cabinet_title}
       />
-      {userInfo()}
       <LentTextField
         contentType="memo"
-        currentContent="필요한 내용을 메모해주세요!"
+        currentContent={myLentInfo?.cabinet_memo}
       />
+      {userInfo()}
     </Content>
   );
 };

--- a/frontend_v3/src/components/templates/LentTemplate.tsx
+++ b/frontend_v3/src/components/templates/LentTemplate.tsx
@@ -53,26 +53,8 @@ const LentReturnSection = styled.div`
 `;
 
 const LentTemplate = (): JSX.Element => {
-  const [myLentInfo, setMyLentInfo] = useState<MyCabinetInfoResponseDto | null>(
-    null
-  );
-
   const navigate = useNavigate();
   const cabinetId = useAppSelector((state) => state.user.cabinet_id);
-
-  useEffect(() => {
-    // TODO (seuan)
-    // 대여, 반납 후 cabinetId에 대한 state 적용이 완료된 후 사용할 것.
-    // if (cabinetId === -1) navigate("/main");
-    axiosMyLentInfo()
-      .then((response) => {
-        setMyLentInfo(response.data);
-      })
-      .catch((error) => {
-        console.error(error);
-        // navigate("/main");
-      });
-  }, []);
 
   return (
     <LentSection id="test">
@@ -81,15 +63,7 @@ const LentTemplate = (): JSX.Element => {
         <MenuButton />
       </LentNavSection>
       <LentInfoSection>
-        <LentInfo
-          location={myLentInfo?.location}
-          floor={myLentInfo?.floor}
-          cabinet_num={myLentInfo?.cabinet_num}
-          cabinet_id={myLentInfo?.cabinet_id}
-          lent_info={myLentInfo?.lent_info}
-          cabinet_title={myLentInfo?.cabinet_title}
-          cabinet_memo={myLentInfo?.cabinet_memo}
-        />
+        <LentInfo />
       </LentInfoSection>
       <LentReturnSection>
         <ReturnButton button_title="반 납 하 기" />

--- a/frontend_v3/src/types/dto/cabinet.dto.ts
+++ b/frontend_v3/src/types/dto/cabinet.dto.ts
@@ -5,7 +5,7 @@ import CabinetStatus from "../enum/cabinet.status.enum";
 // TODO :hybae
 // lent_type을 LentType으로 변경 예정
 export interface MyCabinetInfoResponseDto {
-  activation: number; // (0: 고장, 1: 사용가능, 2: ban, 3: 대여중)
+  status: CabinetStatus;
   lent_info?: LentDto[]; // 대여 정보 (optional)
   location: string; // 사물함 건물
   floor: number; // 사물함 층수


### PR DESCRIPTION
#380 

## 수정사항
### 1. API 호출 위치 변경
  - LentTemplate에서 호출하던 my_lent_info API가 해당 컴포넌트에서 사용되지 않아 LentInfo로 이동시켰습니다.

### 2. lent 페이지 내 title, memo 정렬
  - justify-content: space-between을 통해 정렬했습니다.
  - 대여자 정보를 아래로 내렸습니다.

### 3. title, memo 최신화
  - LentTextField에 전달되는 title, memo 값이 API 응답을 받기 전 undefined로 전달되고 있습니다.
     LentTextField로 전달되는 title, memo 값을 dependency array로 적용한 useEffect를 통해 최신화하도록 변경하였습니다.

### 4. title, memo 빈 값으로 설정에 대한 예외 처리
  - title, memo가 빈 값으로 전달되는 경우 현재 title, memo가 ""으로 설정됩니다.
    DB에도 ""로 저장되며, 이를 다시 불러올 경우 false("", undefined, null)로 받아와 초기설정 됩니다.
    이에 맞춰 빈 값이 전달되는 경우 화면에 표시되는 텍스트를 임시 텍스트로 변경하였습니다.
    title : 방 제목을 입력해주세요
    memo : 필요한 내용을 메모해주세요

## BE 전달사항
방 제목, 메모가 빈 값 ("")으로 전달될 경우, DB에도 null이 아닌 ""으로 저장됩니다.
이 경우에 DB에 null로 저장할지 빈 값으로 저장할지 검토가 필요할 것 같습니다.
현재 title, memo값을 한 번 변경하면 다시 null로 돌릴 수 없는 것 같습니다.