### PR TITLE
fe_v3/expireTimeLentBox

### DIFF
--- a/frontend_v3/src/components/atoms/modals/LentBox.tsx
+++ b/frontend_v3/src/components/atoms/modals/LentBox.tsx
@@ -8,7 +8,8 @@ import Checkbox from "@mui/material/Checkbox";
 import styled from "@emotion/styled";
 import { axiosLentId } from "../../../network/axios/axios.custom";
 import CheckButton from "../buttons/CheckButton";
-import { UserDto } from "../../../types/dto/user.dto";
+import { LentDto } from "../../../types/dto/lent.dto";
+import CabinetStatus from "../../../types/enum/cabinet.status.enum";
 import { useAppDispatch } from "../../../redux/hooks";
 import { setUserCabinet } from "../../../redux/slices/userSlice";
 
@@ -73,9 +74,10 @@ interface LentBoxProps {
   cabinet_title: string | null;
   cabinet_number: number;
   cabinet_id: number;
-  lender: UserDto[];
+  lender: LentDto[];
   cabinet_type: string;
   isLentAble: boolean;
+  status: CabinetStatus;
 }
 
 const LentBox = (props: LentBoxProps): JSX.Element => {
@@ -87,6 +89,7 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
     lender,
     cabinet_type,
     cabinet_id,
+    status,
   } = props;
   const [checked, setChecked] = useState(false);
   const navigate = useNavigate();
@@ -108,7 +111,6 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
   };
 
   const sharedCabinetMessage: string[] = [
-    "대여기간은 3인이 모두 공유하는 순간부터 +45일 입니다.",
     "대여 후 72시간 이내 취소(반납) 시, 72시간의 대여 불가 패널티가 적용됩니다.",
     "'내 사물함' 페이지의 메모 내용은 공유 인원끼리 공유됩니다.",
     "이용 중 귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.",
@@ -117,6 +119,17 @@ const LentBox = (props: LentBoxProps): JSX.Element => {
     "대여기간은 +30일 입니다.",
     "이용 중 귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.",
   ];
+  if (status === CabinetStatus.SET_EXPIRE_AVAILABLE && lender?.length > 0) {
+    sharedCabinetMessage.unshift(
+      `대여기간은 ${lender[0].expire_time
+        .toString()
+        .substring(0, 10)}까지 입니다.`
+    );
+  } else {
+    sharedCabinetMessage.unshift(
+      "대여기간은 3인이 모두 공유하는 순간부터 +45일 입니다."
+    );
+  }
 
   const LentAble: JSX.Element = (
     <Box sx={BoxStyle}>

--- a/frontend_v3/src/components/organisms/Slide.tsx
+++ b/frontend_v3/src/components/organisms/Slide.tsx
@@ -41,7 +41,11 @@ const Slide = (props: SlideProps): JSX.Element => {
                 cabinet_number={item.cabinet_num}
                 cabinet_id={item.cabinet_id}
                 lender={item.lent_info}
-                isLentAble={item.status === CabinetStatus.AVAILABLE || item.status === CabinetStatus.SET_EXPIRE_AVAILABLE}
+                status={item.status}
+                isLentAble={
+                  item.status === CabinetStatus.AVAILABLE ||
+                  item.status === CabinetStatus.SET_EXPIRE_AVAILABLE
+                }
               />
             }
             button={


### PR DESCRIPTION
- **#401 요청에 대해 문구 추가했습니다.**
  - `CabinetBoxButton` 과 동일하게 `status` 를 props로 받도록 추가하고, 기존에 `lenders` 가  `CabinetBoxButton` 에는 `LentDto[]`로,  `LentBox` 에는 `UserDto[]`로 되어 있던 뿐을 동일하게 `LentDto[]` 로 통일했습니다.
  - 사물함 상태에 따라 유의사항의 첫 줄에 **대여기한**이 <u>"대여기간은 3인이 모두 공유하는 순간부터 +45일 입니다."</u> 또는 <u>기존에 설정되어있는 대여기간</u> 중 하나로 보이도록 수정했습니다.

## 논의사항
- **대여기간을 "[ ]번 사물함을 대여합니다" 문구 바로 아래에 넣는게 나을 것 같기도 한데 어디에 두는 게 더 잘 보일지 의견 부탁드립니당**
<img width="260" alt="스크린샷 2022-10-06 오후 5 25 51" src="https://user-images.githubusercontent.com/94846990/194261484-f1f93808-bc45-42db-93d1-2d7d5f69f11b.png"> <img width="250" alt="스크린샷 2022-10-06 오후 5 29 57" src="https://user-images.githubusercontent.com/94846990/194262434-7ddabb62-0e62-4c48-9487-1e840e0c95d6.png">

