### PR TITLE
:bug: fix when return expired cabinet #542

### DIFF
--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -190,11 +190,11 @@ export class LentTools {
         const cumulative = await this.banService.addOverdueDays(user.user_id);
         await this.banService.blockingUser(lent, overdue + cumulative, false);
         if (
-          lent.cabinet.status === CabinetStatusType.EXPIRED &&
+          cabinet.status === CabinetStatusType.EXPIRED &&
           lent_count - 1 === 0
         ) {
           await this.cabinetInfoService.updateCabinetStatus(
-            lent.cabinet.cabinet_id,
+            cabinet_id,
             CabinetStatusType.AVAILABLE,
           );
         }


### PR DESCRIPTION
오늘 `returnCabinet`쪽을 건드리다가 생긴 문제인 것 같네요. 에러가 발생하는 코드를 살펴보니
`lent.component.ts` 의 190번째 줄에서
```
const cumulative = await this.banService.addOverdueDays(user.user_id);
        await this.banService.blockingUser(lent, overdue + cumulative, false);
        if (
          lent.cabinet.status === CabinetStatusType.EXPIRED &&
          lent_count - 1 === 0
        ) {
          await this.cabinetInfoService.updateCabinetStatus(
            lent.cabinet.cabinet_id,
            CabinetStatusType.AVAILABLE,
          );
        }
        break;
```
이런식으로 lent에서 cabinet에 접근하여 값을 가져오고 있었습니다.
`lent.cabinet.status` -> `cabinet.status`
`lent.cabinet.cabinet_id` -> `cabinet_id`로 수정하니 문제 없이 정상 동작합니다~!
사실 문제 발생 원인도 명확해서 셀프 PR/merge하면 될 것 같긴한데 그래도 일단 리뷰어는 달아뒀어용