### PR TITLE
[FE] FIX: 캐비넷 정보 창 수정 #699

### DIFF
--- a/frontend_v4/src/components/CabinetInfoArea.tsx
+++ b/frontend_v4/src/components/CabinetInfoArea.tsx
@@ -6,7 +6,9 @@ import CabinetInfoAreaContainer, {
 import { CabinetInfo, MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 
-const CabinetInfoArea = (): JSX.Element => {
+const CabinetInfoArea = (props: {
+  style: React.CSSProperties;
+}): JSX.Element => {
   const targetCabinetInfo = useRecoilValue(targetCabinetInfoState);
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);

--- a/frontend_v4/src/components/CabinetInfoArea.tsx
+++ b/frontend_v4/src/components/CabinetInfoArea.tsx
@@ -5,10 +5,9 @@ import CabinetInfoAreaContainer, {
 } from "@/containers/CabinetInfoAreaContainer";
 import { CabinetInfo, MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import { useLocation } from "react-router-dom";
 
-const CabinetInfoArea = (props: {
-  style: React.CSSProperties;
-}): JSX.Element => {
+const CabinetInfoArea = (): JSX.Element => {
   const targetCabinetInfo = useRecoilValue(targetCabinetInfoState);
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);
@@ -16,7 +15,7 @@ const CabinetInfoArea = (props: {
     targetCabinetInfo && myCabinetInfo
       ? myCabinetInfo.cabinet_id === targetCabinetInfo.cabinet_id
       : false;
-
+  const { pathname } = useLocation();
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
     if (
@@ -83,7 +82,12 @@ const CabinetInfoArea = (props: {
         detailMessageColor: "var(--black)",
       }
     : null;
-  return <CabinetInfoAreaContainer selectedCabinetInfo={cabinetViewData} />;
+  return (
+    <CabinetInfoAreaContainer
+      path={pathname}
+      selectedCabinetInfo={cabinetViewData}
+    />
+  );
 };
 
 export default CabinetInfoArea;

--- a/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
+++ b/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
@@ -18,22 +18,23 @@ export interface ISelectedCabinetInfo {
   detailMessageColor: string;
 }
 
-const CabinetInfoAreaContainer: React.FC<{
-  selectedCabinetInfo: ISelectedCabinetInfo | null;
-}> = (props) => {
-  const { selectedCabinetInfo } = props;
+const NotSelectedContainer = () => {
+  return (
+    <NotSelectedStyled>
+      <CabiLogoStyled src={cabiLogo} />
+      <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
+        사물함을 <br />
+        선택해주세요
+      </TextStyled>
+    </NotSelectedStyled>
+  );
+};
 
-  if (selectedCabinetInfo === null)
-    return (
-      <NotSelectedStyled>
-        <CabiLogoStyled src={cabiLogo} />
-        <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
-          사물함을 <br />
-          선택해주세요
-        </TextStyled>
-      </NotSelectedStyled>
-    );
-
+const SelectedContainer = ({
+  selectedCabinetInfo,
+}: {
+  selectedCabinetInfo: ISelectedCabinetInfo;
+}) => {
   return (
     <CabinetDetailAreaStyled>
       <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
@@ -67,6 +68,17 @@ const CabinetInfoAreaContainer: React.FC<{
   );
 };
 
+const CabinetInfoAreaContainer: React.FC<{
+  selectedCabinetInfo: ISelectedCabinetInfo | null;
+}> = (props) => {
+  const { selectedCabinetInfo } = props;
+  return selectedCabinetInfo ? (
+    <SelectedContainer selectedCabinetInfo={selectedCabinetInfo} />
+  ) : (
+    <NotSelectedContainer />
+  );
+};
+
 export default CabinetInfoAreaContainer;
 
 const cabinetStatusColorMap = {
@@ -95,6 +107,11 @@ const cabinetLabelColorMap = {
 
 const NotSelectedStyled = styled.div`
   height: 100%;
+  width: 300px;
+  position: absolute;
+  right: 0;
+  background: var(--white);
+  box-shadow: 0px 0px 10px 1px gray;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
+++ b/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
@@ -18,9 +18,9 @@ export interface ISelectedCabinetInfo {
   detailMessageColor: string;
 }
 
-const NotSelectedContainer = () => {
+const NotSelectedContainer = ({ path }: { path: string }) => {
   return (
-    <NotSelectedStyled>
+    <NotSelectedStyled path={path}>
       <CabiLogoStyled src={cabiLogo} />
       <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
         사물함을 <br />
@@ -31,12 +31,14 @@ const NotSelectedContainer = () => {
 };
 
 const SelectedContainer = ({
+  path,
   selectedCabinetInfo,
 }: {
+  path: string;
   selectedCabinetInfo: ISelectedCabinetInfo;
 }) => {
   return (
-    <CabinetDetailAreaStyled>
+    <CabinetDetailAreaStyled path={path}>
       <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
         {selectedCabinetInfo.floor + "F - " + selectedCabinetInfo.section}
       </TextStyled>
@@ -68,14 +70,17 @@ const SelectedContainer = ({
   );
 };
 
-const CabinetInfoAreaContainer: React.FC<{
+const CabinetInfoAreaContainer = ({
+  selectedCabinetInfo,
+  path,
+}: {
   selectedCabinetInfo: ISelectedCabinetInfo | null;
-}> = (props) => {
-  const { selectedCabinetInfo } = props;
+  path: string;
+}) => {
   return selectedCabinetInfo ? (
-    <SelectedContainer selectedCabinetInfo={selectedCabinetInfo} />
+    <SelectedContainer path={path} selectedCabinetInfo={selectedCabinetInfo} />
   ) : (
-    <NotSelectedContainer />
+    <NotSelectedContainer path={path} />
   );
 };
 
@@ -105,11 +110,18 @@ const cabinetLabelColorMap = {
   [CabinetStatus.BANNED]: "var(--white)",
 };
 
-const NotSelectedStyled = styled.div`
+const NotSelectedStyled = styled.div<{ path: string }>`
   height: 100%;
   width: 300px;
-  position: absolute;
-  right: 0;
+  ${({ path }) =>
+    path === "/home"
+      ? css`
+          position: absolute;
+          right: 0;
+        `
+      : css`
+          min-width: 330px;
+        `}
   background: var(--white);
   box-shadow: 0px 0px 10px 1px gray;
   display: flex;
@@ -118,9 +130,18 @@ const NotSelectedStyled = styled.div`
   align-items: center;
 `;
 
-const CabinetDetailAreaStyled = styled.div`
+const CabinetDetailAreaStyled = styled.div<{ path: string }>`
   height: 100%;
   display: flex;
+  ${({ path }) =>
+    path === "/home"
+      ? css`
+          position: absolute;
+          right: 0;
+        `
+      : css`
+          min-width: 330px;
+        `}
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;

--- a/frontend_v4/src/pages/HomePage.tsx
+++ b/frontend_v4/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import TopNavContainer from "@/containers/TopNavContainer";
@@ -72,7 +72,17 @@ const HomePage = () => {
         <MainStyled>
           {loading ? <LoadingModal /> : <InfoContainer />}
         </MainStyled>
-        {toggleCabinetInfo && <CabinetInfoArea />}
+        {toggleCabinetInfo && (
+          <CabinetInfoArea
+            style={{
+              position: "absolute",
+              width: "300px",
+              background: "white",
+              right: 0,
+              boxShadow: "0px 0px 5px grey",
+            }}
+          />
+        )}
         {toggleMapInfo && <MapInfoContainer />}
       </WapperStyled>
     </>

--- a/frontend_v4/src/pages/HomePage.tsx
+++ b/frontend_v4/src/pages/HomePage.tsx
@@ -72,17 +72,7 @@ const HomePage = () => {
         <MainStyled>
           {loading ? <LoadingModal /> : <InfoContainer />}
         </MainStyled>
-        {toggleCabinetInfo && (
-          <CabinetInfoArea
-            style={{
-              position: "absolute",
-              width: "300px",
-              background: "white",
-              right: 0,
-              boxShadow: "0px 0px 5px grey",
-            }}
-          />
-        )}
+        {toggleCabinetInfo && <CabinetInfoArea />}
         {toggleMapInfo && <MapInfoContainer />}
       </WapperStyled>
     </>

--- a/frontend_v4/src/pages/MainPage.tsx
+++ b/frontend_v4/src/pages/MainPage.tsx
@@ -56,9 +56,7 @@ const MainPage = () => {
             <CabinetList colNum={colNum} />
           </CabinetListWrapperStyled>
         </MainStyled>
-        <DetailInfoContainerStyled>
-          <CabinetInfoArea />
-        </DetailInfoContainerStyled>
+        <CabinetInfoArea />
       </WrapperStyled>
     </>
   );


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

/home과 /main을 기준으로
cabinetInfoArea 컴포넌트의 스타일을 변경하여 
home에서는 position:absolute로,
main에서는 display:block 으로 표시하도록 수정하였습니다.

CabinetInfoArea에서
대여 정보가 있고 없고에 따라 컴포넌트를 다르게 내보내는 코드를 리팩토링 하였습니다
