### PR TITLE
[FE] FEAT: 사물함 구역 상단 페이지네이션 바 구현 #598

### DIFF
--- a/frontend_v4/src/assets/images/LeftSectionButton.svg
+++ b/frontend_v4/src/assets/images/LeftSectionButton.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 6L9 12L15 18" stroke="#BCBCBC" stroke-width="2"/>
+</svg>

--- a/frontend_v4/src/containers/SectionPaginationContainer.tsx
+++ b/frontend_v4/src/containers/SectionPaginationContainer.tsx
@@ -25,7 +25,7 @@ export const SectionPaginationContainer = () => {
   const currentPositionName = floor.toString() + "층 - " + currentSectionName;
 
   const paginationIdxBar = sectionList.map((sectionName, idx) => (
-    <IndexRectangle
+    <IndexRectangleStyled
       key={sectionName}
       bgColor={sectionName === currentSectionName ? "#9747FF" : "#D9D9D9"}
       onClick={() => setCurrentSectionIdx(idx)}
@@ -45,13 +45,13 @@ export const SectionPaginationContainer = () => {
   return (
     <SectionPaginationStyled>
       <SectionBarStyled>
-        <MoveSectionButtons
+        <MoveSectionButtonStyled
           src={LeftSectionButton}
           rotate={false}
           onClick={moveToLeftSection}
         />
         {currentPositionName}
-        <MoveSectionButtons
+        <MoveSectionButtonStyled
           src={LeftSectionButton}
           rotate={true}
           onClick={moveToRightSection}
@@ -81,7 +81,7 @@ const SectionBarStyled = styled.div`
   align-items: center;
 `;
 
-const MoveSectionButtons = styled.img<{ rotate: boolean }>`
+const MoveSectionButtonStyled = styled.img<{ rotate: boolean }>`
   opacity: 70%;
   cursor: pointer;
   transform: rotate(${(props) => (props.rotate ? "180deg" : "0")});
@@ -96,7 +96,7 @@ const SectionIndexStyled = styled.div`
   justify-content: center;
 `;
 
-const IndexRectangle = styled.div<{ bgColor: string }>`
+const IndexRectangleStyled = styled.div<{ bgColor: string }>`
   width: 15px;
   height: 8px;
   border-radius: 2px;

--- a/frontend_v4/src/containers/SectionPaginationContainer.tsx
+++ b/frontend_v4/src/containers/SectionPaginationContainer.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import LeftSectionButton from "@/assets/images/LeftSectionButton.svg";
+
+export const SectionPaginationContainer = () => {
+  /* 
+    require props 
+    1. Current floor
+    1. Section list
+    2. Current section name
+    3. Current section index
+    */
+  const floor = 2;
+  const sectionList = [
+    "End of Cluster1",
+    "Cluster1 - OA",
+    "Cluster1 - Terrace",
+    "Oasis",
+    "End of Cluster2",
+  ];
+  const sectionCount = sectionList.length;
+
+  const [currentSectionIdx, setCurrentSectionIdx] = useState<number>(0);
+  const currentSectionName = sectionList.at(currentSectionIdx);
+  const currentPositionName = floor.toString() + "층 - " + currentSectionName;
+
+  const paginationIdxBar = sectionList.map((sectionName, idx) => (
+    <IndexRectangle
+      key={sectionName}
+      bgColor={sectionName === currentSectionName ? "#9747FF" : "#D9D9D9"}
+      onClick={() => setCurrentSectionIdx(idx)}
+    />
+  ));
+
+  const moveToLeftSection = () => {
+    if (currentSectionIdx == 0) return setCurrentSectionIdx(sectionCount - 1);
+    setCurrentSectionIdx(currentSectionIdx - 1);
+  };
+
+  const moveToRightSection = () => {
+    if (currentSectionIdx == sectionCount - 1) return setCurrentSectionIdx(0);
+    setCurrentSectionIdx(currentSectionIdx + 1);
+  };
+
+  return (
+    <SectionPaginationStyled>
+      <SectionBarStyled>
+        <MoveSectionButtons
+          src={LeftSectionButton}
+          rotate={false}
+          onClick={moveToLeftSection}
+        />
+        {currentPositionName}
+        <MoveSectionButtons
+          src={LeftSectionButton}
+          rotate={true}
+          onClick={moveToRightSection}
+        />
+      </SectionBarStyled>
+      <SectionIndexStyled>{paginationIdxBar}</SectionIndexStyled>
+    </SectionPaginationStyled>
+  );
+};
+
+const SectionPaginationStyled = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SectionBarStyled = styled.div`
+  width: 100%;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 5%;
+  margin-right: 5%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const MoveSectionButtons = styled.img<{ rotate: boolean }>`
+  opacity: 70%;
+  cursor: pointer;
+  transform: rotate(${(props) => (props.rotate ? "180deg" : "0")});
+  &:hover {
+    opacity: 100%;
+  }
+`;
+
+const SectionIndexStyled = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+const IndexRectangle = styled.div<{ bgColor: string }>`
+  width: 15px;
+  height: 8px;
+  border-radius: 2px;
+  margin-left: 3px;
+  margin-right: 3px;
+  background: ${(props) => props.bgColor};
+  cursor: pointer;
+`;


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> 사물함 구역을 화살표 또는 아래 사각형 클릭으로 이동할 수 있습니다.
추후 데이터를 받아오는 부분이나 구역 변경 시 state 혹은 redux dispatch 하는 부분을 components로 분리해야합니다.

