### PR TITLE
FIX: 401 response 처리

### DIFF
--- a/frontend_v3/src/network/axios/axios.instance.ts
+++ b/frontend_v3/src/network/axios/axios.instance.ts
@@ -1,8 +1,22 @@
 import axios from "axios";
+import { removeCookie } from "../react-cookie/cookie";
 
 const instance = axios.create({
   baseURL: window.location.origin,
-  withCredentials: true,
 });
+
+instance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    // access_token unauthorized
+    if (error.response?.status === 401) {
+      removeCookie("access_token");
+      window.location.href = "/";
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default instance;

--- a/frontend_v3/src/network/react-cookie/cookie.ts
+++ b/frontend_v3/src/network/react-cookie/cookie.ts
@@ -9,3 +9,7 @@ export const setCookie = (name: string, value: string, option?: any): void => {
 export const getCookie = (name: string): string => {
   return cookies.get(name);
 };
+
+export const removeCookie = (name: string, option?: any): void => {
+  return cookies.remove(name, { ...option });
+};


### PR DESCRIPTION
## Issue
- #513 

## 변경사항
- removeCookie 추가
- Axios intercepter를 instance에 적용해서 모든 요청에 대한 401 응답에 access_token 삭제 + 로그인 페이지로 이동하도록 처리