### PR TITLE
[FE] FEAT: 우측 구역 취소 버튼 기능 추가 #683

### DIFF
--- a/frontend_v4/src/components/CabinetInfoArea.tsx
+++ b/frontend_v4/src/components/CabinetInfoArea.tsx
@@ -1,4 +1,4 @@
-import { useRecoilValue, useRecoilValueLoadable } from "recoil";
+import { useRecoilValue, useResetRecoilState } from "recoil";
 import { myCabinetInfoState, targetCabinetInfoState } from "@/recoil/atoms";
 import CabinetInfoAreaContainer, {
   ISelectedCabinetInfo,
@@ -9,12 +9,14 @@ import useDetailInfo from "@/hooks/useDetailInfo";
 
 const CabinetInfoArea = (): JSX.Element => {
   const targetCabinetInfo = useRecoilValue(targetCabinetInfoState);
+  const resetTargetCabinetInfo = useResetRecoilState(targetCabinetInfoState);
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);
   const isMyCabinet =
     targetCabinetInfo && myCabinetInfo
       ? myCabinetInfo.cabinet_id === targetCabinetInfo.cabinet_id
       : false;
+  const { closeCabinet } = useDetailInfo();
 
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
@@ -104,11 +106,15 @@ const CabinetInfoArea = (): JSX.Element => {
       }
     : null;
 
-  const { closeCabinet } = useDetailInfo();
+  const handleCancle = () => {
+    resetTargetCabinetInfo();
+    closeCabinet();
+  };
+
   return (
     <CabinetInfoAreaContainer
       selectedCabinetInfo={cabinetViewData}
-      closeCabinet={closeCabinet}
+      closeCabinet={handleCancle}
     />
   );
 };


### PR DESCRIPTION
## 해당 사항 (중복 선택)
- #683 
- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>취소 버튼 클릭 시 targetCabinetInfoState를 초기화시키도록 했습니다.

