### PR TITLE
[FE] FIX: pagination 바 로딩완료 체크 조건 추가 #706

### DIFF
--- a/frontend_v4/src/components/SectionPagination.tsx
+++ b/frontend_v4/src/components/SectionPagination.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useRecoilValue, useRecoilState } from "recoil";
 import {
   currentFloorNumberState,
@@ -41,18 +42,24 @@ const SectionPagination = (): JSX.Element => {
     }
   };
 
-  const isLoaded = floor !== undefined && sectionList !== undefined;
-  if (isLoaded === false) return <></>;
+  const isLoaded =
+    floor !== undefined &&
+    sectionList !== undefined &&
+    currentSectionName !== undefined;
 
   return (
-    <SectionPaginationContainer
-      currentSectionName={currentSectionName}
-      currentPositionName={currentPositionName}
-      sectionList={sectionList}
-      changeSectionOnClickIdxButton={changeSectionOnClickIdxButton}
-      moveToLeftSection={moveToLeftSection}
-      moveToRightSection={moveToRightSection}
-    />
+    <React.Fragment>
+      {isLoaded && (
+        <SectionPaginationContainer
+          currentSectionName={currentSectionName}
+          currentPositionName={currentPositionName}
+          sectionList={sectionList}
+          changeSectionOnClickIdxButton={changeSectionOnClickIdxButton}
+          moveToLeftSection={moveToLeftSection}
+          moveToRightSection={moveToRightSection}
+        />
+      )}
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
## 해당 사항 (중복 선택)
- #706 
- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>section pagination 바에 undefined가 출력되지 않도록 currentSectionName도 로딩 완료 체크 조건에 추가하였습니다.
기존에 isLoad 값에 따른 빈 div 반환부분을 && 조건으로 합쳤습니다.
리턴 컴포넌트 전체를 감싸는 React.Fragment는 단축 문법으로 <></> 로 사용할 수 있습니다.
의미없는 div가 추가되는 줄 알았는데 별도의 DOM을 만들지 않고 감싸는 기능이라고 하네요.
[React.Fragment 공식 문서](https://ko.reactjs.org/docs/fragments.html#short-syntax)

