### PR TITLE
[FE] FEAT: TopNav 관련 수정 사항

### DIFF
--- a/frontend_v4/src/components/TopNav.tsx
+++ b/frontend_v4/src/components/TopNav.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
+import { locationsFloorState, currentLocationNameState } from "@/recoil/atoms";
+import { locationsState } from "@/recoil/selectors";
+import { axiosLocationFloor } from "@/api/axios/axios.custom";
+import TopNavContainer from "@/containers/TopNavContainer";
+
+const TopNav = () => {
+  const [locationClicked, setLocationClicked] = useState(false);
+  const setLocationsFloor = useSetRecoilState(locationsFloorState);
+  const [currentLocationName, setCurrentLocationName] = useRecoilState(
+    currentLocationNameState
+  );
+  const locationsList = useRecoilValue<Array<string>>(locationsState);
+  const navigate = useNavigate();
+
+  const onClickLogo = () => {
+    navigate("/home");
+  };
+
+  useEffect(() => {
+    const getLocationsData = async () => {
+      try {
+        const locationsFloorData = await axiosLocationFloor();
+        setLocationsFloor(locationsFloorData.data.space_data);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getLocationsData();
+  }, []);
+
+  useEffect(() => {
+    if (locationsList.length === 0) return;
+
+    setCurrentLocationName(locationsList[0]);
+  }, [locationsList]);
+
+  return (
+    <TopNavContainer
+      currentLocationName={currentLocationName}
+      locationsList={locationsList}
+      locationClicked={locationClicked}
+      setLocationClicked={setLocationClicked}
+      onClickLogo={onClickLogo}
+      setCurrentLocationName={setCurrentLocationName}
+    />
+  );
+};
+
+export default TopNav;

--- a/frontend_v4/src/containers/LeftNavContainer.tsx
+++ b/frontend_v4/src/containers/LeftNavContainer.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+  useResetRecoilState,
+} from "recoil";
 import {
   currentFloorNumberState,
   currentFloorCabinetState,
@@ -20,6 +25,7 @@ const LeftNavContainer = () => {
   const [currentFloor, setCurrentFloor] = useRecoilState<number>(
     currentFloorNumberState
   );
+  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
   const setCurrentFloorData = useSetRecoilState<
     CabinetInfoByLocationFloorDto[]
   >(currentFloorCabinetState);
@@ -50,7 +56,7 @@ const LeftNavContainer = () => {
   const onClickHomeButton = () => {
     toggleMapInfo(() => false);
     toggleCabinetInfo(() => false);
-    setCurrentFloor(-1);
+    resetCurrentFloor();
     navigator("/home");
   };
 

--- a/frontend_v4/src/containers/TopNavContainer.tsx
+++ b/frontend_v4/src/containers/TopNavContainer.tsx
@@ -1,16 +1,11 @@
-import { currentFloorNumberState } from "@/recoil/atoms";
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useResetRecoilState } from "recoil";
-
+import React from "react";
+import { SetterOrUpdater } from "recoil";
 import styled from "styled-components";
 import TopNavButtonsContainer from "./TopNavButtonsContainer";
 
-const locations = ["새롬관", "서초", "강남"];
-
 interface ILocationListItem {
   location: string;
-  onUpdate: React.Dispatch<string>;
+  onUpdate: SetterOrUpdater<string>;
   onClose: React.Dispatch<boolean>;
 }
 
@@ -31,15 +26,23 @@ const LocationListItem: React.FC<ILocationListItem> = ({
   );
 };
 
-const TopNavContainer = () => {
-  const [locationName, setLocationName] = useState("새롬관");
-  const [locationClicked, setLocationClicked] = useState(false);
-  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
-  const navigate = useNavigate();
-  const onClickLogo = () => {
-    resetCurrentFloor();
-    navigate("/home");
-  };
+const TopNavContainer: React.FC<{
+  currentLocationName: string;
+  locationsList: Array<string>;
+  locationClicked: boolean;
+  setLocationClicked: React.Dispatch<boolean>;
+  onClickLogo: React.MouseEventHandler;
+  setCurrentLocationName: SetterOrUpdater<string>;
+}> = (props) => {
+  const {
+    currentLocationName,
+    locationsList,
+    locationClicked,
+    setLocationClicked,
+    onClickLogo,
+    setCurrentLocationName,
+  } = props;
+
   return (
     <TopNavContainerStyled>
       <LogoStyled>
@@ -48,14 +51,14 @@ const TopNavContainer = () => {
         </LogoDivStyled>
         <LocationSelectBoxStyled>
           <span onClick={() => setLocationClicked(!locationClicked)}>
-            {locationName}
+            {currentLocationName}
           </span>
           <LocationListStyled clicked={locationClicked}>
-            {locations.map((location, index) => (
+            {locationsList.map((location, index) => (
               <LocationListItem
                 location={location}
                 key={index}
-                onUpdate={setLocationName}
+                onUpdate={setCurrentLocationName}
                 onClose={setLocationClicked}
               />
             ))}
@@ -127,6 +130,7 @@ const LocationListStyled = styled.ul<{ clicked: boolean }>`
   opacity: 0.9;
   border-radius: 4px;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+  z-index: 100;
   display: ${(props) => (props.clicked ? "block" : "none")};
 `;
 

--- a/frontend_v4/src/pages/HomePage.tsx
+++ b/frontend_v4/src/pages/HomePage.tsx
@@ -1,31 +1,23 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import TopNavContainer from "@/containers/TopNavContainer";
+import TopNav from "@/components/TopNav";
 import InfoContainer from "@/containers/InfoContainer";
 import LeftNavContainer from "@/containers/LeftNavContainer";
 import LeftNavOptionContainer from "@/containers/LeftNavOptionContainer";
 import LoadingModal from "@/components/LoadingModal";
 
 import { getCookie } from "@/api/react_cookie/cookies";
-import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import {
-  locationsFloorState,
   myCabinetInfoState,
   userState,
   toggleCabinetInfoState,
   toggleMapInfoState,
 } from "@/recoil/atoms";
-import {
-  CabinetLocationFloorDto,
-  MyCabinetInfoResponseDto,
-} from "@/types/dto/cabinet.dto";
+import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import { UserDto } from "@/types/dto/user.dto";
-import {
-  axiosLocationFloor,
-  axiosMyInfo,
-  axiosMyLentInfo,
-} from "@/api/axios/axios.custom";
+import { axiosMyInfo, axiosMyLentInfo } from "@/api/axios/axios.custom";
 
 import CabinetInfoArea from "@/components/CabinetInfoArea";
 
@@ -37,12 +29,9 @@ const HomePage = () => {
   const toggleMapInfo = useRecoilValue(toggleMapInfoState);
   const navigator = useNavigate();
   const token = getCookie("access_token");
-  const setCurrentLocationData =
-    useSetRecoilState<CabinetLocationFloorDto[]>(locationsFloorState);
   const setUser = useSetRecoilState<UserDto>(userState);
   const setMyLentInfo =
     useSetRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
-  const resetMyLentInfo = useResetRecoilState(myCabinetInfoState);
   let loading: boolean = false;
 
   useEffect(() => {
@@ -51,11 +40,9 @@ const HomePage = () => {
       try {
         const { data: myInfo } = await axiosMyInfo();
         const { data: myLentInfo } = await axiosMyLentInfo();
-        const locationFloorData = await axiosLocationFloor();
 
         setUser(myInfo);
         setMyLentInfo(myLentInfo);
-        setCurrentLocationData(locationFloorData.data.space_data);
       } catch (error) {
         console.error(error);
       }
@@ -65,7 +52,7 @@ const HomePage = () => {
 
   return (
     <>
-      <TopNavContainer />
+      <TopNav />
       <WapperStyled>
         <LeftNavContainer />
         <LeftNavOptionContainer style={{ display: "none" }} />

--- a/frontend_v4/src/pages/MainPage.tsx
+++ b/frontend_v4/src/pages/MainPage.tsx
@@ -1,26 +1,20 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import TopNavContainer from "@/containers/TopNavContainer";
+import TopNav from "@/components/TopNav";
 import LeftNavContainer from "@/containers/LeftNavContainer";
-import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import { SectionPaginationContainer } from "@/containers/SectionPaginationContainer";
 import LeftNavOptionContainer from "@/containers/LeftNavOptionContainer";
 import CabinetInfoArea from "@/components/CabinetInfoArea";
 import { useRecoilValue } from "recoil";
 import CabinetList from "@/components/CabinetList";
-import {
-  currentFloorNumberState,
-  toggleCabinetInfoState,
-  toggleMapInfoState,
-} from "@/recoil/atoms";
+import { toggleCabinetInfoState, toggleMapInfoState } from "@/recoil/atoms";
 
 const MainPage = () => {
   const CabinetListWrapperRef = useRef<HTMLDivElement>(null);
   const toggleMapInfo = useRecoilValue(toggleMapInfoState);
   const toggleCabinetInfo = useRecoilValue(toggleCabinetInfoState);
   const [colNum, setColNum] = useState<number>(4);
-  const currentFloor = useRecoilValue(currentFloorNumberState);
   const navigate = useNavigate();
   // .env에서 가져올 실제 col_num 값입니다.
   const maxColNum = 7;
@@ -36,7 +30,6 @@ const MainPage = () => {
   };
 
   useEffect(() => {
-    if (currentFloor == -1) navigate("/home");
     if (CabinetListWrapperRef.current !== null) setColNumByDivWidth();
     window.addEventListener("resize", setColNumByDivWidth);
     return () => {
@@ -46,7 +39,7 @@ const MainPage = () => {
 
   return (
     <>
-      <TopNavContainer />
+      <TopNav />
       <WrapperStyled>
         <LeftNavContainer />
         <LeftNavOptionContainer />

--- a/frontend_v4/src/recoil/atoms.ts
+++ b/frontend_v4/src/recoil/atoms.ts
@@ -45,7 +45,7 @@ export const locationsFloorState = atom<CabinetLocationFloorDto[]>({
 
 export const currentLocationNameState = atom<string>({
   key: "CurrentLocation",
-  default: "새롬관",
+  default: undefined,
 });
 
 export const currentFloorNumberState = atom<number>({

--- a/frontend_v4/src/recoil/selectors.ts
+++ b/frontend_v4/src/recoil/selectors.ts
@@ -10,17 +10,27 @@ import {
 } from "./atoms";
 import axios, { AxiosResponse } from "axios";
 
+export const locationsState = selector<Array<string>>({
+  key: "Locations",
+  get: ({ get }) => {
+    const locationsFloorData = get(locationsFloorState);
+
+    const locationsArray = locationsFloorData.map((data) => data.location);
+    return locationsArray;
+  },
+});
+
 export const currentLocationFloorState = selector<Array<number>>({
   key: "CurrentLocationFloor",
   get: ({ get }) => {
-    const currentLocationData = get(locationsFloorState);
+    const locationsFloorData = get(locationsFloorState);
     const currentLocation = get(currentLocationNameState);
 
-    const currentLocationIndex = currentLocationData.findIndex((building) => {
+    const currentLocationIndex = locationsFloorData.findIndex((building) => {
       return building.location === currentLocation;
     });
     if (currentLocationIndex === -1) return [];
-    return currentLocationData[currentLocationIndex].floors;
+    return locationsFloorData[currentLocationIndex].floors;
   },
 });
 


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>TopNav에 건물 정보를 recoil state에서 가져다가 쓰는 것으로 변경(모든 건물 이름 배열 반환하는 selector 추가)
기존 HomePage에서 불러오던 건물 정보를 TopNav에서 받고 세팅하도록 수정
Atoms의 건물 정보 기본값을 새롬관에서 undefined로 변경(TopNav에서 API 요청 받아온 뒤 첫 번째 건물로 세팅)
TopNavContainer에서 기능을 TopNav로 분리
건물 선택 드롭다운이 section 메뉴 밑에 있어서 선택이 안되는 현상 -> 임시로 z-index 100부여(@42inshin z-index 쓰면 안좋다고 들었는데 나이스한 해결 방법 있을까요?)
*기타 수정 사항 : Home 버튼 누르면 currentFloorNumberStatus 변경하는 부분을 useResetRecoilState 훅으로 변경
