### PR TITLE
:zap: 환경변수를 이용하여 상황에 맞게 V2, V3를 구동할 수 있도록 수정 #500

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,7 +4,7 @@ import {
   Module,
   NestModule,
 } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import configuration from './config/configuration';
 import { SessionMiddleware } from './middleware/session-middleware';
@@ -42,10 +42,17 @@ import { BetatestModule } from './betatest/betatest.module';
     AuthModule,
     EventModule,
     BlackholeModule,
-    ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '../../', 'frontend_v3/dist/'),
-      exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
-      // serveRoot: '../img'
+    // ServeStaticModule.forRoot({
+    //   // rootPath: join(__dirname, `../../', ${this.configService.get<number>('is_v3')} ? 'frontend_v3/dist/' : 'frontend/dist/`),
+    //   exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
+    //   // serveRoot: '../img'
+    // }),
+    ServeStaticModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => [{
+        rootPath: join(__dirname, '../../', `${configService.get<number>('is_v3') ? 'frontend_v3/dist/' : 'frontend/dist/'}`),
+        exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
+      }],
     }),
     EventEmitterModule.forRoot(),
     CabinetModule,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -50,7 +50,7 @@ import { BetatestModule } from './betatest/betatest.module';
     ServeStaticModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => [{
-        rootPath: join(__dirname, '../../', `${configService.get<number>('is_v3') ? 'frontend_v3/dist/' : 'frontend/dist/'}`),
+        rootPath: join(__dirname, '../../', `${configService.get<boolean>('is_v3') ? 'frontend_v3/dist/' : 'frontend/dist/'}`),
         exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
       }],
     }),

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -41,4 +41,5 @@ export default () => ({
     forcedreturn: parseInt(process.env.EXPIRE_TERM_FORCEDRETURN, 10),
   },
   penalty_day_share: parseInt(process.env.PENALTY_DAY_SHARE, 10),
+  is_v3: process.env.IS_V3 === 'true',
 });


### PR DESCRIPTION
환경변수를 이용하여 상황에 맞게 V2, V3를 구동할 수 있도록 수정했습니다.

.env 파일에 `IS_V3=true`로 설정하면 V3로 구동되고 그렇지 않은 경우 V2로 구동됩니다.

이를 이용하면 서비스 오픈/클로즈할 때 쉽게 안내 페이지/메인 서비스 페이지 전환이 가능할 것 같습니다!!