### PR TITLE
fe_v3/MainTemplateRatio

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/FloorButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/FloorButton.tsx
@@ -3,18 +3,6 @@ import Button from "@mui/material/Button";
 import React from "react";
 import { CabinetLocationFloorDto } from "../../../types/dto/cabinet.dto";
 
-// XXX:
-// 로그인 시 최초 API 호출로 4중 배열 불러오고, 버튼에서는 내부 커스텀 액션으로 필요한 정보만 나눠서 가져오기
-// TODO:
-// 1. 현재 건물 위치 알려주는 l_idx 변수명 더 구체적으로 변경하면 좋을 것 같습니다
-// 2. location 변경 시 setLidx 함수를 통해 l_idx가 변경되고 있어,
-// 버튼이 아닌 다른 컴포넌트에서 이 상태를 관리하도록 변경하는 게 좋을 것 같습니다
-//   const [l_idx, setLidx] = useState<number>(0);
-//   // TODO:
-//   // 3. info 업데이트하기 위해 axios API 및 dispatch 호출
-//   // TODO:
-//   // 4. handleClick 이벤트 핸들러 구현
-
 interface FloorButtonProps {
   currentFloor: number;
   setFloor: (floor: number) => void;
@@ -32,7 +20,9 @@ const FloorButton = (props: FloorButtonProps): JSX.Element => {
       {floorsByLocation?.floors?.map((floor: number) => {
         return (
           <Button
+            style={{ height: "1.7rem" }}
             variant={floor === currentFloor ? "outlined" : "contained"}
+            color="info"
             key={floor}
             button-key={floor}
             onClick={handleClick}

--- a/frontend_v3/src/components/organisms/Carousel.tsx
+++ b/frontend_v3/src/components/organisms/Carousel.tsx
@@ -30,12 +30,12 @@ const SectionButtonArea = styled.div`
   flex-direction: row;
   justify-content: between-space;
   align-items: center;
-  height: 2rem;
+  height: 1rem;
 `;
 
 const RowDiv = styled.div`
   display: flex;
-  height: calc(100% - 2rem);
+  height: calc(100% - 3rem);
   flex-direction: row;
   align-items: center;
 `;

--- a/frontend_v3/src/themes/muiCustomTheme.tsx
+++ b/frontend_v3/src/themes/muiCustomTheme.tsx
@@ -14,6 +14,9 @@ const muiCustomTheme = createTheme({
     secondary: {
       main: "#6c757d",
     },
+    info: {
+      main: "#a3a4ce",
+    },
   },
 });
 


### PR DESCRIPTION
## 상황
- SectionName을 추가하면서 하단의 GuideModal이 밀려나는 현상 발생

## 변경사항 요약
- Carousel의 Row div height 비율을 height: calc(100% - 2rem) -> height: calc(100% - 3rem) 수정
- 기존 커밋된 부분에 해당 내용이 적용되어 있어 삭제하였습니다.

## 추가
- SectionName과 Button 사이 공간이 넓어 SectionButton의 height를 2rem -> 1rem으로 수정
- FloorButton의 크기 수정 및 내부 글씨가 잘 보이도록 Carousel에 사용되는 색상과 동일하게 수정