### PR TITLE
[FE] 내 사물함보기 버튼 기능 추가

### DIFF
--- a/frontend_v4/src/components/TopNavButton.tsx
+++ b/frontend_v4/src/components/TopNavButton.tsx
@@ -24,7 +24,7 @@ const TopNavButtonStyled = styled.div<{ disable?: boolean }>`
   height: 35px;
   margin-right: 10px;
   cursor: pointer;
-  opacity: ${({ disable }) => (disable ? 0.6 : 1)};
+  display: ${({ disable }) => (disable ? "none" : "block")};
   &:hover {
     opacity: 0.9;
   }

--- a/frontend_v4/src/containers/TopNavButtonsContainer.tsx
+++ b/frontend_v4/src/containers/TopNavButtonsContainer.tsx
@@ -1,16 +1,51 @@
 import styled from "styled-components";
 import TopNavButton from "@/components/TopNavButton";
-import { useRecoilState, useSetRecoilState } from "recoil";
-import { toggleCabinetInfoState, toggleMapInfoState } from "@/recoil/atoms";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  currentCabinetIdState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
 import useDetailInfo from "@/hooks/useDetailInfo";
+import { axiosCabinetById } from "@/api/axios/axios.custom";
+import { CabinetInfo } from "@/types/dto/cabinet.dto";
 
 const TopNavButtonsContainer = () => {
-  const { clickCabinet, clickMap } = useDetailInfo();
+  const { clickCabinet, clickMap, openCabinet, closeCabinet } = useDetailInfo();
+  const [currentCabinetId, setCurrentCabinetId] = useRecoilState(
+    currentCabinetIdState
+  );
+  const setTargetCabinetInfo = useSetRecoilState<CabinetInfo>(
+    targetCabinetInfoState
+  );
+  const myInfo = useRecoilValue(userState);
 
+  async function setTargetCabinetInfoToMyCabinet() {
+    setCurrentCabinetId(myInfo.cabinet_id);
+    try {
+      const { data } = await axiosCabinetById(myInfo.cabinet_id);
+      setTargetCabinetInfo(data);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  const clickMyCabinet = () => {
+    if (myInfo.cabinet_id === -1) {
+      return;
+    }
+    if (currentCabinetId !== myInfo.cabinet_id) {
+      setTargetCabinetInfoToMyCabinet();
+      openCabinet();
+    } else {
+      clickCabinet();
+    }
+  };
   return (
     <NaviButtonsStyled>
       <TopNavButton
-        onClick={clickCabinet}
+        disable={myInfo.cabinet_id === -1}
+        onClick={clickMyCabinet}
         imgSrc="src/assets/images/myCabinetIcon.svg"
       />
       <TopNavButton onClick={clickMap} imgSrc="src/assets/images/map.svg" />

--- a/frontend_v4/src/hooks/useDetailInfo.ts
+++ b/frontend_v4/src/hooks/useDetailInfo.ts
@@ -7,7 +7,7 @@ import {
 import { useRecoilState, useSetRecoilState } from "recoil";
 
 const useDetailInfo = () => {
-  const [toggleMyCabinet, toggleMyCabinetState] = useRecoilState(
+  const [toggleMyCabinet, setToggleMyCabinet] = useRecoilState(
     toggleCabinetInfoState
   );
   const offMapSelect = useSetRecoilState(toggleMapSelectState);
@@ -65,14 +65,14 @@ const useDetailInfo = () => {
   const openCabinet = () => {
     if (toggleMyCabinet == false) {
       cabinetDetailArea!.classList.add("on");
-      toggleMyCabinetState(true);
+      setToggleMyCabinet(true);
     }
   };
 
   const closeCabinet = () => {
     if (toggleMyCabinet == true) {
       cabinetDetailArea!.classList.remove("on");
-      toggleMyCabinetState(false);
+      setToggleMyCabinet(false);
     }
   };
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
사물함 보기 버튼 (탑 내비게이션 바 우측 아이콘)을 눌렀을 시 사물함 상세보기 페이지가 뜨고 자신이 대여중인 사물함이 나오는 기능을 구현하였습니다. 만약 대여한 사물함이 없는 유저의 경우 해당 아이콘이 보이지 않게 처리하였습니다. 
closes #719 