### PR TITLE
fe_v3/gaCSP

### DIFF
--- a/frontend_v3/index.html
+++ b/frontend_v3/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/img/cabinet.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="script-src https://www.google-analytics.com https://ssl.google-analytics.com,
+                                                    img-src https://www.google-analytics.com, 
+                                                    connect-src https://www.google-analytics.com"
+    />
     <title>42 Cabi</title>
   </head>
   <body>


### PR DESCRIPTION
## 변경사항 요약
- ga error를 디버깅하는 과정에서 CSP에 대한 지시어를 포함해야한다는 해결 방법을 찾게되었습니다.
- `<head>` 태그 내부에 `<meta>` 태그로 정의된 CSP 정책을 작성해보았습니다.
```
<meta
      http-equiv="Content-Security-Policy"
      content="script-src https://www.google-analytics.com https://ssl.google-analytics.com,
                                                    img-src https://www.google-analytics.com, 
                                                    connect-src https://www.google-analytics.com"
    />
```