### PR TITLE
fe_v3/PrivateTitleUserInfo

### DIFF
--- a/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
+++ b/frontend_v3/src/components/atoms/inputs/LentTextField.tsx
@@ -2,10 +2,6 @@ import React, { useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import EditButton from "../buttons/EditButton";
 
-// TODO: gyuwlee(?)
-// 본 테스트 필드 제거하고, Organism 단위로 텍스트 입력 필드 구현
-// 근데 이것도 제대로 작동하긴 합니당
-
 const Container = styled.div`
   display: flex;
   width: 70%;
@@ -35,10 +31,11 @@ const TextDiv = styled.div`
 interface LentTextFieldProps {
   contentType: "title" | "memo";
   currentContent: string | undefined;
+  cabinetType: string | undefined;
 }
 
-const LentTextField = (props: LentTextFieldProps): JSX.Element => {
-  const { contentType, currentContent } = props;
+const LentTextField = (props: LentTextFieldProps): JSX.Element | null => {
+  const { contentType, currentContent, cabinetType } = props;
   const [textValue, setTextValue] = useState<string>(
     currentContent || contentType === "title"
       ? "방 제목을 입력해주세요"
@@ -67,9 +64,12 @@ const LentTextField = (props: LentTextFieldProps): JSX.Element => {
     setInputValue(e.target.value);
   };
 
-  return (
+  const isPrivateAndTitle: boolean =
+    cabinetType === "PRIVATE" && contentType === "title";
+
+  return isPrivateAndTitle ? null : (
     <>
-      {contentType === "title" ? "방 제목" : "비밀스러운 메모장"}
+      <p>{contentType === "title" ? "방 제목" : "비밀스러운 메모장"}</p>
       <Container className="Container" style={{ marginBottom: "2rem" }}>
         <TextDiv className="textDiv">
           {isToggle === false ? (

--- a/frontend_v3/src/components/organisms/LentInfo.tsx
+++ b/frontend_v3/src/components/organisms/LentInfo.tsx
@@ -58,15 +58,21 @@ const LentInfo = (): JSX.Element => {
     );
   };
 
-  const userInfo = (): JSX.Element[] | null => {
-    if (myLentInfo?.lent_info) {
-      return myLentInfo.lent_info.map((user: LentDto) => {
-        return (
-          <p style={{ margin: 0 }} key={user.user_id}>
-            📌 {user.intra_id}
-          </p>
-        );
-      });
+  const userInfo = (): JSX.Element | null => {
+    if (myLentInfo?.lent_info && myLentInfo?.lent_type === "SHARE") {
+      return (
+        <UserInfoDiv>
+          <p style={{ margin: 0 }}>함께 사용중인 카뎃들</p>
+          <hr />
+          {myLentInfo.lent_info.map((user: LentDto) => {
+            return (
+              <p style={{ margin: 0 }} key={user.user_id}>
+                📌 {user.intra_id}
+              </p>
+            );
+          })}
+        </UserInfoDiv>
+      );
     }
     return null;
   };
@@ -77,15 +83,13 @@ const LentInfo = (): JSX.Element => {
       <LentTextField
         contentType="title"
         currentContent={myLentInfo?.cabinet_title}
+        cabinetType={myLentInfo?.lent_type}
       />
       <LentTextField
         contentType="memo"
         currentContent={myLentInfo?.cabinet_memo}
+        cabinetType={myLentInfo?.lent_type}
       />
-      {/* TODO: gyuwlee
-      개인사물함인 경우 보이지 않게 바꾸기 */}
-      함께 사용중인 카뎃들
-      <hr />
       {userInfo()}
     </Content>
   );


### PR DESCRIPTION
### 개인 사물함의 lent page에서 방 제목과 함께 사용하는 카뎃 표기되는 부분(#420) 해결

1. `LentInfo.tsx` 의 `userInfo` 함수
  - 캐비닛 공유 중인 카뎃 목록뿐 아니라 "함께 사용중인 카뎃들" 문구 및 `hr` 태그까지 모두 **공유사물함인 경우** 에만 보여지도록 userInfo 함수에서 `lent_type` 까지 체크하도록 수정했습니다.

2. `LentTextField`
  - 백엔드에서 **개인 사물함의 경우 비밀번호를 localStorage에 저장하는 방안**에 대한 의견이 나와서, `LentInfo.tsx` 에서 `lent_type` 을 `LentTextField` 에도 넘겨주도록 일단 수정했습니다.
  - 이로 인해 **`LentInfo` 가 아니라 `LentTextField` 에서 조건을 검사**(개인 캐비닛이고 title 타입인 경우 null)하여 렌더링되도록 수정했습니다.

### 논의사항
- 상기 내용대로, 개인사물함은 공유사물함보다 귀중품(노트북 등) 보관 빈도가 높아, 물건 도난 시 **서버 비밀번호 유출로 인한 cabi 팀 쪽 책임**이 발생할 수 있다는 우려가 있습니다. 따라서 **개인 사물함은 서버가 아닌 localStorage에 메모장 내용을 저장하자는 방안**에 대해 의견 부탁드립니다.