### PR TITLE
[FE] FEAT: 새로고침을 위한 recoil-persist 적용 #739

### DIFF
--- a/frontend_v4/package-lock.json
+++ b/frontend_v4/package-lock.json
@@ -15,6 +15,7 @@
         "react-ga": "^3.3.1",
         "react-router-dom": "^6.5.0",
         "recoil": "^0.7.6",
+        "recoil-persist": "^4.2.0",
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
@@ -3865,6 +3866,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -7156,6 +7165,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "requires": {}
     },
     "regenerator-runtime": {
       "version": "0.13.11",

--- a/frontend_v4/package.json
+++ b/frontend_v4/package.json
@@ -16,6 +16,7 @@
     "react-ga": "^3.3.1",
     "react-router-dom": "^6.5.0",
     "recoil": "^0.7.6",
+    "recoil-persist": "^4.2.0",
     "styled-components": "^5.3.6"
   },
   "devDependencies": {

--- a/frontend_v4/src/containers/LeftNavContainer.tsx
+++ b/frontend_v4/src/containers/LeftNavContainer.tsx
@@ -11,6 +11,7 @@ import {
   currentFloorNumberState,
   currentFloorCabinetState,
   currentSectionNameState,
+  currentLocationNameState,
 } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
 import { axiosCabinetByLocationFloor } from "@/api/axios/axios.custom";
@@ -24,7 +25,10 @@ const LeftNavContainer = () => {
   const [currentFloor, setCurrentFloor] = useRecoilState<number>(
     currentFloorNumberState
   );
+  const currentLocation = useRecoilValue<string>(currentLocationNameState);
   const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
+  const resetCurrentSection = useResetRecoilState(currentSectionNameState);
+  const resetLocation = useResetRecoilState(currentLocationNameState);
   const setCurrentFloorData = useSetRecoilState<
     CabinetInfoByLocationFloorDto[]
   >(currentFloorCabinetState);
@@ -36,8 +40,7 @@ const LeftNavContainer = () => {
 
   useEffect(() => {
     if (currentFloor === undefined) return;
-
-    axiosCabinetByLocationFloor("새롬관", currentFloor)
+    axiosCabinetByLocationFloor(currentLocation, currentFloor)
       .then((response) => {
         setCurrentFloorData(response.data);
         setCurrentSection(response.data[0].section);
@@ -45,13 +48,12 @@ const LeftNavContainer = () => {
       .catch((error) => {
         console.error(error);
       });
-  }, [currentFloor]);
+  }, [currentLocation, currentFloor]);
 
-  const onClick = (floor: number) => {
+  const onClickFloorButton = (floor: number) => {
     setCurrentFloor(floor);
     if (pathname == "/home") {
-      closeLeftNav();
-      closeMap();
+      closeDetailInfo();
       navigator("/main");
     }
   };
@@ -59,17 +61,20 @@ const LeftNavContainer = () => {
   const onClickHomeButton = () => {
     closeDetailInfo();
     resetCurrentFloor();
+    resetCurrentSection();
     closeLeftNav();
     navigator("/home");
   };
 
-  const handleLogout = (): void => {
+  const onClickLogoutButton = (): void => {
     if (import.meta.env.VITE_IS_LOCAL === "true") {
       removeCookie("access_token");
     } else {
       removeCookie("access_token", { path: "/", domain: "cabi.42seoul.io" });
     }
-
+    resetLocation();
+    resetCurrentFloor();
+    resetCurrentSection();
     navigator("/login");
   };
 
@@ -86,7 +91,7 @@ const LeftNavContainer = () => {
           {floors.map((floor, index) => (
             <TopBtnStyled
               className={floor === currentFloor ? "leftNavButtonActive" : ""}
-              onClick={() => onClick(floor)}
+              onClick={() => onClickFloorButton(floor)}
               key={index}
             >
               {floor + "층"}
@@ -105,7 +110,7 @@ const LeftNavContainer = () => {
             Log
           </BottomBtnStyled>
           <BottomBtnStyled
-            onClick={handleLogout}
+            onClick={onClickLogoutButton}
             src={"src/assets/images/close-square.svg"}
           >
             <div></div>

--- a/frontend_v4/src/recoil/atoms.ts
+++ b/frontend_v4/src/recoil/atoms.ts
@@ -1,3 +1,4 @@
+import { recoilPersist } from "recoil-persist";
 import { UserDto } from "@/types/dto/user.dto";
 import {
   CabinetInfo,
@@ -7,6 +8,8 @@ import {
 } from "@/types/dto/cabinet.dto";
 import { atom } from "recoil";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
+
+const { persistAtom } = recoilPersist();
 
 export const userState = atom<UserDto>({
   key: "UserInfo",
@@ -46,16 +49,19 @@ export const locationsFloorState = atom<CabinetLocationFloorDto[]>({
 export const currentLocationNameState = atom<string>({
   key: "CurrentLocation",
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const currentFloorNumberState = atom<number>({
   key: "CurrentFloor",
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const currentSectionNameState = atom<string>({
   key: "CurrentSection",
   default: undefined,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const currentCabinetIdState = atom<number>({


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

메인에서 새로고침 시 recoil값이 초기화 되어 사물함 정보가 안나오는 부분을 recoil-persist 라이브러리를 통하여 개선하였습니다.
새로운 라이브러리가 설치되었으므로, npm install이 필요합니다.

추가적으로, 섹션 부분도 저장하고 싶었으나, 해당 값도 저장하게 되면 다른 층으로 갔을때 새로운 값으로 변하지 않는 버그가 있어서 floor가 바뀌는 경우와 새로고침 시 모두 섹션은 index 0 값을 넣어 처리하였습니다.

이 내용은 개선의 여지가 있습니다. 

Closes #739 