### PR TITLE
[BE] ETC: LOCAL=true일 때만 ServeStaticModule이 동작하도록 수정 #612

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -40,15 +40,6 @@ import { BetatestModule } from './betatest/betatest.module';
     }),
     AuthModule,
     BlackholeModule,
-    ServeStaticModule.forRootAsync({
-      inject: [ConfigService],
-      useFactory: () => [
-        {
-          rootPath: join(__dirname, '../', 'deploy'),
-          exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
-        },
-      ],
-    }),
     EventEmitterModule.forRoot(),
     CabinetModule,
     LentModule,
@@ -57,6 +48,19 @@ import { BetatestModule } from './betatest/betatest.module';
     CacheModule.register({
       isGlobal: true,
     }),
+    ...(process.env.LOCAL === 'true'
+      ? [
+          ServeStaticModule.forRootAsync({
+            inject: [ConfigService],
+            useFactory: () => [
+              {
+                rootPath: join(__dirname, '../', 'deploy'),
+                exclude: ['/api/(.*)', '/v3/(.*)', '/auth/(.*)'],
+              },
+            ],
+          }),
+        ]
+      : []),
     // import if UNBAN_API=true
     ...(process.env.UNBAN_API === 'true' ? [BetatestModule] : []),
   ],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

ec2 서버에서 프론트 build 결과를 정적 파일로 관리하기 위해 사용했던 `ServeStaticModule`을 제거하려고 했으나 
로컬 환경에서 필요한 경우가 있을 수 있을 것 같아(간헐적으로 로컬에서 nginx 서버로 보낸 요청이 pending이 걸리는 현상 발생), 
환경변수 `LOCAL=true`인 경우에만 initialize 되도록 수정했습니다.