### PR TITLE
원격 저장소로 push 될 때 LF로 저장되도록 .gitattributes 수정 #573

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Auto detect text files and perform LF normalization
 *        text=auto
 
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf
+
 *.html   text diff=html
 *.css    text
 *.js     text

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,34 @@
 
 # 추후 spring으로 포팅시에 java 파일을 LF로 변환되도록 설정
 *.java   text diff=java
+
+# These files are binary and should be left untouched
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary
+*.cur binary
+*.wav binary
+*.webp binary
+*.woff2 binary
+
+# related link https://gist.github.com/dpalomar/ebc64d6f56cfc25a3e5c20fe7cdfbd4f

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Auto detect text files and perform LF normalization
+*        text=auto
+
+*.html   text diff=html
+*.css    text
+*.js     text
+*.ts     text
+*.sql    text
+*.sh     text diff=bash
+*.conf   text
+*.json   text
+*.md     text
+
+# 추후 spring으로 포팅시에 java 파일을 LF로 변환되도록 설정
+*.java   text diff=java

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "build:fe_v3": "npm i --prefix ../frontend_v3 && npm run build --prefix ../frontend_v3 && cp -r ../frontend_v3/img ../frontend_v3/dist && mv ../frontend_v3/dist deploy",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "export PORT=2424 && nest start --watch",
+    "start:dev": "set PORT=2424 && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
#573 문제 해결을 위해 `.gitattributes` 파일 추가를 통해 원격 저장소로 push 될 때 개행 문자가 `LF`로 저장될 수 있도록 수정했습니다.


### 참고 자료

https://git-scm.com/docs/gitattributes#_checking-out_and_checking-in
https://stackoverflow.com/questions/170961/whats-the-strategy-for-handling-crlf-carriage-return-line-feed-with-git