### PR TITLE
fe_v3/LentBoxRedesign

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/EditButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/EditButton.tsx
@@ -55,7 +55,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
       const cabinet_title = inputValue;
       axiosUpdateCabinetTitle({ cabinet_title })
         .then(() => {
-          setTextValue(inputValue);
+          if (inputValue === "") setTextValue("방 제목을 입력해주세요");
+          else setTextValue(inputValue);
         })
         .catch((error) => {
           console.error(error);
@@ -66,7 +67,8 @@ const EditButton = (props: EditButtonProps): JSX.Element => {
       const cabinet_memo = inputValue;
       axiosUpdateCabinetMemo({ cabinet_memo })
         .then(() => {
-          setTextValue(inputValue);
+          if (inputValue === "") setTextValue("필요한 내용을 메모해주세요");
+          else setTextValue(inputValue);
         })
         .catch((error) => {
           console.error(error);

--- a/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import EditButton from "../buttons/EditButton";
 
@@ -8,20 +8,42 @@ import EditButton from "../buttons/EditButton";
 
 const Container = styled.div`
   display: flex;
-  justify-content: left;
+  width: 70%;
+  height: 2rem;
+  justify-content: space-between;
   align-items: center;
 `;
 
 interface LentTextFieldProps {
   contentType: "title" | "memo";
-  currentContent: string;
+  currentContent: string | undefined;
 }
 
 const LentTextField = (props: LentTextFieldProps): JSX.Element => {
   const { contentType, currentContent } = props;
-  const [textValue, setTextValue] = useState(currentContent);
+  const [textValue, setTextValue] = useState<string>(
+    currentContent || contentType === "title"
+      ? "방 제목을 입력해주세요"
+      : "필요한 내용을 메모해주세요"
+  );
   const [inputValue, setInputValue] = useState(textValue);
   const [isToggle, setIsToggle] = useState(false);
+
+  useEffect(() => {
+    if (currentContent) {
+      setTextValue(currentContent);
+    } else {
+      setTextValue(
+        contentType === "title"
+          ? "방 제목을 입력해주세요"
+          : "필요한 내용을 메모해주세요"
+      );
+    }
+  }, [currentContent]);
+
+  useEffect(() => {
+    setInputValue(textValue);
+  }, [textValue]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     setInputValue(e.target.value);

--- a/frontend_v3/src/components/atoms/modals/LentBox.tsx
+++ b/frontend_v3/src/components/atoms/modals/LentBox.tsx
@@ -55,6 +55,7 @@ const cabinetInfo = {
 interface LentBoxProps {
   // eslint-disable-next-line react/require-default-props
   handleClose: () => void;
+  cabinet_title: string | null;
   cabinet_number: number;
   cabinet_id: number;
   lender: UserDto[];
@@ -67,6 +68,7 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
     handleClose,
     isLentAble,
     cabinet_number,
+    cabinet_title,
     lender,
     cabinet_type,
     cabinet_id,
@@ -105,6 +107,14 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
     <Box sx={BoxStyle}>
       <Typography id="modal-modal-title" variant="h6" component="h2">
         [{cabinet_number}]번 사물함을 대여합니다.
+      </Typography>
+      <Typography
+        id="modal-modal-title"
+        align="center"
+        variant="h6"
+        component="h3"
+      >
+        {cabinet_title}
       </Typography>
       {(cabinet_type === "SHARE"
         ? sharedCabinetMessage

--- a/frontend_v3/src/components/atoms/modals/LentBox.tsx
+++ b/frontend_v3/src/components/atoms/modals/LentBox.tsx
@@ -35,6 +35,21 @@ const CenterAlignStyle = {
   alignItems: "center",
 };
 
+const ScrollBox = styled.div`
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  height: 5rem;
+  overflow: auto;
+  background-color: #fafafa;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+`;
+
+const LenderBox = styled.div`
+  display: flex;
+`;
+
 // TODO:
 // cabinetInfo는 API로 받아와야 함
 const cabinetInfo = {
@@ -105,9 +120,15 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
 
   const LentAble: JSX.Element = (
     <Box sx={BoxStyle}>
-      <Typography id="modal-modal-title" variant="h6" component="h2">
+      <Typography
+        id="modal-modal-title"
+        variant="h6"
+        component="h2"
+        align="center"
+      >
         [{cabinet_number}]번 사물함을 대여합니다.
       </Typography>
+      <hr />
       <Typography
         id="modal-modal-title"
         align="center"
@@ -116,25 +137,40 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
       >
         {cabinet_title}
       </Typography>
-      {(cabinet_type === "SHARE"
-        ? sharedCabinetMessage
-        : personalCabinetMessage
-      ).map((message: string, i: number) => (
-        <Typography
-          key={i}
-          id="modal-modal-description"
-          sx={{ mt: 2 }}
-          align="left"
-        >
-          {message}
-        </Typography>
-      ))}
+      <ScrollBox>
+        {/* TODO: gyuwlee
+        산재해 있는 style 태그 변수화 필요 */}
+        <strong style={{ color: "red" }}>📌 이용 시 주의사항 📌</strong>
+        {(cabinet_type === "SHARE"
+          ? sharedCabinetMessage
+          : personalCabinetMessage
+        ).map((message: string, i: number) => (
+          <Typography
+            key={i}
+            id="modal-modal-description"
+            sx={{ mt: 2 }}
+            align="left"
+          >
+            {message}
+          </Typography>
+        ))}
+      </ScrollBox>
       {cabinet_type === "SHARE" && lender?.length > 0 && (
         <>
-          <p>대여자 목록</p>
-          {lender.map((item) => (
-            <p>{item.intra_id}</p>
-          ))}
+          <p style={{ margin: 0 }}>대여자 목록 : </p>
+          <LenderBox>
+            {lender.map((item) => (
+              <p
+                style={{
+                  marginTop: 0,
+                  marginBottom: 0,
+                  marginRight: "0.8rem",
+                }}
+              >
+                {item.intra_id}
+              </p>
+            ))}
+          </LenderBox>
         </>
       )}
       <FormGroup sx={CenterAlignStyle}>

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { axiosMyLentInfo } from "../../network/axios/axios.custom";
+import { MyCabinetInfoResponseDto } from "../../types/dto/cabinet.dto";
 import { LentDto } from "../../types/dto/lent.dto";
-import { UserDto } from "../../types/dto/user.dto";
 import LentTextField from "../atoms/inputs/LentTextField";
 
 const Content = styled.div`
@@ -13,56 +15,42 @@ const Content = styled.div`
 `;
 
 interface LentInfoProps {
-  location: string | undefined; // 사물함 건물
-  floor: number | undefined; // 사물함 층수
-  section?: string | undefined; // 사물함의 섹션 종류 (오아시스 등)
-  cabinet_memo: string | undefined; // 사물함 비밀번호와 관련된 메모
-  cabinet_id: number | undefined; // 캐비넷 고유 ID
-  cabinet_num?: number; // 사물함에 붙어있는 숫자
-  lent_type?: string | undefined; // 사물함의 종류 (개인, 공유, 동아리)
-  cabinet_title: string | undefined; // 공유/동아리 사물함인 경우 사물함에 대한 설명
-  max_user?: number | undefined; // 해당 사물함을 대여할 수 있는 최대 유저 수
-  lent_info: LentDto[] | undefined;
-  // lent_info: LentDto | undefined;
+  cabinet_data: MyCabinetInfoResponseDto | null;
 }
 
-const LentInfo = (prop: LentInfoProps): JSX.Element => {
-  const {
-    location,
-    floor,
-    section,
-    cabinet_memo,
-    cabinet_id,
-    cabinet_num,
-    lent_type,
-    cabinet_title,
-    max_user,
-    lent_info,
-  } = prop;
+const LentInfo = (): JSX.Element => {
+  const [myLentInfo, setMyLentInfo] = useState<MyCabinetInfoResponseDto | null>(
+    null
+  );
+  useEffect(() => {
+    // TODO (seuan)
+    // 대여, 반납 후 cabinetId에 대한 state 적용이 완료된 후 사용할 것.
+    // if (cabinetId === -1) navigate("/main");
+    axiosMyLentInfo()
+      .then((response) => {
+        setMyLentInfo(response.data);
+      })
+      .then(() => console.log(myLentInfo))
+      .catch((error) => {
+        console.error(error);
+        // navigate("/main");
+      });
+  }, []);
 
   const cabinetInfo = (): JSX.Element => {
     return (
       <>
-        <p>
-          {location} {floor}F {cabinet_num}
-        </p>
+        <h2>
+          {myLentInfo?.location} {myLentInfo?.floor}F {myLentInfo?.cabinet_num}
+        </h2>
         <p>{/* lent_info.expire_time */}</p>
       </>
     );
   };
 
-  // const userInfo = (): JSX.Element[] | null => {
-  //   if (lent_info) {
-  //     return lent_info.users.map((user: UserDto) => {
-  //       return <p key={user.user_id}>{user.intra_id}</p>;
-  //     });
-  //   }
-  //   return null;
-  // };
-
   const userInfo = (): JSX.Element[] | null => {
-    if (lent_info) {
-      return lent_info.map((user: LentDto) => {
+    if (myLentInfo?.lent_info) {
+      return myLentInfo.lent_info.map((user: LentDto) => {
         return <p key={user.user_id}>{user.intra_id}</p>;
       });
     }
@@ -74,13 +62,13 @@ const LentInfo = (prop: LentInfoProps): JSX.Element => {
       {cabinetInfo()}
       <LentTextField
         contentType="title"
-        currentContent="방 제목을 설정해주세요!"
+        currentContent={myLentInfo?.cabinet_title}
       />
-      {userInfo()}
       <LentTextField
         contentType="memo"
-        currentContent="필요한 내용을 메모해주세요!"
+        currentContent={myLentInfo?.cabinet_memo}
       />
+      {userInfo()}
     </Content>
   );
 };

--- a/frontend_v3/src/components/organisms/Slide.tsx
+++ b/frontend_v3/src/components/organisms/Slide.tsx
@@ -36,6 +36,7 @@ const Slide = (props: SlideProps): JSX.Element => {
             box={
               <LentBox
                 key={index}
+                cabinet_title={item.cabinet_title}
                 cabinet_type={item.lent_type}
                 cabinet_number={item.cabinet_num}
                 cabinet_id={item.cabinet_id}

--- a/frontend_v3/src/components/templates/LentTemplate.tsx
+++ b/frontend_v3/src/components/templates/LentTemplate.tsx
@@ -53,26 +53,8 @@ const LentReturnSection = styled.div`
 `;
 
 const LentTemplate = (): JSX.Element => {
-  const [myLentInfo, setMyLentInfo] = useState<MyCabinetInfoResponseDto | null>(
-    null
-  );
-
   const navigate = useNavigate();
   const cabinetId = useAppSelector((state) => state.user.cabinet_id);
-
-  useEffect(() => {
-    // TODO (seuan)
-    // 대여, 반납 후 cabinetId에 대한 state 적용이 완료된 후 사용할 것.
-    // if (cabinetId === -1) navigate("/main");
-    axiosMyLentInfo()
-      .then((response) => {
-        setMyLentInfo(response.data);
-      })
-      .catch((error) => {
-        console.error(error);
-        // navigate("/main");
-      });
-  }, []);
 
   return (
     <LentSection id="test">
@@ -81,15 +63,7 @@ const LentTemplate = (): JSX.Element => {
         <MenuButton />
       </LentNavSection>
       <LentInfoSection>
-        <LentInfo
-          location={myLentInfo?.location}
-          floor={myLentInfo?.floor}
-          cabinet_num={myLentInfo?.cabinet_num}
-          cabinet_id={myLentInfo?.cabinet_id}
-          lent_info={myLentInfo?.lent_info}
-          cabinet_title={myLentInfo?.cabinet_title}
-          cabinet_memo={myLentInfo?.cabinet_memo}
-        />
+        <LentInfo />
       </LentInfoSection>
       <LentReturnSection>
         <ReturnButton button_title="반 납 하 기" />

--- a/frontend_v3/src/types/dto/cabinet.dto.ts
+++ b/frontend_v3/src/types/dto/cabinet.dto.ts
@@ -35,6 +35,6 @@ export interface CabinetInfo {
 }
 
 export interface CabinetInfoByLocationFloorDto {
-  section: Array<object>;
+  section: string; // swagger의 CabinetPerSectionDto에 맞추어 object -> string으로 수정했습니다.
   cabinets: CabinetInfo[];
 }

--- a/frontend_v3/src/types/dto/cabinet.dto.ts
+++ b/frontend_v3/src/types/dto/cabinet.dto.ts
@@ -5,7 +5,7 @@ import CabinetStatus from "../enum/cabinet.status.enum";
 // TODO :hybae
 // lent_type을 LentType으로 변경 예정
 export interface MyCabinetInfoResponseDto {
-  activation: number; // (0: 고장, 1: 사용가능, 2: ban, 3: 대여중)
+  status: CabinetStatus;
   lent_info?: LentDto[]; // 대여 정보 (optional)
   location: string; // 사물함 건물
   floor: number; // 사물함 층수


### PR DESCRIPTION

<img width="348" alt="스크린샷 2022-10-05 오후 5 27 44" src="https://user-images.githubusercontent.com/94846990/194017444-87a36fd2-9978-4f0a-8eca-40eadf8db321.png">

- 사물함 대여 모달의 전체적인 디자인을 수정했습니다.
  - **이용 시 유의사항**을 `ScrollBox` 내부에 넣어 스크롤되도록 수정했습니다.
  - (피드백을 받아) 대여자 목록이 가로로 나열되도록 수정했습니다.