### PR TITLE
:ambulance: set timezone to Asia/Seoul in typeorm config #452

### DIFF
--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -17,6 +17,7 @@ export default class TypeOrmConfigService implements TypeOrmOptionsFactory {
       entities: [`${__dirname}/../**/entities/*.entity.{js,ts}`],
       synchronize: false,
       logging: true,
+      timezone: "Asia/Seoul",
     };
   }
 }


### PR DESCRIPTION
DB에 저장되는 Date의 `timezone` 설정이 `Asia/Seoul`로 되어있지 않아 발생한 문제였네용
`Asia/Seoul`로 설정해주니 한국 시간으로 잘 찍힙니다!
<img width="649" alt="스크린샷 2022-10-14 오후 9 00 04" src="https://user-images.githubusercontent.com/83565255/195842059-eb8d8b3a-d2db-4ba0-90f3-0a51ba0ce884.png">
<img width="368" alt="스크린샷 2022-10-14 오후 9 00 11" src="https://user-images.githubusercontent.com/83565255/195842090-3e54cc4c-3334-41b5-b251-07c72d4ba4f9.png">
