### PR TITLE
[FE] BUG: 로컬에서도 쿠키가 삭제되도록 수정 #655

### DIFF
--- a/frontend_v3/src/components/atoms/buttons/MenuButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/MenuButton.tsx
@@ -52,14 +52,12 @@ const MenuButton = (): JSX.Element => {
   };
 
   const handleLogout = (): void => {
-    axiosLogout()
-      .then((response) => {
-        removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
-        navigate("/");
-      })
-      .catch((error) => {
-        console.error(error);
-      });
+    if (import.meta.env.VITE_IS_LOCAL === "true") {
+      removeCookie("access_token");
+    } else {
+      removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
+    }
+    navigate("/");
   };
 
   // 베타테스트용 페널티 해제 메뉴

--- a/frontend_v3/src/network/axios/axios.instance.ts
+++ b/frontend_v3/src/network/axios/axios.instance.ts
@@ -26,7 +26,11 @@ instance.interceptors.response.use(
   (error) => {
     // access_token unauthorized
     if (error.response?.status === 401) {
-      removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
+      if (import.meta.env.VITE_IS_LOCAL === "true") {
+        removeCookie("access_token");
+      } else {
+        removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
+      }
       alert(error.response.data.message);
       window.location.href = "/";
     }

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -19,7 +19,9 @@ const Login = (): JSX.Element => {
       dispatch(userInfoInitialize());
     }
     if (token && !(user.intra_id === "default")) {
-      removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
+      navigate("/main");
+    } else {
+      navigate("/");
     }
   }, []);
 

--- a/frontend_v3/src/pages/Login.tsx
+++ b/frontend_v3/src/pages/Login.tsx
@@ -20,8 +20,6 @@ const Login = (): JSX.Element => {
     }
     if (token && !(user.intra_id === "default")) {
       navigate("/main");
-    } else {
-      navigate("/");
     }
   }, []);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,3 @@
 {
-  "name": "42cabi",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
+  "lockfileVersion": 1
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

변경 전
```
    removeCookie("access_token");
```

변경 후
```
if (import.meta.env.VITE_IS_LOCAL === "true") {
      removeCookie("access_token");
    } else {
      removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
    }
```

추가 변경 사항
- MenuButton.tsx
서버측에서 클라이언트의 쿠키를 대신 지워주는 것이 불가능해졌으므로 API 요청을 하는 대신 쿠키를 스스로 지우도록 로직 수정했습니다.
- Login.tsx
토큰을 가지고, redux에 유저 정보를 가진 채로 로그인 페이지 진입 시, main으로 리다이렉트 되도록 수정했습니다. 기존에 쿠키가 제대로 지워지지 않을 때 이 부분 때문에 login <-> main 간의 무한 리다이렉트가 되는 버그가 존재했었는데, 이제는 어느 환경에서든 쿠키가 정상적으로 지워집니다!

프론트 .env에서 `VITE_IS_LOCAL=true`일 때만 정상적으로 동작하오니 꼭 추가하시길 바랍니다.