### PR TITLE
[FE] BUG: 404 페이지에서 "홈으로 가기" 버튼 클릭 시 다른 층이 선택 #753

### DIFF
--- a/frontend_v4/src/containers/LeftNavContainer.tsx
+++ b/frontend_v4/src/containers/LeftNavContainer.tsx
@@ -40,14 +40,11 @@ const LeftNavContainer = () => {
   const setCurrentSection = useSetRecoilState<string>(currentSectionNameState);
   const navigator = useNavigate();
   const { pathname } = useLocation();
-  const { closeLeftNav } = useLeftNav();
-  const { closeMap, closeDetailInfo } = useDetailInfo();
   const isMount = useIsMount();
   const [isMyCabinetIdChanged, setIsMyCabinetIdChanged] = useRecoilState(
     isMyCabinetIdChangedState
   );
 
-  // 층을 클릭할 때,
   useEffect(() => {
     if (currentFloor === undefined) return;
     axiosCabinetByLocationFloor(currentLocation, currentFloor)
@@ -72,21 +69,14 @@ const LeftNavContainer = () => {
       });
   }, [currentLocation, currentFloor, myInfo.cabinet_id]);
 
-  useEffect(() => {}, [currentLocation, currentFloor]);
-
   const onClickFloorButton = (floor: number) => {
     setCurrentFloor(floor);
     if (pathname == "/home") {
-      closeDetailInfo();
       navigator("/main");
     }
   };
 
   const onClickHomeButton = () => {
-    closeDetailInfo();
-    resetCurrentFloor();
-    resetCurrentSection();
-    closeLeftNav();
     navigator("/home");
   };
 

--- a/frontend_v4/src/pages/HomePage.tsx
+++ b/frontend_v4/src/pages/HomePage.tsx
@@ -1,15 +1,35 @@
-import React from "react";
+import React, { useEffect } from "react";
 import HomeInfoContainer from "@/containers/HomeInfoContainer";
 import { useNavigate } from "react-router-dom";
-import { currentFloorNumberState } from "@/recoil/atoms";
+import {
+  currentFloorNumberState,
+  currentSectionNameState,
+} from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from "recoil";
 import "@/assets/css/homePage.css";
+import useLeftNav from "@/hooks/useLeftNav";
+import useDetailInfo from "@/hooks/useDetailInfo";
 
 const HomePage = () => {
   const floors = useRecoilValue<Array<number>>(currentLocationFloorState);
   const setCurrentFloor = useSetRecoilState<number>(currentFloorNumberState);
+  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
+  const resetCurrentSection = useResetRecoilState(currentSectionNameState);
+  const { closeLeftNav } = useLeftNav();
+  const { closeDetailInfo } = useDetailInfo();
   const navigator = useNavigate();
+
+  useEffect(() => {
+    closeDetailInfo();
+    closeLeftNav();
+    resetCurrentFloor();
+    resetCurrentSection();
+
+    return () => {
+      closeDetailInfo();
+    };
+  }, []);
 
   const lentStartHandler = () => {
     setCurrentFloor(floors[0]);

--- a/frontend_v4/src/pages/NotFoundPage.tsx
+++ b/frontend_v4/src/pages/NotFoundPage.tsx
@@ -15,9 +15,7 @@ const NotFoundPage = () => {
         요청하신 페이지가 사라졌거나,{" "}
         <span>잘못된 경로를 이용하셨습니다 :(</span>
       </ContentStyled>
-      <ButtonStyled onClick={() => navigate("/login")}>
-        홈으로 가기
-      </ButtonStyled>
+      <ButtonStyled onClick={() => navigate("/")}>홈으로 가기</ButtonStyled>
     </NotFoundPageStyled>
   );
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

main페이지에서 층 정보를 보고 있다가, 없는 페이지에 갔을 경우 recoilFloor, recoilSection 정보가 유지되어서 생기는 문제였습니다.

이전의 코드에서는 홈으로 가거나, 나가는 버튼에 reset 하는 내용이 적혀있었는데,
해당 기능을 homePage에서 useEffect를 사용하여 처리했습니다.
