### PR TITLE
fe_v3/myCabinetaPageRedesign

### DIFF
--- a/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
@@ -12,6 +12,24 @@ const Container = styled.div`
   height: 2rem;
   justify-content: space-between;
   align-items: center;
+  border: 1px solid #fafafa;
+  padding: 0.5rem 1rem;
+  margin-top: 0.2rem;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: inset 5px 5px 9px #ededed, inset -5px -5px 9px #ffffff;
+`;
+
+const TextDiv = styled.div`
+  box-sizing: border-box;
+  height: 80%;
+  width: 90%;
+  display: flex;
+  justify-content: center;
+  overflow: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 interface LentTextFieldProps {
@@ -50,22 +68,27 @@ const LentTextField = (props: LentTextFieldProps): JSX.Element => {
   };
 
   return (
-    <Container>
-      {isToggle === false ? (
-        <p>{textValue}</p>
-      ) : (
-        <input type="text" value={inputValue} onChange={handleChange} />
-      )}
-      <EditButton
-        isToggle={isToggle}
-        setIsToggle={setIsToggle}
-        contentType={contentType}
-        inputValue={inputValue}
-        textValue={textValue}
-        setTextValue={setTextValue}
-        setInputValue={setInputValue}
-      />
-    </Container>
+    <>
+      {contentType === "title" ? "방 제목" : "비밀스러운 메모장"}
+      <Container className="Container" style={{ marginBottom: "2rem" }}>
+        <TextDiv className="textDiv">
+          {isToggle === false ? (
+            <p style={{ margin: 0 }}>{textValue}</p> // 대체
+          ) : (
+            <input type="text" value={inputValue} onChange={handleChange} />
+          )}
+        </TextDiv>
+        <EditButton
+          isToggle={isToggle}
+          setIsToggle={setIsToggle}
+          contentType={contentType}
+          inputValue={inputValue}
+          textValue={textValue}
+          setTextValue={setTextValue}
+          setInputValue={setInputValue}
+        />
+      </Container>
+    </>
   );
 };
 

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -14,6 +14,8 @@ const Content = styled.div`
   background-color: white;
 `;
 
+const UserInfoDiv = styled.div``;
+
 interface LentInfoProps {
   cabinet_data: MyCabinetInfoResponseDto | null;
 }
@@ -29,6 +31,7 @@ const LentInfo = (): JSX.Element => {
     axiosMyLentInfo()
       .then((response) => {
         setMyLentInfo(response.data);
+        console.log(response.data);
       })
       .then(() => console.log(myLentInfo))
       .catch((error) => {
@@ -40,10 +43,12 @@ const LentInfo = (): JSX.Element => {
   const cabinetInfo = (): JSX.Element => {
     return (
       <>
-        <h2>
+        <h2 style={{ marginBottom: "0.4rem" }}>
           {myLentInfo?.location} {myLentInfo?.floor}F {myLentInfo?.cabinet_num}
         </h2>
-        <p>{/* lent_info.expire_time */}</p>
+        <p style={{ marginTop: 0, marginBottom: "2rem" }}>
+          ~ {myLentInfo?.lent_info?.[0].expire_time.toString().substring(0, 10)}
+        </p>
       </>
     );
   };
@@ -51,7 +56,11 @@ const LentInfo = (): JSX.Element => {
   const userInfo = (): JSX.Element[] | null => {
     if (myLentInfo?.lent_info) {
       return myLentInfo.lent_info.map((user: LentDto) => {
-        return <p key={user.user_id}>{user.intra_id}</p>;
+        return (
+          <p style={{ margin: 0 }} key={user.user_id}>
+            📌 {user.intra_id}
+          </p>
+        );
       });
     }
     return null;
@@ -68,6 +77,10 @@ const LentInfo = (): JSX.Element => {
         contentType="memo"
         currentContent={myLentInfo?.cabinet_memo}
       />
+      {/* TODO: gyuwlee
+      개인사물함인 경우 보이지 않게 바꾸기 */}
+      함께 사용중인 카뎃들
+      <hr />
       {userInfo()}
     </Content>
   );


### PR DESCRIPTION
- 내 사물함 페이지에서 빌린 캐비닛 번호 아래 **대여 만료 기한**이 보이도록 수정했습니다.
- 내 사물함 페이지 `LentTextField` 에 뉴모피즘 디자인을 적용하여 수정했습니다.
  - 제목 / 메모 내용이 길어질 경우 스크롤하여 전문 확인할 수 있도록 `overflow: auto` 속성을 주었습니다.
  - 공유사물함의 경우 함께 이용중인 카뎃 명단이 보이도록 수정했습니다.
<img width="474" alt="스크린샷 2022-10-05 오후 8 44 15" src="https://user-images.githubusercontent.com/94846990/194052747-fe576f70-49f8-482f-93d6-469abebb1c81.png">
