### PR TITLE
블랙홀 모듈 최종 개선안 #517

### DIFF
--- a/backend/src/auth/42/ft.strategy.ts
+++ b/backend/src/auth/42/ft.strategy.ts
@@ -39,9 +39,12 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
     if (!profile.staff && !profile.cursus_users[1]) {
       cb(null, undefined);
     }
-    let blackholed_at: Date = undefined;
+    let blackholed_at: Date;
     if (profile.cursus_users[1]) {
       blackholed_at = profile.cursus_users[1].blackholed_at;
+      if (blackholed_at !== null) {
+        blackholed_at = new Date(blackholed_at);
+      }
     }
     const user: UserSessionDto = {
       user_id: profile.userId,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
   ) {}
 
   async addUserIfNotExists(user: UserSessionDto): Promise<boolean> {
-    const find = await this.authRepository.addUserIfNotExists(user);
+    const find = await this.authRepository.addUserIfNotExists(user, user.blackholed_at);
     const is_local = this.configService.get<boolean>('is_local');
     if (!find && !is_local) this.eventEmitter.emit('user.created', user);
     await this.cacheManager.set(`user-${user.user_id}`, true, { ttl: 0 });

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -7,7 +7,7 @@ export interface IAuthRepository {
    * @param user 추가될 유저
    * @return boolean 존재했다면 true, 존재하지 않았다면 false
    */
-  addUserIfNotExists(user: UserDto): Promise<boolean>;
+  addUserIfNotExists(user: UserDto, blackhole_date?: Date): Promise<boolean>;
 
   /**
    * 유저가 사물함을 빌렸는지 확인합니다.

--- a/backend/src/auth/repository/auth.repository.ts
+++ b/backend/src/auth/repository/auth.repository.ts
@@ -1,6 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserDto } from 'src/dto/user.dto';
 import User from 'src/entities/user.entity';
+import UserStateType from 'src/enums/user.state.type.enum';
 import { Repository } from 'typeorm';
 import { IAuthRepository } from './auth.repository.interface';
 
@@ -9,7 +10,7 @@ export class AuthRepository implements IAuthRepository {
     @InjectRepository(User) private userRepository: Repository<User>,
   ) {}
 
-  async addUserIfNotExists(user: UserDto): Promise<boolean> {
+  async addUserIfNotExists(user: UserDto, blackhole_date?: Date): Promise<boolean> {
     const find = await this.userRepository.findOne({
       where: {
         user_id: user.user_id,
@@ -19,10 +20,11 @@ export class AuthRepository implements IAuthRepository {
       await this.userRepository.save({
         user_id: user.user_id,
         intra_id: user.intra_id,
-        auth: 0,
+        state: UserStateType.NORMAL,
         email: user.email,
         first_login: new Date(),
         last_login: new Date(),
+        blackhole_date: blackhole_date,
       });
       return false;
     }

--- a/backend/src/blackhole/blackhole.component.ts
+++ b/backend/src/blackhole/blackhole.component.ts
@@ -42,6 +42,7 @@ export class BlackholeTools {
   // Today - Blackhole_date후 fired될 Timer등록.
   // Timer가 fired 되면 콜백으로 validateBlackholedUser를 수행.
   async addBlackholeTimer(user: UserDto, blackhole_date: Date) {
+    this.logger.log(`new timer that fired on ${blackhole_date} set!`);
     const callback = async () => {
       this.logger.debug(`Blackhole timer for ${user.intra_id} fired!`);
       await this.blackholeService.postOauthToken().catch((err) => {

--- a/backend/src/blackhole/blackhole.component.ts
+++ b/backend/src/blackhole/blackhole.component.ts
@@ -67,23 +67,13 @@ export class BlackholeTools {
   /**
    * 유저가 생성되면 해당 유저의 블랙홀 타이머를 등록.
    */
-  async validateBlackholeForNewUser(user: UserSessionDto) {
-    const data = {
-      'staff?': user.staff,
-      blackholed_at: user.blackholed_at,
-    };
-    await this.blackholeService
-      .validateBlackholedUser(user, data)
-      .catch(async (err) => {
-        if (err.status === HttpStatus.NOT_FOUND) {
-          this.logger.error(
-            `${user.intra_id} is already expired or not exists in 42 intra`,
-          );
-          await this.blackholeService.deleteBlackholedUser(user);
-        } else {
-          this.logger.error(err);
-        }
-      });
-    this.logger.debug(`New Timer: ${user.intra_id} set!`);
+  async addBlackholeTimerNewUser(user: UserSessionDto) {
+    if (user.staff === true || user.blackholed_at === null) {
+      const fire_date = new Date();
+      fire_date.setDate(fire_date.getDate() + 90);
+      await this.addBlackholeTimer(user, fire_date);
+    } else {
+      await this.addBlackholeTimer(user, user.blackholed_at);
+    }
   }
 }

--- a/backend/src/blackhole/blackhole.service.ts
+++ b/backend/src/blackhole/blackhole.service.ts
@@ -133,7 +133,17 @@ export class BlackholeService implements OnApplicationBootstrap {
     const today = new Date();
     const fire_date = new Date();
     // 스태프는 판별하지 않음.
+    let is_staff = false;
     if (data['staff?'] === true) {
+      is_staff = true;
+    } else if (data.groups.length !== 0) {
+      for (const group of data.groups) {
+        if (group.name === 'STAFF' || group.name === 'pedago') {
+          is_staff = true;
+        }
+      }
+    }
+    if (is_staff) {
       this.logger.log(`${user.intra_id} is staff`);
       fire_date.setDate(today.getDate() + 90);
       await this.blackholeTools.addBlackholeTimer(user, fire_date);

--- a/backend/src/user/repository/user.repository.interface.ts
+++ b/backend/src/user/repository/user.repository.interface.ts
@@ -1,6 +1,7 @@
 import { CabinetDto } from 'src/dto/cabinet.dto';
 import { CabinetExtendDto } from 'src/dto/cabinet.extend.dto';
 import { UserDto } from 'src/dto/user.dto';
+import { UserSessionDto } from 'src/dto/user.session.dto';
 import UserStateType from 'src/enums/user.state.type.enum';
 
 export interface IUserRepository {
@@ -32,7 +33,7 @@ export interface IUserRepository {
    *
    * @return UserDto[]
    */
-  getAllUser(): Promise<UserDto[]>;
+  getAllUser(): Promise<UserSessionDto[]>;
 
   /**
    * 특정 유저가 대여한 사물함 정보를 CabinetDto로 가져옵니다.
@@ -46,4 +47,10 @@ export interface IUserRepository {
    * @param user_id
    */
   deleteUserById(user_id: number): Promise<void>;
+
+  /**
+   * 해당 유저의 blackhole_date를 업데이트합니다.
+   * @param user_id
+   */
+  updateBlackholeDate(user_id: number, blackhole_date: Date): Promise<void>;
 }

--- a/backend/src/user/repository/user.repository.ts
+++ b/backend/src/user/repository/user.repository.ts
@@ -2,6 +2,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CabinetDto } from 'src/dto/cabinet.dto';
 import { CabinetExtendDto } from 'src/dto/cabinet.extend.dto';
 import { UserDto } from 'src/dto/user.dto';
+import { UserSessionDto } from 'src/dto/user.session.dto';
 import User from 'src/entities/user.entity';
 import UserStateType from 'src/enums/user.state.type.enum';
 import { Repository } from 'typeorm';
@@ -68,12 +69,13 @@ export class UserRepository implements IUserRepository {
       .execute();
   }
 
-  async getAllUser(): Promise<UserDto[]> {
+  async getAllUser(): Promise<UserSessionDto[]> {
     const result = await this.userRepository.find();
     return result.map((user) => {
       return {
         user_id: user.user_id,
         intra_id: user.intra_id,
+        blackholed_at: user.blackhole_date,
       };
     });
   }
@@ -111,5 +113,17 @@ export class UserRepository implements IUserRepository {
         user_id: user_id,
       })
       .execute();
+  }
+
+  async updateBlackholeDate(user_id: number, blackhole_date: Date): Promise<void> {
+    await this.userRepository.createQueryBuilder()
+    .update(User)
+    .set({
+      blackhole_date: blackhole_date,
+    })
+    .where({
+      user_id: user_id,
+    })
+    .execute();
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -7,6 +7,7 @@ import { UserDto } from 'src/dto/user.dto';
 import UserStateType from 'src/enums/user.state.type.enum';
 import { CabinetInfoService } from '../cabinet/cabinet.info.service';
 import { IUserRepository } from './repository/user.repository.interface';
+import { UserSessionDto } from 'src/dto/user.session.dto';
 
 @Injectable()
 export class UserService {
@@ -54,7 +55,7 @@ export class UserService {
     await this.userRepository.updateUserState(user_id, state);
   }
 
-  async getAllUser(): Promise<UserDto[]> {
+  async getAllUser(): Promise<UserSessionDto[]> {
     this.logger.debug(`Called ${this.getAllUser.name}`);
     return await this.userRepository.getAllUser();
   }
@@ -68,5 +69,10 @@ export class UserService {
     this.logger.debug(`Called ${this.deleteUserById.name}`);
     await this.cacheManager.del(`user-${user_id}`);
     await this.userRepository.deleteUserById(user_id);
+  }
+
+  async updateBlackholeDate(user_id: number, blackhole_date?: Date): Promise<void> {
+    this.logger.debug(`Called ${this.updateBlackholeDate.name}`);
+    await this.userRepository.updateBlackholeDate(user_id, blackhole_date);
   }
 }


### PR DESCRIPTION
### 추가된 기능
서버가 재구동될 때 모든 유저에 대해 블랙홀 검증을 하는 것이 아닌 기존에 추가했던 `blackhole_date` 필드를 활용하여 
이 필드 값에 따라 동작하는 타이머를 달아 타이머가 fired될 때 블랙홀 검증을 하도록 개선했습니다.

### 기존에 존재하는 유저 테스트
- [x] blackhole_date가 null인 유저에게 정상적으로 15일 타이머가 달리는가?
- [x] blackhole_date > today인 유저에게 정상적으로 blackhole_date에 동작하는 타이머가 달리는가?
- [x] blackhole_date <= today인 유저에게 즉시 블랙홀 판정 작업이 이루어지는가?

### 새로 들어온 유저 테스트
- [ ] 새로 들어온 유저의 블랙홀/staff 정보를 잘 가져오는가?
- [ ] staff와 member면 90일 타이머가 등록되는가?
- [x] 그 외에 경우는 blackhole_date에 동작하는 타이머가 달리는가?
- [x] DB에 블랙홀 정보가 잘 업데이트 되는가?


### 타이머 관련 테스트
- [x] 타이머가 발동될 때 정상적으로 intra로부터 유저정보를 가져오는가?
- [x] 유저 정보를 가져올 때 staff이면 blackhole_date를 null로 업데이트하고 90일 타이머가 달리는가?
- [x] 유저 정보를 가져올 때 member이면 blackhole_date를 null로 업데이트하고 90일 타이머가 달리는가?
- [x] blackhole_date > today인 유저에게 정상적으로 blackhole_date에 동작하는 타이머가 달리는가?
- [x] blackhole_date <= today인 유저를 강제반납/삭제 처리 시키는가?