### PR TITLE
[FE] FIX: 연체된 사물함 밑에 메시지 색깔 바꾸기 #725

### DIFF
--- a/frontend_v4/src/components/CabinetInfoArea.tsx
+++ b/frontend_v4/src/components/CabinetInfoArea.tsx
@@ -60,11 +60,33 @@ const CabinetInfoArea = (): JSX.Element => {
       );
       const remainTimeString =
         remainTime < 0
-          ? `반납일이 ${-remainTime}일 지났습니다.`
-          : `반납일이 ${remainTime}일 남았습니다.`;
+          ? `반납일이 ${-remainTime}일 지났습니다`
+          : `반납일이 ${remainTime}일 남았습니다`;
       return remainTimeString;
       // 빈 사물함
     } else return null;
+  };
+
+  const getDetailMessageColor = (selectedCabinetInfo: CabinetInfo): string => {
+    // 밴, 고장 사물함
+    if (
+      selectedCabinetInfo.status === CabinetStatus.BANNED ||
+      selectedCabinetInfo.status === CabinetStatus.BROKEN
+    )
+      return "var(--expired)";
+    // 사용 중 사물함
+    else if (
+      selectedCabinetInfo.status === CabinetStatus.SET_EXPIRE_FULL ||
+      selectedCabinetInfo.status === CabinetStatus.EXPIRED
+    ) {
+      const nowDate = new Date();
+      const expireTime = new Date(selectedCabinetInfo.lent_info[0].expire_time);
+      const remainTime = Math.floor(
+        (expireTime.getTime() - nowDate.getTime()) / (1000 * 60 * 60 * 24)
+      );
+      return remainTime < 0 ? "var(--expired)" : "var(--black)";
+      // 빈 사물함
+    } else return "var(--black)";
   };
 
   const cabinetViewData: ISelectedCabinetInfo | null = targetCabinetInfo
@@ -78,12 +100,17 @@ const CabinetInfoArea = (): JSX.Element => {
         userNameList: getCabinetUserList(targetCabinetInfo),
         expireDate: targetCabinetInfo.lent_info[0]?.expire_time,
         detailMessage: getDetailMessage(targetCabinetInfo),
-        detailMessageColor: "var(--black)",
+        detailMessageColor: getDetailMessageColor(targetCabinetInfo),
       }
     : null;
 
-  const {closeCabinet} = useDetailInfo();
-  return <CabinetInfoAreaContainer selectedCabinetInfo={cabinetViewData} closeCabinet={closeCabinet} />;
+  const { closeCabinet } = useDetailInfo();
+  return (
+    <CabinetInfoAreaContainer
+      selectedCabinetInfo={cabinetViewData}
+      closeCabinet={closeCabinet}
+    />
+  );
 };
 
 export default CabinetInfoArea;

--- a/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
+++ b/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
@@ -26,7 +26,6 @@ const CabinetInfoAreaContainer: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
   closeCabinet: () => void;
 }> = (props) => {
-
   const { selectedCabinetInfo, closeCabinet } = props;
   const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
@@ -146,7 +145,6 @@ const CabinetInfoAreaContainer: React.FC<{
     setShowMemoModal(false);
   };
 
-
   if (selectedCabinetInfo === null)
     return (
       <NotSelectedStyled>
@@ -168,12 +166,14 @@ const CabinetInfoAreaContainer: React.FC<{
       >
         {selectedCabinetInfo.cabinetNum}
       </CabinetRectangleStyled>
-      <CabinetTypeIconStyled title={selectedCabinetInfo.lentType} cabinetType={selectedCabinetInfo.lentType} />
+      <CabinetTypeIconStyled
+        title={selectedCabinetInfo.lentType}
+        cabinetType={selectedCabinetInfo.lentType}
+      />
       <TextStyled fontSize="1rem" fontColor="black">
         {selectedCabinetInfo.userNameList}
       </TextStyled>
       <CabinetInfoButtonsContainerStyled>
-
         {selectedCabinetInfo.isMine ? (
           <>
             <ButtonContainer
@@ -198,17 +198,16 @@ const CabinetInfoAreaContainer: React.FC<{
             <ButtonContainer onClick={closeCabinet} text="취소" theme="white" />
           </>
         )}
-
       </CabinetInfoButtonsContainerStyled>
-      <CabinetLentDateInfoStyled textColor="var(--black)">
-        {selectedCabinetInfo.expireDate
-          ? `~ ${selectedCabinetInfo.expireDate.toString().substring(0, 10)}`
-          : null}
-      </CabinetLentDateInfoStyled>
       <CabinetLentDateInfoStyled
         textColor={selectedCabinetInfo.detailMessageColor}
       >
         {selectedCabinetInfo.detailMessage}
+      </CabinetLentDateInfoStyled>
+      <CabinetLentDateInfoStyled textColor="var(--black)">
+        {selectedCabinetInfo.expireDate
+          ? `${selectedCabinetInfo.expireDate.toString().substring(0, 10)}`
+          : null}
       </CabinetLentDateInfoStyled>
       {showReturnModal && (
         <ModalPortal>
@@ -321,11 +320,10 @@ const CabinetInfoButtonsContainerStyled = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  margin-top: 40px;
+  margin: 40px 0;
 `;
 
 const CabinetLentDateInfoStyled = styled.div<{ textColor: string }>`
-  margin-top: 35px;
   color: ${(props) => props.textColor};
   font-size: 1rem;
   font-weight: 700;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX: 기능 수정
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
사물함 상세보기에서 맨 아래의 텍스트가 연체를 나타낼 시 (OO일 지났습니다)의 색상 변경
