### PR TITLE
swagger와 트랜잭션 관련 작은 수정사항

### DIFF
--- a/backend/src/ban/ban.service.ts
+++ b/backend/src/ban/ban.service.ts
@@ -95,7 +95,6 @@ export class BanService {
     this.logger.debug(`Called ${BanService.name} ${this.blockingUser.name}`);
     // 1. Today + ban_day 만큼 unbanned_date주어 ban_log 테이블에 값 추가.
     await this.banRepository.addToBanLogByUserId(lent, ban_day, is_penalty);
-    runOnTransactionComplete((err) => err && this.logger.error(err));
   }
 
   /**

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -58,7 +58,6 @@ export class LentTools {
       );
     }
     await this.lentRepository.setExpireTimeAll(cabinet_id, expire_time);
-    runOnTransactionComplete((err) => err && this.logger.error(err));
   }
 
   @Transactional({

--- a/backend/src/lent/lent.controller.ts
+++ b/backend/src/lent/lent.controller.ts
@@ -57,7 +57,7 @@ export class LentController {
   })
   @ApiForbiddenResponse({
     description:
-      '임시 밴 사물함이나 고장 사물함을 대여 시도한 경우, 403 Forbidden을 응답합니다.',
+      '임시 밴 사물함이나 연체 사물함 혹은 고장 사물함을 대여 시도한 경우, 403 Forbidden을 응답합니다.',
   })
   @ApiResponse({
     status: HttpStatus.I_AM_A_TEAPOT,
@@ -96,10 +96,7 @@ export class LentController {
     description: 'Patch 성공 시, 200 Ok를 응답합니다.',
   })
   @ApiForbiddenResponse({
-    description: '사물함을 빌리지 않았는데 호출할 때',
-  })
-  @ApiBadRequestResponse({
-    description: '요청 필드가 비어있을 때',
+    description: '사물함을 빌리지 않았는데 호출할 때, 403 Forbidden을 응답합니다.',
   })
   @ApiUnauthorizedResponse({
     description: '로그아웃 상태거나 밴 된 사용자거나 JWT 세션이 만료됨',
@@ -139,10 +136,7 @@ export class LentController {
     description: 'Patch 성공 시, 200 Ok를 응답합니다.',
   })
   @ApiForbiddenResponse({
-    description: '사물함을 빌리지 않았는데 호출할 때',
-  })
-  @ApiBadRequestResponse({
-    description: '요청 필드가 비어있을 때',
+    description: '사물함을 빌리지 않았는데 호출할 때, 403 Forbidden을 응답합니다.',
   })
   @ApiUnauthorizedResponse({
     description: '로그아웃 상태거나 밴 된 사용자거나 JWT 세션이 만료됨',
@@ -166,7 +160,7 @@ export class LentController {
       if (err instanceof HttpException) {
         throw err;
       } else {
-        throw new InternalServerErrorException(err.message);
+        throw new InternalServerErrorException(`🚨 Cabi 내부 서버 에러가 발생했습니다 🥲 🚨`);
       }
     }
   }
@@ -179,10 +173,7 @@ export class LentController {
     description: 'Delete 성공 시, 204 No_Content를 응답합니다.',
   })
   @ApiForbiddenResponse({
-    description: '사물함을 빌리지 않았는데 호출할 때 ',
-  })
-  @ApiInternalServerErrorResponse({
-    description: '쿼리 수행 에러 등 기타 서버 문제 발생 시',
+    description: '사물함을 빌리지 않았는데 호출할 때, 403 Forbidden을 응답합니다.',
   })
   @Delete('/return')
   @HttpCode(HttpStatus.NO_CONTENT)
@@ -196,7 +187,7 @@ export class LentController {
       if (err instanceof HttpException) {
         throw err;
       } else {
-        throw new InternalServerErrorException(err.message);
+        throw new InternalServerErrorException(`🚨 Cabi 내부 서버 에러가 발생했습니다 🥲 🚨`);
       }
     }
   }

--- a/backend/src/lent/lent.service.ts
+++ b/backend/src/lent/lent.service.ts
@@ -52,17 +52,17 @@ export class LentService {
         case LentExceptionType.LENT_EXPIRED:
           throw new HttpException(
             `🚨 연체된 사물함은 대여할 수 없습니다. 🚨`,
-            HttpStatus.CONFLICT,
+            HttpStatus.FORBIDDEN,
           );
         case LentExceptionType.LENT_BROKEN:
           throw new HttpException(
             `🚨 고장난 사물함은 대여할 수 없습니다. 🚨`,
-            HttpStatus.CONFLICT,
+            HttpStatus.FORBIDDEN,
           );
         case LentExceptionType.LENT_BANNED:
           throw new HttpException(
             '🚨 해당 사물함은 비활성화된 사물함입니다 🚨',
-            HttpStatus.CONFLICT,
+            HttpStatus.FORBIDDEN,
           );
       }
     } catch (err) {

--- a/backend/src/lent/repository/lent.repository.ts
+++ b/backend/src/lent/repository/lent.repository.ts
@@ -166,6 +166,10 @@ export class lentRepository implements ILentRepository {
     return result;
   }
 
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async deleteLentByLentId(lent_id: number): Promise<void> {
     await this.lentRepository
       .createQueryBuilder(this.deleteLentByLentId.name)


### PR DESCRIPTION
메인에서 사용했던 lent/return 코드를 admin에서 참고하면서 작성하다보니 작은 문제가 발견돼서 수정 PR 올립니다!

- [x] lent/return에서 response status가 swagger 일치하지 않는 문제
- [x] 연체 사물함 대여 시, 응답 swagger 추가
- [x] 트랜잭션 내부에서 실행되는 함수인데 `runOnTransactionComplete`을 호출하는 부분 삭제
- [x] 트랜잭션 내부에서 실행되는 함수인데 Transactional 데코레이터가 빠져있는 부분 수정
- [x] `InternalServerError Exception`이 보내질 때 응답 메시지 수정