### PR TITLE
토큰 인증 방식 수정 #580

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,8 @@
     "deploy:main": "aws s3 sync ./deploy s3://42cabi --profile=CABI",
     "invalidate:dev": "aws cloudfront create-invalidation --profile=CABI --distribution-id EWPTW52IH5L5C --paths '/*'",
     "invalidate:main": "aws cloudfront create-invalidation --profile=CABI --distribution-id E12WMB9HCNB1DT --paths '/*'",
+    "all:dev": "npm run build && npm run build:fe_v3 && npm run deploy:dev && npm run invalidate:dev && pm2 reload cabi_dev",
+    "all:main": "npm run build && npm run build:fe_v3 && npm run deploy:main && npm run invalidate:main && pm2 reload cabi_main",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "set PORT=2424 && nest start --watch",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -67,7 +67,6 @@ export class AuthController {
     this.logger.log('Login -> callback');
     const token = this.jwtService.sign(user);
     this.logger.debug(`generete ${user.intra_id}'s token`);
-    res.cookie('access_token', token);
     // NOTE: 42 계정이 존재하면 무조건 로그인 처리를 할것이므로 계정 등록도 여기서 처리합니다.
     await this.authService.addUserIfNotExists(user);
     return res.redirect(`https://${this.configService.get<string>('fe_host')}/?access_token=${token}`);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  Inject,
   Logger,
   Res,
   UseGuards,
@@ -21,12 +22,18 @@ import { JWTSignGuard } from './jwt/guard/jwtsign.guard';
 import { User } from '../decorator/user.decorator';
 import { AuthService } from './auth.service';
 import { UserSessionDto } from 'src/dto/user.session.dto';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   private logger = new Logger(AuthController.name);
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private jwtService: JwtService,
+    @Inject(ConfigService) private configService: ConfigService,
+    ) {}
 
   @ApiOperation({
     summary: 'intra 로그인에 대한 요청입니다.',
@@ -55,12 +62,15 @@ export class AuthController {
     description: '토큰 에러, 키 에러, 기타 에러 발생 시',
   })
   @Get('login/callback')
-  @UseGuards(FtGuard, JWTSignGuard)
+  @UseGuards(FtGuard)
   async loginCallback(@Res() res: Response, @User() user: UserSessionDto) {
     this.logger.log('Login -> callback');
+    const token = this.jwtService.sign(user);
+    this.logger.debug(`generete ${user.intra_id}'s token`);
+    res.cookie('access_token', token);
     // NOTE: 42 계정이 존재하면 무조건 로그인 처리를 할것이므로 계정 등록도 여기서 처리합니다.
     await this.authService.addUserIfNotExists(user);
-    return res.redirect('/main');
+    return res.redirect(`https://${this.configService.get<string>('fe_host')}/?access_token=${token}`);
   }
 
   @ApiOperation({

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Strategy } from 'passport-jwt';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -25,7 +25,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     private authService: AuthService,
   ) {
     super({
-      jwtFromRequest: extracter,
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: configService.get<string>('jwt.secret'),
     });
   }

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -1,4 +1,5 @@
 export default () => ({
+  fe_host: process.env.FE_HOST,
   port: parseInt(process.env.PORT, 10),
   is_local: process.env.LOCAL === 'true',
   debug: {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -26,9 +26,11 @@ async function bootstrap() {
   const configService = app.get(ConfigService);
   const port = configService.get<number>('port');
   const is_local = configService.get<boolean>('is_local');
-  if (is_local === true) {
-    app.enableCors();
-  }
+  app.enableCors({
+    origin: 'https://' + process.env.FE_HOST,
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    credentials: true,
+  });
   await app.listen(port);
 }
 bootstrap();

--- a/backend/src/middleware/session-middleware.ts
+++ b/backend/src/middleware/session-middleware.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as cookieParser from 'cookie-parser';
 import { Middleware } from './middleware';
@@ -9,17 +9,19 @@ export class SessionMiddleware {
   cookieParser: Middleware;
   helmet: Middleware;
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    @Inject(ConfigService) private configService: ConfigService,
+    ) {
     this.cookieParser = cookieParser();
     this.helmet = helmet({
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],
-          scriptSrc: ["'self'", process.env.FE_HOST],
-          styleSrc: ["'self'", process.env.FE_HOST],
-          imgSrc: ["'self'", process.env.FE_HOST],
-          fontSrc: ["'self'", process.env.FE_HOST],
-          connectSrc: ["'self'", process.env.FE_HOST],
+          scriptSrc: ["'self'", configService.get<string>('fe_host')],
+          styleSrc: ["'self'", configService.get<string>('fe_host')],
+          imgSrc: ["'self'", configService.get<string>('fe_host')],
+          fontSrc: ["'self'", configService.get<string>('fe_host')],
+          connectSrc: ["'self'", configService.get<string>('fe_host')],
           objectSrc: ["'none'"],
           upgradeInsecureRequests: [],
         },

--- a/backend/src/middleware/session-middleware.ts
+++ b/backend/src/middleware/session-middleware.ts
@@ -13,19 +13,19 @@ export class SessionMiddleware {
     @Inject(ConfigService) private configService: ConfigService,
     ) {
     this.cookieParser = cookieParser();
-    this.helmet = helmet({
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'"],
-          scriptSrc: ["'self'", configService.get<string>('fe_host')],
-          styleSrc: ["'self'", configService.get<string>('fe_host')],
-          imgSrc: ["'self'", configService.get<string>('fe_host')],
-          fontSrc: ["'self'", configService.get<string>('fe_host')],
-          connectSrc: ["'self'", configService.get<string>('fe_host')],
-          objectSrc: ["'none'"],
-          upgradeInsecureRequests: [],
-        },
-      },
-    });
+    // this.helmet = helmet({
+    //   contentSecurityPolicy: {
+    //     directives: {
+    //       defaultSrc: ["'self'"],
+    //       scriptSrc: ["'self'", configService.get<string>('fe_host')],
+    //       styleSrc: ["'self'", configService.get<string>('fe_host')],
+    //       imgSrc: ["'self'", configService.get<string>('fe_host')],
+    //       fontSrc: ["'self'", configService.get<string>('fe_host')],
+    //       connectSrc: ["'self'", configService.get<string>('fe_host')],
+    //       objectSrc: ["'none'"],
+    //       upgradeInsecureRequests: [],
+    //     },
+    //   },
+    // });
   }
 }

--- a/frontend_v3/src/components/atoms/buttons/LoginButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/LoginButton.tsx
@@ -11,8 +11,13 @@ const Button = style.a`
 `;
 
 const LoginButton = (): JSX.Element => {
-  const url = "/auth/login";
-  return <Button href={url}>L O G I N</Button>;
+  const url = `https://${import.meta.env.VITE_BE_HOST}/auth/login`;
+  return <Button onClick={(): void => window.location.replace(url)}>L O G I N</Button>;
 };
+
+// const LoginButton = (): JSX.Element => {
+//   const url = "/auth/login";
+//   return <Button href={url}>L O G I N</Button>;
+// };
 
 export default LoginButton;

--- a/frontend_v3/src/network/axios/axios.instance.ts
+++ b/frontend_v3/src/network/axios/axios.instance.ts
@@ -1,11 +1,23 @@
 import axios from "axios";
-import { removeCookie } from "../react-cookie/cookie";
+import { getCookie, removeCookie } from "../react-cookie/cookie";
+
+axios.defaults.withCredentials = true;
 
 const instance = axios.create({
   // baseURL: window.location.origin,
   baseURL: import.meta.env.VITE_BE_HOST,
   withCredentials: true,
 });
+
+instance.interceptors.request.use(
+  async config => {
+    const token = getCookie('access_token');
+    config.headers = {
+      'Authorization': `Bearer ${token}`,
+    }
+    return config;
+  }
+);
 
 instance.interceptors.response.use(
   (response) => {

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -5,16 +5,22 @@ import LoginTemplate from "../components/templates/LoginTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import ContentTemplate from "../components/templates/ContentTemplate";
 import { useAppSelector, useAppDispatch } from "../redux/hooks";
-import { getCookie } from "../network/react-cookie/cookie";
+import { getCookie, setCookie } from "../network/react-cookie/cookie";
 import { userInfoInitialize } from "../redux/slices/userSlice";
+import qs from "qs";
 
 const Login = (): JSX.Element => {
   const user = useAppSelector((state) => state.user);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const query = qs.parse(window.location.search, {
+    ignoreQueryPrefix : true,
+  });
+  const token: string = String(query['access_token']);
 
   useEffect(() => {
-    const token = getCookie("access_token");
+    // const token = getCookie("access_token");
+    setCookie('access_token', token);
     if (!token) {
       dispatch(userInfoInitialize());
     }

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -5,22 +5,16 @@ import LoginTemplate from "../components/templates/LoginTemplate";
 import FooterTemplate from "../components/templates/FooterTemplate";
 import ContentTemplate from "../components/templates/ContentTemplate";
 import { useAppSelector, useAppDispatch } from "../redux/hooks";
-import { getCookie, setCookie } from "../network/react-cookie/cookie";
+import { getCookie } from "../network/react-cookie/cookie";
 import { userInfoInitialize } from "../redux/slices/userSlice";
-import qs from "qs";
 
 const Login = (): JSX.Element => {
   const user = useAppSelector((state) => state.user);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const query = qs.parse(window.location.search, {
-    ignoreQueryPrefix : true,
-  });
-  const token: string = String(query['access_token']);
 
   useEffect(() => {
-    // const token = getCookie("access_token");
-    setCookie('access_token', token);
+    const token = getCookie("access_token");
     if (!token) {
       dispatch(userInfoInitialize());
     }

--- a/frontend_v3/src/pages/Main.tsx
+++ b/frontend_v3/src/pages/Main.tsx
@@ -23,7 +23,7 @@ const Main = (): JSX.Element => {
             if (response.data.cabinet_id !== -1) navigate("/lent");
           })
           .catch((error) => {
-            navigate("/");
+            // navigate("/");
           });
       } else {
         axiosMyInfo()
@@ -31,11 +31,11 @@ const Main = (): JSX.Element => {
             dispatch(setUserCabinet(response.data.cabinet_id));
           })
           .catch((error) => {
-            navigate("/");
+            // navigate("/");
           });
       }
     } else {
-      navigate("/");
+      // navigate("/");
     }
   }, []);
 


### PR DESCRIPTION
기존에는 백엔드에서 클라이언트의 쿠키에서 토큰을 추출하여 인증을 수행했었었습니다.
그러나 백엔드와 프론트 도메인이 서로 달라 클라이언트의 쿠키를 추출할 수 없는 문제가 생겼습니다.
따라서 프론트에서 API 요청을 할 때 Request header에 Bearer 토큰을 넣어서 요청하는 방식으로 수정했습니다.
그럼에도 첫 로그인 시에 401 에러가 발생하여 원인을 파악해본 결과, 토큰을 쿠키에서 꺼내오기 전에 API 요청이 발생하여 생긴 에러인 것으로 파악됩니다.
따라서 axios instance의 interceptor 기능을 이용하여 요청을 보내기 전에 토큰을 쿠키에서 꺼내오는 동작을 보장시켜 오류를 해결했습니다.

아래는 해당 이슈 해결 참고 링크입니다!
https://velog.io/@ordidxzero/axios-instance-%EB%A7%8C%EB%93%A4%EC%96%B4%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0