### PR TITLE
단일 사물함 정보 API response 값 추가 #676

### DIFF
--- a/backend/src/cabinet/repository/cabinet.info.repository.ts
+++ b/backend/src/cabinet/repository/cabinet.info.repository.ts
@@ -60,6 +60,8 @@ export class CabinetInfoRepository implements ICabinetInfoRepository {
       cabinet_title: cabinet.title,
       max_user: cabinet.max_user,
       status: cabinet.status,
+      location: cabinet.location,
+      floor: cabinet.floor,
       section: cabinet.section,
       lent_info: cabinet.lent.map((lent) => ({
         user_id: lent.user.user_id,
@@ -119,6 +121,8 @@ export class CabinetInfoRepository implements ICabinetInfoRepository {
       cabinet_title: result.title,
       max_user: result.max_user,
       status: result.status,
+      location: result.location,
+      floor: result.floor,
       section: result.section,
       lent_info: result.lent
         ? result.lent.map((l) => ({

--- a/backend/src/dto/response/cabinet.info.response.dto.ts
+++ b/backend/src/dto/response/cabinet.info.response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { CabinetDto } from '../cabinet.dto';
 import { LentDto } from '../lent.dto';
 
@@ -7,6 +7,18 @@ import { LentDto } from '../lent.dto';
  * @extends CabinetExtendDto
  */
 export class CabinetInfoResponseDto extends CabinetDto {
+  @ApiProperty({
+    description: '사물함이 존재하는 건물 이름',
+    example: '새롬관',
+  })
+  location: string; // 사물함 건물
+
+  @ApiProperty({
+    description: '사물함이 존재하는 층수',
+    example: 2,
+  })
+  floor: number; // 사물함 층수
+
   @ApiPropertyOptional({
     description: '대여되어 있을 경우 대여 정보',
     type: [LentDto],


### PR DESCRIPTION


<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

#676 에 따라 `/api/cabinet_info/{cabinet_id}` 에서 주는 사물함 정보에 `location`과 `floor`값을 추가했습니다.
해당 요청에 대한 응답은 `CabinetInfoResponseDto`를 통해 보내집니다.

`CabinetInfoResponseDto`의 부모인 `CabinetDto`에 `location`과 `floor` 필드를 추가하는 것도 고려했으나
해당 정보를 사용하지 않는 곳도 많고, 불필요하게 수정해야 할 부분이 많습니다.
따라서 `CabinetInfoResponseDto`에 `location`과 `floor` 필드를 추가하여 수정했습니다.
