### PR TITLE
fe_v3/cabinetStatus #430

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/CabinetBoxButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/CabinetBoxButton.tsx
@@ -55,7 +55,8 @@ const CabinetBoxButton = (props: CabinetBoxButtonProps): JSX.Element => {
   const setCabinetColor = (): string => {
     if (cabinet_id === user.cabinet_id) return cabinetColor.myCabinet;
     switch (status) {
-      case CabinetStatus.AVAILABLE || CabinetStatus.SET_EXPIRE_AVAILABLE:
+      case CabinetStatus.AVAILABLE:
+      case CabinetStatus.SET_EXPIRE_AVAILABLE:
         return cabinetColor.emptyCabinet;
       case CabinetStatus.SET_EXPIRE_FULL:
         return cabinetColor.lentedCabinet;


### PR DESCRIPTION
#430 에 대한 오류를 수정했습니다.

`CabinetBoxButton`의 `setCabinetColor` switch case문에서
`case CabinetStatus.AVAILABLE || CabinetStatus.SET_EXPIRE_AVAILABLE:`을
```
case CabinetStatus.AVAILABLE:
case CabinetStatus.SET_EXPIRE_AVAILABLE:
```
로 수정하여 문제를 해결했습니다.