### PR TITLE
Be v3/hotfix

### DIFF
--- a/backend/src/lent/repository/lent.repository.ts
+++ b/backend/src/lent/repository/lent.repository.ts
@@ -61,11 +61,12 @@ export class lentRepository implements ILentRepository {
     //   },
     // });
 
-    const result: number = await this.lentRepository.createQueryBuilder()
-    .innerJoin("Lent.cabinet","cabinet")
-    .where("cabinet.cabinet_id = :cabinet_id", { cabinet_id : cabinet_id })
-    .setLock("pessimistic_write")
-    .getCount();
+    const result: number = await this.lentRepository
+      .createQueryBuilder()
+      .innerJoin('Lent.cabinet', 'cabinet')
+      .where('cabinet.cabinet_id = :cabinet_id', { cabinet_id: cabinet_id })
+      .setLock('pessimistic_write')
+      .getCount();
     return result;
   }
 
@@ -209,12 +210,13 @@ export class lentRepository implements ILentRepository {
     //   },
     // });
 
-    const result = await this.lentRepository.createQueryBuilder()
-    .leftJoinAndSelect("Lent.cabinet","cabinet")
-    .leftJoinAndSelect("Lent.user","user")
-    .setLock("pessimistic_write")
-    .where("lent_user_id = :user_id", {user_id: user_id})
-    .getOne()
+    const result = await this.lentRepository
+      .createQueryBuilder()
+      .leftJoinAndSelect('Lent.cabinet', 'cabinet')
+      .leftJoinAndSelect('Lent.user', 'user')
+      .setLock('pessimistic_write')
+      .where('lent_user_id = :user_id', { user_id: user_id })
+      .getOne();
 
     return result;
   }

--- a/backend/src/lent/repository/lent.repository.ts
+++ b/backend/src/lent/repository/lent.repository.ts
@@ -33,6 +33,12 @@ export class lentRepository implements ILentRepository {
         lent_user_id: user_id,
       },
     });
+    // const result = await this.lentRepository.createQueryBuilder()
+    // .select()
+    // .setLock("pessimistic_write")
+    // .where("lent_user_id = :user_id", { user_id : user_id })
+    // .getOne();
+
     if (!result) {
       return false;
     }
@@ -44,16 +50,22 @@ export class lentRepository implements ILentRepository {
     isolationLevel: IsolationLevel.SERIALIZABLE,
   })
   async getLentUserCnt(cabinet_id: number): Promise<number> {
-    const result: number = await this.lentRepository.count({
-      relations: {
-        cabinet: true,
-      },
-      where: {
-        cabinet: {
-          cabinet_id: cabinet_id,
-        },
-      },
-    });
+    // const result: number = await this.lentRepository.count({
+    //   relations: {
+    //     cabinet: true,
+    //   },
+    //   where: {
+    //     cabinet: {
+    //       cabinet_id: cabinet_id,
+    //     },
+    //   },
+    // });
+
+    const result: number = await this.lentRepository.createQueryBuilder()
+    .innerJoin("Lent.cabinet","cabinet")
+    .where("cabinet.cabinet_id = :cabinet_id", { cabinet_id : cabinet_id })
+    .setLock("pessimistic_write")
+    .getCount();
     return result;
   }
 
@@ -187,15 +199,23 @@ export class lentRepository implements ILentRepository {
     isolationLevel: IsolationLevel.SERIALIZABLE,
   })
   async getLent(user_id: number): Promise<Lent> {
-    const result = await this.lentRepository.findOne({
-      relations: {
-        cabinet: true,
-        user: true,
-      },
-      where: {
-        lent_user_id: user_id,
-      },
-    });
+    // const result = await this.lentRepository.findOne({
+    //   relations: {
+    //     cabinet: true,
+    //     user: true,
+    //   },
+    //   where: {
+    //     lent_user_id: user_id,
+    //   },
+    // });
+
+    const result = await this.lentRepository.createQueryBuilder()
+    .leftJoinAndSelect("Lent.cabinet","cabinet")
+    .leftJoinAndSelect("Lent.user","user")
+    .setLock("pessimistic_write")
+    .where("lent_user_id = :user_id", {user_id: user_id})
+    .getOne()
+
     return result;
   }
 


### PR DESCRIPTION
#532 에 대한 PR입니다.

## 버그에 대한 설명
isolation level을 serializable로 설정한 경우, db에 대한 모든 접근이 불가능할거라고 예상했으나, select문은 모두 처리가 되는 것을 확인했습니다. select가 실행이 되는 이유는 select는 s-lock(공유잠금)이기 때문에 서로 공유가 됩니다. 
ex) `A 트랜잭션의 select 실행 -> B 트랜잭션의 select 실행`
하지만 이 다음에 A 트랜잭션에서 update를 하려고 하면 x-lock(배타적잠금)으로 바꾸기를 시도하는데 B 트랜잭션에서도 잠금이 걸려있으므로 변환에 실패하게됩니다. B에서는 A의 공유잠금때문에 실패하게 되고 이를 conversion deadlock이라고 합니다.

## 버그 해결 방법
기존에 isolation level을 설정할 때 기대한 방향과 같이 실행되도록 하나의 트랜잭션에서 select를 하면 다른 트랜잭션에서 select 또한 하지 못하게 막는 for update를 사용했습니다.

개인적으로 테스트는 해보았으나 할 수 있는 테스트에 제한이 있어 다 같이 테스트 해보면 좋을 것 같습니다.
그리고 일단 deadlock 문제가 생겼던 쿼리에만 추가를 해놨으니 다른 곳에도 추가를 할 지는 논의해봐야할 것 같습니다.
혹은 다른 방법으로 처리할 수 있을지도 논의해보면 좋을 것 같습니다!