### PR TITLE
[COMMON] REFACTOR: api v3 태그 제거 및 admin api 병합 #638

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,19 @@
+import { Module } from "@nestjs/common";
+import { CabinetModule } from "./cabinet/cabinet.module";
+import { LentModule } from "./lent/lent.module";
+import { LogModule } from "./log/log.module";
+import { ReturnModule } from "./return/return.module";
+import { SearchModule } from "./search/search.module";
+
+@Module({
+  imports: [
+    CabinetModule,
+    LentModule,
+    LogModule,
+    ReturnModule,
+    SearchModule,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AdminModule {}

--- a/backend/src/admin/cabinet/cabinet.controller.ts
+++ b/backend/src/admin/cabinet/cabinet.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Get, Logger, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
 
+@ApiTags('(Admin) Cabinet')
 @Controller('/api/admin/cabinet')
 @UseGuards(JwtAuthGuard)
 export class CabinetController {
   private logger = new Logger(CabinetController.name);
 
   @Get('/user/:userId')
+  @ApiOperation({})
   async getLentLogByUserId(
     @Param('userId') userId: string,
     @Query('index') index: number,
@@ -16,11 +19,13 @@ export class CabinetController {
   }
 
   @Get('/count/floor')
+  @ApiOperation({})
   async getCabinetCountEachFloor(): Promise<void> {
     this.logger.debug(`Called ${this.getCabinetCountEachFloor.name}`);
   }
 
   @Get('/:cabinetId')
+  @ApiOperation({})
   async getCabinetInfoByCabinetId(
     @Param('cabinetId') cabinetId: string,
   ): Promise<void> {
@@ -28,6 +33,7 @@ export class CabinetController {
   }
 
   @Patch('/status/:cabinetId/:status')
+  @ApiOperation({})
   async updateCabinetStatusByCabinetId(
     @Param('cabinetId') cabinetId: string,
     @Param('status') status: string,
@@ -36,6 +42,7 @@ export class CabinetController {
   }
 
   @Patch('/lentType/:cabinetId/:lentType')
+  @ApiOperation({})
   async updateCabinetLentTypeByCabinetId(
     @Param('cabinetId') cabinetId: string,
     @Param('lentType') lentType: string,
@@ -44,6 +51,7 @@ export class CabinetController {
   }
 
   @Patch('/statusNote/:cabinetId/:statusNote')
+  @ApiOperation({})
   async updateCabinetStatusNoteByCabinetId(
     @Param('cabinetId') cabinetId: string,
     @Param('statusNote') statusNote: string,
@@ -52,6 +60,7 @@ export class CabinetController {
   }
 
   @Patch('/bundle/status/:status')
+  @ApiOperation({})
   async updateCabinetBundleStatus(
     @Param('status') status: string,
   ): Promise<void> {
@@ -59,6 +68,7 @@ export class CabinetController {
   }
 
   @Patch('/bundle/lentType/:lentType')
+  @ApiOperation({})
   async updateCabinetBundleLentType(
     @Param('lentType') lentType: string,
   ): Promise<void> {
@@ -66,6 +76,7 @@ export class CabinetController {
   }
 
   @Patch('/:cabinetId/:title')
+  @ApiOperation({})
   async updateCabinetTitleByCabinetId(
     @Param('cabinetId') cabinetId: string,
     @Param('title') title: string,

--- a/backend/src/admin/cabinet/cabinet.controller.ts
+++ b/backend/src/admin/cabinet/cabinet.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Get, Logger, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
+
+@Controller('/api/admin/cabinet')
+@UseGuards(JwtAuthGuard)
+export class CabinetController {
+  private logger = new Logger(CabinetController.name);
+
+  @Get('/user/:userId')
+  async getLentLogByUserId(
+    @Param('userId') userId: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getLentLogByUserId.name}`);
+  }
+
+  @Get('/count/floor')
+  async getCabinetCountEachFloor(): Promise<void> {
+    this.logger.debug(`Called ${this.getCabinetCountEachFloor.name}`);
+  }
+
+  @Get('/:cabinetId')
+  async getCabinetInfoByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getCabinetInfoByCabinetId.name}`);
+  }
+
+  @Patch('/status/:cabinetId/:status')
+  async updateCabinetStatusByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+    @Param('status') status: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetStatusByCabinetId.name}`);
+  }
+
+  @Patch('/lentType/:cabinetId/:lentType')
+  async updateCabinetLentTypeByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+    @Param('lentType') lentType: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetLentTypeByCabinetId.name}`);
+  }
+
+  @Patch('/statusNote/:cabinetId/:statusNote')
+  async updateCabinetStatusNoteByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+    @Param('statusNote') statusNote: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetStatusNoteByCabinetId.name}`);
+  }
+
+  @Patch('/bundle/status/:status')
+  async updateCabinetBundleStatus(
+    @Param('status') status: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetBundleStatus.name}`);
+  }
+
+  @Patch('/bundle/lentType/:lentType')
+  async updateCabinetBundleLentType(
+    @Param('lentType') lentType: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetBundleLentType.name}`);
+  }
+
+  @Patch('/:cabinetId/:title')
+  async updateCabinetTitleByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+    @Param('title') title: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.updateCabinetTitleByCabinetId.name}`);
+  }
+}

--- a/backend/src/admin/cabinet/cabinet.module.ts
+++ b/backend/src/admin/cabinet/cabinet.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { CabinetController } from './Cabinet.controller';
+
+@Module({
+  controllers: [CabinetController],
+  providers: [],
+  imports: [AuthModule],
+})
+export class CabinetModule {}

--- a/backend/src/admin/cabinet/cabinet.module.ts
+++ b/backend/src/admin/cabinet/cabinet.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from 'src/auth/auth.module';
-import { CabinetController } from './Cabinet.controller';
+import { CabinetController } from './cabinet.controller';
 
 @Module({
   controllers: [CabinetController],

--- a/backend/src/admin/lent/lent.controller.ts
+++ b/backend/src/admin/lent/lent.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Logger, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
+
+@Controller('/api/admin/lent')
+@UseGuards(JwtAuthGuard)
+export class LentController {
+  private logger = new Logger(LentController.name);
+
+  @Get('/')
+  async getLentInfo(): Promise<void> {
+    this.logger.debug(`Called ${this.getLentInfo.name}`);
+  }
+
+  @Get('/overdue')
+  async getLentOverdueInfo(): Promise<void> {
+    this.logger.debug(`Called ${this.getLentOverdueInfo.name}`);
+  }
+
+  @Post('/cabinet/:cabinetId/:userId')
+  async postLentCabinet(
+    @Param('cabinetId') cabinetId: number,
+    @Param('userId') userId: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.postLentCabinet.name}`);
+  }
+}

--- a/backend/src/admin/lent/lent.controller.ts
+++ b/backend/src/admin/lent/lent.controller.ts
@@ -1,22 +1,27 @@
 import { Controller, Get, Logger, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
 
+@ApiTags('(Admin) Lent')
 @Controller('/api/admin/lent')
 @UseGuards(JwtAuthGuard)
 export class LentController {
   private logger = new Logger(LentController.name);
 
   @Get('/')
+  @ApiOperation({})
   async getLentInfo(): Promise<void> {
     this.logger.debug(`Called ${this.getLentInfo.name}`);
   }
 
   @Get('/overdue')
+  @ApiOperation({})
   async getLentOverdueInfo(): Promise<void> {
     this.logger.debug(`Called ${this.getLentOverdueInfo.name}`);
   }
 
   @Post('/cabinet/:cabinetId/:userId')
+  @ApiOperation({})
   async postLentCabinet(
     @Param('cabinetId') cabinetId: number,
     @Param('userId') userId: number,

--- a/backend/src/admin/lent/lent.module.ts
+++ b/backend/src/admin/lent/lent.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import Lent from 'src/entities/lent.entity';
+import { LentController } from './lent.controller';
+
+@Module({
+  controllers: [LentController],
+  providers: [],
+  imports: [AuthModule],
+})
+export class LentModule {}

--- a/backend/src/admin/log/log.controller.ts
+++ b/backend/src/admin/log/log.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Logger, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
+
+@Controller('/api/admin/log')
+@UseGuards(JwtAuthGuard)
+export class LogController {
+  private logger = new Logger(LogController.name);
+
+  @Get('/user/:userId')
+  async getLentLogByUserId(
+    @Param('userId') userId: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getLentLogByUserId.name}`);
+  }
+
+  @Get('/cabinet/:cabinetId')
+  async getLentLogByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getLentLogByCabinetId.name}`);
+  }
+}

--- a/backend/src/admin/log/log.controller.ts
+++ b/backend/src/admin/log/log.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Get, Logger, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
 
+@ApiTags('(Admin) Log')
 @Controller('/api/admin/log')
 @UseGuards(JwtAuthGuard)
 export class LogController {
   private logger = new Logger(LogController.name);
 
   @Get('/user/:userId')
+  @ApiOperation({})
   async getLentLogByUserId(
     @Param('userId') userId: string,
     @Query('index') index: number,
@@ -16,6 +19,7 @@ export class LogController {
   }
 
   @Get('/cabinet/:cabinetId')
+  @ApiOperation({})
   async getLentLogByCabinetId(
     @Param('cabinetId') cabinetId: string,
     @Query('index') index: number,

--- a/backend/src/admin/log/log.module.ts
+++ b/backend/src/admin/log/log.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from 'src/auth/auth.module';
+import { LogController } from './log.controller';
+
+@Module({
+  controllers: [LogController],
+  providers: [],
+  imports: [AuthModule],
+})
+export class LogModule {}

--- a/backend/src/admin/return/return.controller.ts
+++ b/backend/src/admin/return/return.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Delete, Get, Logger, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
+
+@Controller('/api/admin/return')
+@UseGuards(JwtAuthGuard)
+export class ReturnController {
+  private logger = new Logger(ReturnController.name);
+
+  @Get('/user/:userId')
+  async getLentLogByUserId(
+    @Param('userId') userId: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getLentLogByUserId.name}`);
+  }
+
+  @Delete('/cabinet/:cabinetId')
+  async returnCabinetByCabinetId(
+    @Param('cabinetId') cabinetId: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.returnCabinetByCabinetId.name}`);
+  }
+
+  @Delete('/user/:userId')
+  async returnCabinetByUserId(
+    @Param('userId') userId: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.returnCabinetByUserId.name}`);
+  }
+
+  @Delete('/bundle/cabinet')
+  async returnCabinetBundle(): Promise<void> {
+    this.logger.debug(`Called ${this.returnCabinetBundle.name}`);
+  }
+}

--- a/backend/src/admin/return/return.controller.ts
+++ b/backend/src/admin/return/return.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Delete, Get, Logger, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
 
+@ApiTags('(Admin) Return')
 @Controller('/api/admin/return')
 @UseGuards(JwtAuthGuard)
 export class ReturnController {
   private logger = new Logger(ReturnController.name);
 
   @Get('/user/:userId')
+  @ApiOperation({})
   async getLentLogByUserId(
     @Param('userId') userId: string,
     @Query('index') index: number,
@@ -16,6 +19,7 @@ export class ReturnController {
   }
 
   @Delete('/cabinet/:cabinetId')
+  @ApiOperation({})
   async returnCabinetByCabinetId(
     @Param('cabinetId') cabinetId: string,
   ): Promise<void> {
@@ -23,6 +27,7 @@ export class ReturnController {
   }
 
   @Delete('/user/:userId')
+  @ApiOperation({})
   async returnCabinetByUserId(
     @Param('userId') userId: string,
   ): Promise<void> {
@@ -30,6 +35,7 @@ export class ReturnController {
   }
 
   @Delete('/bundle/cabinet')
+  @ApiOperation({})
   async returnCabinetBundle(): Promise<void> {
     this.logger.debug(`Called ${this.returnCabinetBundle.name}`);
   }

--- a/backend/src/admin/return/return.module.ts
+++ b/backend/src/admin/return/return.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { ReturnController } from './Return.controller';
+
+@Module({
+  controllers: [ReturnController],
+  providers: [],
+  imports: [AuthModule],
+})
+export class ReturnModule {}

--- a/backend/src/admin/return/return.module.ts
+++ b/backend/src/admin/return/return.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from 'src/auth/auth.module';
-import { ReturnController } from './Return.controller';
+import { ReturnController } from './return.controller';
 
 @Module({
   controllers: [ReturnController],

--- a/backend/src/admin/search/search.controller.ts
+++ b/backend/src/admin/search/search.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, Logger, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
+
+@Controller('/api/admin/search')
+@UseGuards(JwtAuthGuard)
+export class SearchController {
+  private logger = new Logger(SearchController.name);
+
+  @Get('/intraId/:intraId')
+  async getUserListByIntraId(
+    @Param('intraId') intraId: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getUserListByIntraId.name}`);
+  }
+
+  @Get('/cabinet/lentType/:lentType')
+  async getCabinetListByLentType(
+    @Param('lentType') lentType: string,
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getCabinetListByLentType.name}`);
+  }
+
+  @Get('/cabinet/visibleNum/:visibleNum')
+  async getCabinetListByVisibleNum(
+    @Param('visibleNum') visibleNum: string,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getCabinetListByVisibleNum.name}`);
+  }
+
+  @Get('/cabinet/banned')
+  async getBannedCabinetList(
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getBannedCabinetList.name}`);
+  }
+
+  @Get('/cabinet/broken')
+  async getBrokenCabinetList(
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getBrokenCabinetList.name}`);
+  }
+
+  @Get('/user/banned')
+  async getBannedUserList(
+    @Query('index') index: number,
+    @Query('length') length: number,
+  ): Promise<void> {
+    this.logger.debug(`Called ${this.getBannedUserList.name}`);
+  }
+}

--- a/backend/src/admin/search/search.controller.ts
+++ b/backend/src/admin/search/search.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Get, Logger, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/jwt/guard/jwtauth.guard';
 
+@ApiTags('(Admin) Search')
 @Controller('/api/admin/search')
 @UseGuards(JwtAuthGuard)
 export class SearchController {
   private logger = new Logger(SearchController.name);
 
   @Get('/intraId/:intraId')
+  @ApiOperation({})
   async getUserListByIntraId(
     @Param('intraId') intraId: string,
     @Query('index') index: number,
@@ -16,6 +19,7 @@ export class SearchController {
   }
 
   @Get('/cabinet/lentType/:lentType')
+  @ApiOperation({})
   async getCabinetListByLentType(
     @Param('lentType') lentType: string,
     @Query('index') index: number,
@@ -25,6 +29,7 @@ export class SearchController {
   }
 
   @Get('/cabinet/visibleNum/:visibleNum')
+  @ApiOperation({})
   async getCabinetListByVisibleNum(
     @Param('visibleNum') visibleNum: string,
   ): Promise<void> {
@@ -32,6 +37,7 @@ export class SearchController {
   }
 
   @Get('/cabinet/banned')
+  @ApiOperation({})
   async getBannedCabinetList(
     @Query('index') index: number,
     @Query('length') length: number,
@@ -40,6 +46,7 @@ export class SearchController {
   }
 
   @Get('/cabinet/broken')
+  @ApiOperation({})
   async getBrokenCabinetList(
     @Query('index') index: number,
     @Query('length') length: number,
@@ -48,6 +55,7 @@ export class SearchController {
   }
 
   @Get('/user/banned')
+  @ApiOperation({})
   async getBannedUserList(
     @Query('index') index: number,
     @Query('length') length: number,

--- a/backend/src/admin/search/search.module.ts
+++ b/backend/src/admin/search/search.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from 'src/auth/auth.module';
+import { SearchController } from './search.controller';
+
+@Module({
+  controllers: [SearchController],
+  providers: [],
+  imports: [AuthModule],
+})
+export class SearchModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -60,6 +60,7 @@ import { AdminModule } from './admin/admin.module';
     }),
     // import if UNBAN_API=true
     ...(process.env.UNBAN_API === 'true' ? [BetatestModule] : []),
+    AdminModule,
   ],
   controllers: [],
   providers: [SessionMiddleware],

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { UserModule } from './user/user.module';
 import { UtilsModule } from './utils/utils.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { BetatestModule } from './betatest/betatest.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [

--- a/backend/src/betatest/betatest.controller.ts
+++ b/backend/src/betatest/betatest.controller.ts
@@ -19,10 +19,7 @@ import { UserSessionDto } from 'src/dto/user.session.dto';
 import { BetatestService } from './betatest.service';
 
 @ApiTags('베타 테스트용 API (실배포시 구동 X)')
-@Controller({
-  version: '3',
-  path: 'api/betatest',
-})
+@Controller('api/betatest')
 export class BetatestController {
   private logger = new Logger(BetatestController.name);
 

--- a/backend/src/cabinet/cabinet.info.controller.ts
+++ b/backend/src/cabinet/cabinet.info.controller.ts
@@ -19,10 +19,7 @@ import { SpaceDataResponseDto } from 'src/dto/response/space.data.response.dto';
 import { CabinetInfoService } from './cabinet.info.service';
 
 @ApiTags('Cabinet')
-@Controller({
-  version: '3',
-  path: 'api/cabinet_info',
-})
+@Controller('api/cabinet_info')
 export class CabinetController {
   private logger = new Logger(CabinetController.name);
 

--- a/backend/src/lent/lent.controller.ts
+++ b/backend/src/lent/lent.controller.ts
@@ -35,10 +35,7 @@ import { BanCheckGuard } from '../ban/guard/ban-check.guard';
 import { LentService } from './lent.service';
 
 @ApiTags('Lent')
-@Controller({
-  version: '3',
-  path: '/api/lent',
-})
+@Controller('/api/lent')
 export class LentController {
   private logger = new Logger(LentController.name);
   constructor(private lentService: LentService) {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,9 +17,9 @@ async function bootstrap() {
   // for URI Versioning
   app.enableVersioning();
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('42cabi v3 API')
-    .setDescription('42cabi v3 API 명세')
-    .setVersion('3.0')
+    .setTitle('Cabi API')
+    .setDescription('Cabi API 명세')
+    .setVersion('4.0')
     .build();
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('docs', app, swaggerDocument);

--- a/backend/src/user/my.info.controller.ts
+++ b/backend/src/user/my.info.controller.ts
@@ -13,10 +13,7 @@ import { UserSessionDto } from 'src/dto/user.session.dto';
 import { UserService } from './user.service';
 
 @ApiTags('User')
-@Controller({
-  version: '3',
-  path: 'api/my_info',
-})
+@Controller('api/my_info')
 export class MyInfoController {
   private logger = new Logger(MyInfoController.name);
 

--- a/backend/src/user/my.lent.info.controller.ts
+++ b/backend/src/user/my.lent.info.controller.ts
@@ -21,10 +21,7 @@ import { UserSessionDto } from 'src/dto/user.session.dto';
 import { UserService } from './user.service';
 
 @ApiTags('User')
-@Controller({
-  version: '3',
-  path: 'api/my_lent_info',
-})
+@Controller('api/my_lent_info')
 export class MyLentInfoController {
   private logger = new Logger(MyLentInfoController.name);
 

--- a/frontend_v3/src/components/atoms/buttons/MenuButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/MenuButton.tsx
@@ -63,7 +63,7 @@ const MenuButton = (): JSX.Element => {
   };
 
   // 베타테스트용 페널티 해제 메뉴
-  const axiosRemovePenaltyURL = "/v3/api/betatest/deletebanlog";
+  const axiosRemovePenaltyURL = "/api/betatest/deletebanlog";
   const axiosRemovePenalty = async (): Promise<any> => {
     try {
       const response = await instance.delete(axiosRemovePenaltyURL);

--- a/frontend_v3/src/components/atoms/buttons/ReturnButton.tsx
+++ b/frontend_v3/src/components/atoms/buttons/ReturnButton.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
-import { axiosV3Return } from "../../../network/axios/axios.custom";
 import { setUserCabinet } from "../../../redux/slices/userSlice";
 import { useAppDispatch } from "../../../redux/hooks";
 

--- a/frontend_v3/src/components/atoms/modals/ReturnBox.tsx
+++ b/frontend_v3/src/components/atoms/modals/ReturnBox.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import dayjs from "dayjs";
 import { Typography } from "@mui/material";
 import CheckButton from "../buttons/CheckButton";
-import { axiosV3Return } from "../../../network/axios/axios.custom";
+import { axiosReturn } from "../../../network/axios/axios.custom";
 import { setUserCabinet } from "../../../redux/slices/userSlice";
 import { useAppDispatch } from "../../../redux/hooks";
 import { LentDto } from "../../../types/dto/lent.dto";
@@ -59,7 +59,7 @@ const ReturnBox = (props: ReturnBoxProps): JSX.Element => {
   const lentTime = dayjs(user.lent_time).format("YYYY/MM/DD HH:mm");
 
   const handleReturn = () => {
-    axiosV3Return()
+    axiosReturn()
       .then((response) => {
         dispatch(setUserCabinet(-1));
         navigate("/main");

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -43,7 +43,7 @@ export const axiosReturn = async (lent_id: number): Promise<any> => {
   }
 };
 
-const axiosMyInfoURL = "/v3/api/my_info";
+const axiosMyInfoURL = "/api/my_info";
 export const axiosMyInfo = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosMyInfoURL);
@@ -83,7 +83,7 @@ export const axiosReturnInfo = async (): Promise<any> => {
   }
 };
 
-const axiosUpdateCabinetMemoURL = "/v3/api/lent/update_cabinet_memo";
+const axiosUpdateCabinetMemoURL = "/api/lent/update_cabinet_memo";
 export const axiosUpdateCabinetMemo = async (
   cabinet_memo: object
 ): Promise<any> => {
@@ -98,7 +98,7 @@ export const axiosUpdateCabinetMemo = async (
   }
 };
 
-const axiosUpdateCabinetTitleURL = "/v3/api/lent/update_cabinet_title";
+const axiosUpdateCabinetTitleURL = "/api/lent/update_cabinet_title";
 export const axiosUpdateCabinetTitle = async (
   cabinet_title: object
 ): Promise<any> => {
@@ -116,7 +116,7 @@ export const axiosUpdateCabinetTitle = async (
 // V3 API
 // TODO
 // 차후 API 확인 후에 URL 수정
-const axiosLocationFloorURL = "/v3/api/cabinet_info";
+const axiosLocationFloorURL = "/api/cabinet_info";
 export const axiosLocationFloor = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosLocationFloorURL);
@@ -126,7 +126,7 @@ export const axiosLocationFloor = async (): Promise<any> => {
   }
 };
 
-const axiosCabinetByLocationFloorURL = "/v3/api/cabinet_info/";
+const axiosCabinetByLocationFloorURL = "/api/cabinet_info/";
 export const axiosCabinetByLocationFloor = async (
   location: string,
   floor: number
@@ -141,7 +141,7 @@ export const axiosCabinetByLocationFloor = async (
   }
 };
 
-const axiosCabinetByIdURL = "/v3/api/cabinet_info/";
+const axiosCabinetByIdURL = "/api/cabinet_info/";
 export const axiosCabinetById = async (cabinetId: number): Promise<any> => {
   try {
     const response = await instance.get(`${axiosCabinetByIdURL}${cabinetId}`);
@@ -151,7 +151,7 @@ export const axiosCabinetById = async (cabinetId: number): Promise<any> => {
   }
 };
 
-const axiosLentIdURL = "/v3/api/lent/";
+const axiosLentIdURL = "/api/lent/";
 export const axiosLentId = async (cabinetId: number): Promise<any> => {
   try {
     const response = await instance.post(`${axiosLentIdURL}${cabinetId}`);
@@ -161,7 +161,7 @@ export const axiosLentId = async (cabinetId: number): Promise<any> => {
   }
 };
 
-const axiosMyLentInfoURL = "/v3/api/my_lent_info";
+const axiosMyLentInfoURL = "/api/my_lent_info";
 export const axiosMyLentInfo = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosMyLentInfoURL);
@@ -171,7 +171,7 @@ export const axiosMyLentInfo = async (): Promise<any> => {
   }
 };
 
-const axiosV3ReturnURL = "v3/api/lent/return";
+const axiosV3ReturnURL = "/api/lent/return";
 export const axiosV3Return = async (): Promise<any> => {
   try {
     const response = await instance.delete(axiosV3ReturnURL);

--- a/frontend_v3/src/network/axios/axios.custom.ts
+++ b/frontend_v3/src/network/axios/axios.custom.ts
@@ -11,72 +11,10 @@ export const axiosLogout = async (): Promise<any> => {
   }
 };
 
-const axiosExtensionUrl = "/api/extension";
-export const axiosExtension = async (): Promise<any> => {
-  try {
-    const response = await instance.post(axiosExtensionUrl);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosLentUrl = "/api/lent";
-export const axiosLent = async (cabinet_id: number): Promise<any> => {
-  try {
-    const response = await instance.post(axiosLentUrl, {
-      cabinet_id,
-    });
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosReturnUrl = "/api/return";
-export const axiosReturn = async (lent_id: number): Promise<any> => {
-  try {
-    const response = await instance.post(axiosReturnUrl, { lent_id });
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
 const axiosMyInfoURL = "/api/my_info";
 export const axiosMyInfo = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosMyInfoURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosLentInfoURL = "/api/lent_info";
-export const axiosLentInfo = async (): Promise<any> => {
-  try {
-    const response = await instance.post(axiosLentInfoURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosCabinetInfoURL = "/api/cabinet";
-export const axiosCabinetInfo = async (): Promise<any> => {
-  try {
-    const response = await instance.post(axiosCabinetInfoURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosReturnInfoURL = "/api/return_info";
-export const axiosReturnInfo = async (): Promise<any> => {
-  try {
-    const response = await instance.post(axiosReturnInfoURL);
     return response;
   } catch (error) {
     throw error;
@@ -171,10 +109,10 @@ export const axiosMyLentInfo = async (): Promise<any> => {
   }
 };
 
-const axiosV3ReturnURL = "/api/lent/return";
-export const axiosV3Return = async (): Promise<any> => {
+const axiosReturnURL = "/api/lent/return";
+export const axiosReturn = async (): Promise<any> => {
   try {
-    const response = await instance.delete(axiosV3ReturnURL);
+    const response = await instance.delete(axiosReturnURL);
     return response;
   } catch (error) {
     throw error;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

기존 dev에 있던 api에 달려있는 v3 태그들을 전부 정리하였습니다(백 + 프론트)
+ 하지만, axiosV3Return이라는 라이브러리가 있는 것으로 보아 추후 프론트쪽에서 개선이 필요해 보입니다.

admin에서 미리 사용하기로 결정해놓은 api들을 AdminModule에 서브 모듈로 옮겼습니다.

Swagger에서 나타나는 API 명세의 정보를 컨벤션에 맞게 변경하고,  admin API에 대해서는 차후에 디테일하게 설명을 채워 넣을 수 있도록 틀만 만들어 두었습니다.