### PR TITLE
[BE] FEAT: CI 단계에서 e2e Test를 위한 환경 셋업

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,9 +4,33 @@ on: [push]
 jobs:
   backend-CI:
     runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb
+        env:
+          MARIADB_DATABASE: test_db
+          MARIADB_USER: test_user
+          MARIADB_PASSWORD: test_password
+          MARIADB_ROOT_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -P 3306 -ptest_password | grep 'mysqld is alive' || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: 체크아웃
         uses: actions/checkout@v2
+      - name: DB에 샘플 데이터 삽입
+        run: >-
+          mysql --force
+          --host="127.0.0.1"
+          --port="3306"
+          --database="test_db"
+          --user="test_user"
+          --password="test_password"
+          < "backend/database/42cabi_v3_test.sql"
       - name: Node.js 16.x Version
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -50,8 +50,25 @@ jobs:
         run: npm run build --prefix backend
       # - name: 단위 테스트 체크
       #   run: npm run test --prefix backend
-      # - name: 통합 테스트 체크
-      #   run: npm run test:e2e --prefix backend
+      - name: E2E 테스트
+        env:
+          HOST: localhost
+          DB_USER: test_user
+          DB_PORT: 3306
+          DATABASE: test_db
+          DB_PASSWORD: test_password
+          ROOT_PASSWORD: test_password
+          FORTYTWO_APP_ID: 1234
+          FORTYTWO_APP_SECRET: 1234
+          CALLBACK_URL: /auth/login/callback
+          COOKIE_KEY: secret
+          JWT_SECRETKEY: SecretKey
+          JWT_ALGORITHM: HS256
+          JWT_EXPIREIN: 28d
+          JWT_ISSUER: 42cabi
+          MAIL_SEND: false
+          DEBUG_LOG: true
+        run: npm run test:e2e --prefix backend
 
   frontend-CI:
     runs-on: ubuntu-latest

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -16,9 +16,10 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(404);
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 });

--- a/backend/test/cabinet.e2e-spec.ts
+++ b/backend/test/cabinet.e2e-spec.ts
@@ -3,7 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
 
-describe('Cabinet E2E Test', () => {
+// NOTE: 일단 스킵
+describe.skip('Cabinet E2E Test', () => {
   let app: INestApplication;
   let cookie: string[];
 

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -3,6 +3,9 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  },
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

GitHub Actions에서 제공하는 기능들을 이용해 CI 상에서 MariaDB를 도커 컨테이너로서 구동시키고 컨테이너에 DDL과 샘플 데이터를 주입시켰습니다.

그리고 CI에 e2e 테스트를 추가하였으며 기존 e2e 테스트에 아래와 같은 테스트 파일을 일부 수정하였습니다.
- `app.e2e-spec.ts`
  - 루트 엔드포인트에 대한 테스트로 저희 앱애선 현재까진 해당 없으므로 404 Error를 리턴하는 것이 정상인 상황으로 적용하였습니다.
  - `afterEach` 를 이용해 현재 실행중인 테스트 앱을 종료시킵니다.
- `cabinet.e2e-spec.ts`
  - 로그인 및 세션을 어떻게 적용할 것인지에 대해 협의가 필요하다 판단해 skip 처리하였습니다.
  - 추후에 해당 테스트를 동작시킬 때 `afterEach` 를 이용해 현재 실행중인 테스트 앱을 종료시키는 코드를 추가하여야 합니다.

작업한 기록은 https://github.com/innovationacademy-kr/42cabi/wiki/CI-에서-DB-Test를-위한-환경-셋업 에 간략하게 작성하였습니다.