### PR TITLE
expired_time이 null인 경우 예외처리

### DIFF
--- a/backend/src/utils/expired.checker.component.ts
+++ b/backend/src/utils/expired.checker.component.ts
@@ -68,6 +68,8 @@ export class ExpiredChecker {
     );
     const lentList = await Promise.all(await this.lentTools.getAllLent());
     lentList.forEach(async (lent: Lent) => {
+      if (lent.expire_time === null)
+        return ;
       await this.checkExpiredCabinetEach(lent);
     });
   }


### PR DESCRIPTION
expired_time이 null인 경우 날짜를 계산할 필요가 없기 때문에 예외처리 했습니다.