### PR TITLE
누적 연체일에 관한 기능 추가

### DIFF
--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -75,4 +75,28 @@ export class BanService {
     );
     runOnTransactionComplete((err) => err && this.logger.error(err));
   }
+
+  async calDateDiff(begin: Date, end: Date): Promise<number> {
+    this.logger.debug(
+      `Called ${BanService.name} ${this.calDateDiff.name}`,
+    );
+    const diffDatePerSec = end.getTime() - begin.getTime();
+    const days = Math.floor(diffDatePerSec / 1000 / 60 / 60 / 24);
+    return days;
+  }
+
+  /**
+   * 유저의 누적 연체일을 계산
+   * @param user_id
+   */
+    async addOverdueDays(user_id: number): Promise<number> {
+      this.logger.debug(`Called ${BanService.name} ${this.addOverdueDays.name}`);
+      const banLog = await this.banRepository.getBanLogByUserId(user_id);
+      let expiredDays = 0;
+      for (const log of banLog) {
+        if (log.is_penalty == false)
+          expiredDays += await this.calDateDiff(log.banned_date, log.unbanned_date);
+      } 
+      return expiredDays;
+    }
 }

--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -98,11 +98,11 @@ export class BanService {
     async addOverdueDays(user_id: number): Promise<number> {
       this.logger.debug(`Called ${BanService.name} ${this.addOverdueDays.name}`);
       const banLog = await this.banRepository.getBanLogByUserId(user_id);
-      let expiredDays = 0;
+      let accumulate = 0;
       for (const log of banLog) {
         if (log.is_penalty == false)
-          expiredDays += await this.calDateDiff(log.banned_date, log.unbanned_date);
+          accumulate += await this.calDateDiff(log.banned_date, log.unbanned_date);
       } 
-      return expiredDays;
+      return accumulate;
     }
 }

--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -51,7 +51,7 @@ export class BanService {
     const target = new Date(lent.lent_time.getTime());
     target.setDate(target.getDate() + 3);
     if (now < target) {
-      await this.blockingUser(lent, 3);
+      await this.blockingUser(lent, 3, true);
     }
     runOnTransactionComplete((err) => err && this.logger.error(err));
   }
@@ -64,10 +64,10 @@ export class BanService {
   @Transactional({
     propagation: Propagation.REQUIRED,
   })
-  async blockingUser(lent: Lent, ban_day: number): Promise<void> {
+  async blockingUser(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void> {
     this.logger.debug(`Called ${BanService.name} ${this.blockingUser.name}`);
     // 1. Today + ban_day 만큼 unbanned_date주어 ban_log 테이블에 값 추가.
-    await this.banRepository.addToBanLogByUserId(lent, ban_day);
+    await this.banRepository.addToBanLogByUserId(lent, ban_day, is_penalty);
     // 2. 해당 user의 state를 BAN으로 변경.
     await this.userService.updateUserState(
       lent.lent_user_id,
@@ -76,6 +76,12 @@ export class BanService {
     runOnTransactionComplete((err) => err && this.logger.error(err));
   }
 
+  /**
+   * 날짜 차이 계산
+   * @param begin 
+   * @param end 
+   * @returns days
+   */
   async calDateDiff(begin: Date, end: Date): Promise<number> {
     this.logger.debug(
       `Called ${BanService.name} ${this.calDateDiff.name}`,

--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -64,7 +64,11 @@ export class BanService {
   @Transactional({
     propagation: Propagation.REQUIRED,
   })
-  async blockingUser(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void> {
+  async blockingUser(
+    lent: Lent,
+    ban_day: number,
+    is_penalty: boolean,
+  ): Promise<void> {
     this.logger.debug(`Called ${BanService.name} ${this.blockingUser.name}`);
     // 1. Today + ban_day 만큼 unbanned_date주어 ban_log 테이블에 값 추가.
     await this.banRepository.addToBanLogByUserId(lent, ban_day, is_penalty);
@@ -78,14 +82,12 @@ export class BanService {
 
   /**
    * 날짜 차이 계산
-   * @param begin 
-   * @param end 
+   * @param begin
+   * @param end
    * @returns days
    */
   async calDateDiff(begin: Date, end: Date): Promise<number> {
-    this.logger.debug(
-      `Called ${BanService.name} ${this.calDateDiff.name}`,
-    );
+    this.logger.debug(`Called ${BanService.name} ${this.calDateDiff.name}`);
     const diffDatePerSec = end.getTime() - begin.getTime();
     const days = Math.floor(diffDatePerSec / 1000 / 60 / 60 / 24);
     return days;
@@ -95,14 +97,17 @@ export class BanService {
    * 유저의 누적 연체일을 계산
    * @param user_id
    */
-    async addOverdueDays(user_id: number): Promise<number> {
-      this.logger.debug(`Called ${BanService.name} ${this.addOverdueDays.name}`);
-      const banLog = await this.banRepository.getBanLogByUserId(user_id);
-      let accumulate = 0;
-      for (const log of banLog) {
-        if (log.is_penalty == false)
-          accumulate += await this.calDateDiff(log.banned_date, log.unbanned_date);
-      } 
-      return accumulate;
+  async addOverdueDays(user_id: number): Promise<number> {
+    this.logger.debug(`Called ${BanService.name} ${this.addOverdueDays.name}`);
+    const banLog = await this.banRepository.getBanLogByUserId(user_id);
+    let accumulate = 0;
+    for (const log of banLog) {
+      if (log.is_penalty == false)
+        accumulate += await this.calDateDiff(
+          log.banned_date,
+          log.unbanned_date,
+        );
     }
+    return accumulate;
+  }
 }

--- a/backend/src/ban/repository/ban.repository.interface.ts
+++ b/backend/src/ban/repository/ban.repository.interface.ts
@@ -1,3 +1,4 @@
+import BanLog from 'src/entities/ban.log.entity';
 import Lent from 'src/entities/lent.entity';
 
 export interface IBanRepository {
@@ -14,4 +15,10 @@ export interface IBanRepository {
    * @param ban_day
    */
   addToBanLogByUserId(lent: Lent, ban_day: number): Promise<void>;
+
+  /**
+   * user_id를 받아 유저의 ban log들을 반환.
+   * @param user_id 
+   */
+  getBanLogByUserId(user_id: number): Promise<BanLog[]>;
 }

--- a/backend/src/ban/repository/ban.repository.interface.ts
+++ b/backend/src/ban/repository/ban.repository.interface.ts
@@ -15,11 +15,15 @@ export interface IBanRepository {
    * @param ban_day
    * @param is_penalty
    */
-  addToBanLogByUserId(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void>;
+  addToBanLogByUserId(
+    lent: Lent,
+    ban_day: number,
+    is_penalty: boolean,
+  ): Promise<void>;
 
   /**
    * user_id를 받아 유저의 ban log들을 반환.
-   * @param user_id 
+   * @param user_id
    */
   getBanLogByUserId(user_id: number): Promise<BanLog[]>;
 }

--- a/backend/src/ban/repository/ban.repository.interface.ts
+++ b/backend/src/ban/repository/ban.repository.interface.ts
@@ -13,8 +13,9 @@ export interface IBanRepository {
    * Today + ban_day 만큼 unbanned_date주어 ban_log 테이블에 값 추가.
    * @param lent
    * @param ban_day
+   * @param is_penalty
    */
-  addToBanLogByUserId(lent: Lent, ban_day: number): Promise<void>;
+  addToBanLogByUserId(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void>;
 
   /**
    * user_id를 받아 유저의 ban log들을 반환.

--- a/backend/src/ban/repository/ban.repository.ts
+++ b/backend/src/ban/repository/ban.repository.ts
@@ -21,7 +21,7 @@ export class BanRepository implements IBanRepository {
     return result ? result.unbanned_date : null;
   }
 
-  async addToBanLogByUserId(lent: Lent, ban_day: number): Promise<void> {
+  async addToBanLogByUserId(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void> {
     const banned_date = new Date();
     const unbanned_date = new Date(banned_date.getTime());
     unbanned_date.setDate(banned_date.getDate() + ban_day);
@@ -34,6 +34,7 @@ export class BanRepository implements IBanRepository {
         ban_cabinet_id: lent.lent_cabinet_id,
         banned_date,
         unbanned_date,
+        is_penalty,
       })
       .execute();
   }

--- a/backend/src/ban/repository/ban.repository.ts
+++ b/backend/src/ban/repository/ban.repository.ts
@@ -37,4 +37,12 @@ export class BanRepository implements IBanRepository {
       })
       .execute();
   }
+
+  async getBanLogByUserId(user_id: number): Promise<BanLog[]> {
+    return await this.banLogRepository.find({
+      where: {
+        ban_user_id: user_id,
+      },
+    });
+  }
 }

--- a/backend/src/ban/repository/ban.repository.ts
+++ b/backend/src/ban/repository/ban.repository.ts
@@ -21,7 +21,11 @@ export class BanRepository implements IBanRepository {
     return result ? result.unbanned_date : null;
   }
 
-  async addToBanLogByUserId(lent: Lent, ban_day: number, is_penalty: boolean): Promise<void> {
+  async addToBanLogByUserId(
+    lent: Lent,
+    ban_day: number,
+    is_penalty: boolean,
+  ): Promise<void> {
     const banned_date = new Date();
     const unbanned_date = new Date(banned_date.getTime());
     unbanned_date.setDate(banned_date.getDate() + ban_day);

--- a/backend/src/entities/ban.log.entity.ts
+++ b/backend/src/entities/ban.log.entity.ts
@@ -44,7 +44,7 @@ export default class BanLog {
     type: 'boolean',
   })
   is_penalty: boolean;
-  
+
   @ManyToOne(() => User, (user) => user.user_id)
   @JoinColumn({
     name: 'ban_user_id',

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -137,9 +137,12 @@ export class LentTools {
         break;
       case CabinetStatusType.BANNED:
       case CabinetStatusType.EXPIRED:
+        const overdue = await this.banService.calDateDiff(lent.expire_time, new Date());
+        const cumulative = await this.banService.addOverdueDays(user.user_id);
         await this.banService.blockingUser(
           lent,
-          await this.banService.calDateDiff(lent.expire_time, new Date()),
+          overdue + cumulative,
+          false,
         );
         if (
           lent.cabinet.status === CabinetStatusType.EXPIRED &&

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -137,13 +137,12 @@ export class LentTools {
         break;
       case CabinetStatusType.BANNED:
       case CabinetStatusType.EXPIRED:
-        const overdue = await this.banService.calDateDiff(lent.expire_time, new Date());
-        const cumulative = await this.banService.addOverdueDays(user.user_id);
-        await this.banService.blockingUser(
-          lent,
-          overdue + cumulative,
-          false,
+        const overdue = await this.banService.calDateDiff(
+          lent.expire_time,
+          new Date(),
         );
+        const cumulative = await this.banService.addOverdueDays(user.user_id);
+        await this.banService.blockingUser(lent, overdue + cumulative, false);
         if (
           lent.cabinet.status === CabinetStatusType.EXPIRED &&
           lent_user_cnt - 1 === 0

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -7,7 +7,6 @@ import CabinetStatusType from 'src/enums/cabinet.status.type.enum';
 import LentType from 'src/enums/lent.type.enum';
 import { BanService } from '../ban/ban.service';
 import { CabinetInfoService } from '../cabinet/cabinet.info.service';
-import { ExpiredChecker } from '../utils/expired.checker.component';
 import { LentService } from './lent.service';
 import { ILentRepository } from './repository/lent.repository.interface';
 import {
@@ -26,8 +25,6 @@ export class LentTools {
     @Inject(forwardRef(() => LentService))
     private lentService: LentService,
     private banService: BanService,
-    @Inject(forwardRef(() => ExpiredChecker))
-    private expiredChecker: ExpiredChecker,
   ) {}
 
   /**
@@ -142,7 +139,7 @@ export class LentTools {
       case CabinetStatusType.EXPIRED:
         await this.banService.blockingUser(
           lent,
-          await this.expiredChecker.getExpiredDays(lent.expire_time),
+          await this.banService.calDateDiff(lent.expire_time, new Date()),
         );
         if (
           lent.cabinet.status === CabinetStatusType.EXPIRED &&

--- a/backend/src/lent/lent.module.ts
+++ b/backend/src/lent/lent.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
 import { CabinetModule } from '../cabinet/cabinet.module';
@@ -10,7 +10,6 @@ import LentLog from 'src/entities/lent.log.entity';
 import { BanModule } from '../ban/ban.module';
 import { LentMockController } from './lent.mock.controller';
 import { LentTools } from './lent.component';
-import { UtilsModule } from '../utils/utils.module';
 
 const repo = {
   provide: 'ILentRepository',
@@ -23,7 +22,6 @@ const repo = {
     AuthModule,
     BanModule,
     TypeOrmModule.forFeature([Lent, LentLog]),
-    forwardRef(() => UtilsModule),
   ],
   controllers: [LentController, LentMockController],
   providers: [LentService, repo, LentTools],

--- a/backend/src/utils/expired.checker.component.ts
+++ b/backend/src/utils/expired.checker.component.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import CabinetStatusType from 'src/enums/cabinet.status.type.enum';
 import { CabinetInfoService } from '../cabinet/cabinet.info.service';
@@ -28,15 +28,17 @@ export class ExpiredChecker {
     propagation: Propagation.REQUIRED,
   })
   async checkExpiredCabinetEach(lent: Lent) {
-    const days = await this.banService.calDateDiff(lent.expire_time, new Date());
+    const days = await this.banService.calDateDiff(
+      lent.expire_time,
+      new Date(),
+    );
     if (days >= 0) {
       if (days > 0 && days < 15) {
         await this.cabinetInfoService.updateCabinetStatus(
           lent.lent_cabinet_id,
           CabinetStatusType.EXPIRED,
         );
-      }
-      else if (days >= 15) {
+      } else if (days >= 15) {
         await this.cabinetInfoService.updateCabinetStatus(
           lent.lent_cabinet_id,
           CabinetStatusType.BANNED,
@@ -58,8 +60,7 @@ export class ExpiredChecker {
     );
     const lentList = await Promise.all(await this.lentTools.getAllLent());
     lentList.forEach(async (lent: Lent) => {
-      if (lent.expire_time === null)
-        return ;
+      if (lent.expire_time === null) return;
       await this.checkExpiredCabinetEach(lent);
     });
   }

--- a/backend/src/utils/expired.checker.component.ts
+++ b/backend/src/utils/expired.checker.component.ts
@@ -11,34 +11,24 @@ import {
   runOnTransactionComplete,
 } from 'typeorm-transactional';
 import Lent from 'src/entities/lent.entity';
+import { BanService } from 'src/ban/ban.service';
 
 @Injectable()
 export class ExpiredChecker {
   private logger = new Logger(ExpiredChecker.name);
   constructor(
-    @Inject(forwardRef(() => LentTools))
     private readonly lentTools: LentTools,
-    @Inject(forwardRef(() => LentService))
     private readonly lentService: LentService,
     private readonly emailsender: EmailSender,
     private cabinetInfoService: CabinetInfoService,
+    private banService: BanService,
   ) {}
-
-  async getExpiredDays(expire_time: Date): Promise<number> {
-    this.logger.debug(
-      `Called ${ExpiredChecker.name} ${this.getExpiredDays.name}`,
-    );
-    const today = new Date();
-    const diffDatePerSec = today.getTime() - expire_time.getTime();
-    const days = Math.floor(diffDatePerSec / 1000 / 60 / 60 / 24);
-    return days;
-  }
 
   @Transactional({
     propagation: Propagation.REQUIRED,
   })
   async checkExpiredCabinetEach(lent: Lent) {
-    const days = await this.getExpiredDays(lent.expire_time);
+    const days = await this.banService.calDateDiff(lent.expire_time, new Date());
     if (days >= 0) {
       if (days > 0 && days < 15) {
         await this.cabinetInfoService.updateCabinetStatus(

--- a/backend/src/utils/utils.module.ts
+++ b/backend/src/utils/utils.module.ts
@@ -2,10 +2,12 @@ import { MailerModule } from '@nestjs-modules/mailer';
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
+import { BanModule } from 'src/ban/ban.module';
 import MailerConfigService from 'src/config/mailer.config';
 import { LentModule } from 'src/lent/lent.module';
 import { CabinetModule } from '../cabinet/cabinet.module';
 import { EmailSender } from './email.sender.component';
+import { ExpiredChecker } from './expired.checker.component';
 
 @Module({
   imports: [
@@ -16,9 +18,10 @@ import { EmailSender } from './email.sender.component';
     }),
     CabinetModule,
     LentModule,
+    BanModule,
   ],
 
-  providers: [EmailSender],
+  providers: [EmailSender, ExpiredChecker],
   exports: [EmailSender],
 })
 export class UtilsModule {}

--- a/backend/src/utils/utils.module.ts
+++ b/backend/src/utils/utils.module.ts
@@ -3,10 +3,9 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import MailerConfigService from 'src/config/mailer.config';
+import { LentModule } from 'src/lent/lent.module';
 import { CabinetModule } from '../cabinet/cabinet.module';
-import { LentModule } from '../lent/lent.module';
 import { EmailSender } from './email.sender.component';
-import { ExpiredChecker } from './expired.checker.component';
 
 @Module({
   imports: [
@@ -15,11 +14,11 @@ import { ExpiredChecker } from './expired.checker.component';
       imports: [ConfigModule],
       useClass: MailerConfigService,
     }),
-    forwardRef(() => LentModule),
     CabinetModule,
+    LentModule,
   ],
 
-  providers: [EmailSender, ExpiredChecker],
-  exports: [EmailSender, ExpiredChecker],
+  providers: [EmailSender],
+  exports: [EmailSender],
 })
 export class UtilsModule {}

--- a/backend/src/utils/utils.module.ts
+++ b/backend/src/utils/utils.module.ts
@@ -1,5 +1,5 @@
 import { MailerModule } from '@nestjs-modules/mailer';
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { BanModule } from 'src/ban/ban.module';


### PR DESCRIPTION
패널티로 인한 ban은 연체일로 인한 ban과는 다르다는 판단하에 새로운 필드 `is_penalty`를 추가하여 패널티로 인한 ban log 날짜는 제외하고 누적 연체일 계산

expired checker component에 있었던 `getExpriedDays` 함수는 ban service로 이동하여 `calDateDiff`로 이름을 변경, 
now()와 expired_time의 차이만 계산할 수 있었던 함수를 begin, end date를 받아 계산하는 로직으로 변경하였습니다.