### PR TITLE
Be v3/email

### DIFF
--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -114,7 +114,7 @@ export class BanService {
     const beginMonth = begin.getMonth();
     const beginDay = begin.getDate();
 
-    const newEnd = new Date(endYear,endMonth,endDay);
+    const newEnd = new Date(endYear, endMonth, endDay);
     const newBegin = new Date(beginYear, beginMonth, beginDay);
 
     const diffDatePerSec = newEnd.getTime() - newBegin.getTime();

--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -106,8 +106,19 @@ export class BanService {
    */
   async calDateDiff(begin: Date, end: Date): Promise<number> {
     this.logger.debug(`Called ${BanService.name} ${this.calDateDiff.name}`);
-    const diffDatePerSec = end.getTime() - begin.getTime();
-    const days = Math.floor(diffDatePerSec / 1000 / 60 / 60 / 24);
+    const endYear = end.getFullYear();
+    const endMonth = end.getMonth();
+    const endDay = end.getDate();
+
+    const beginYear = begin.getFullYear();
+    const beginMonth = begin.getMonth();
+    const beginDay = begin.getDate();
+
+    const newEnd = new Date(endYear,endMonth,endDay);
+    const newBegin = new Date(beginYear, beginMonth, beginDay);
+
+    const diffDatePerSec = newEnd.getTime() - newBegin.getTime();
+    const days = Math.ceil(diffDatePerSec / 1000 / 60 / 60 / 24);
     return days;
   }
 

--- a/backend/src/utils/expired.checker.component.ts
+++ b/backend/src/utils/expired.checker.component.ts
@@ -36,9 +36,9 @@ export class ExpiredChecker {
       lent.expire_time,
       new Date(),
     );
-    if (days >= 0) {
+    if (days >= this.configService.get<number>('expire_term.soonoverdue') ) {
       if (
-        days >= 0 &&
+        days > 0 &&
         days < this.configService.get<number>('expire_term.forcedreturn')
       ) {
         await this.cabinetInfoService.updateCabinetStatus(
@@ -62,7 +62,7 @@ export class ExpiredChecker {
     runOnTransactionComplete((err) => err && this.logger.error(err));
   }
 
-  @Cron(CronExpression.EVERY_DAY_AT_9PM)
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async checkExpiredLent() {
     this.logger.debug(
       `Called ${ExpiredChecker.name} ${this.checkExpiredLent.name}`,

--- a/backend/src/utils/expired.checker.component.ts
+++ b/backend/src/utils/expired.checker.component.ts
@@ -36,7 +36,7 @@ export class ExpiredChecker {
       lent.expire_time,
       new Date(),
     );
-    if (days >= this.configService.get<number>('expire_term.soonoverdue') ) {
+    if (days >= this.configService.get<number>('expire_term.soonoverdue')) {
       if (
         days > 0 &&
         days < this.configService.get<number>('expire_term.forcedreturn')


### PR DESCRIPTION
만일 이메일 보내는 시간을 바꿀 경우 날짜 계산에 문제가 생길 수 있어 calDateDiff를 수정하였고,
expiredchecker에서 환경 변수에 저장되어 있는 날짜를 통해 이메일을 제대로 보낼 수 있도록 수정하였습니다.