### PR TITLE
[FE] REFACTOR: 대여 반납 api호출부 모듈화 #763

### DIFF
--- a/frontend_v4/src/components/Modal.tsx
+++ b/frontend_v4/src/components/Modal.tsx
@@ -1,11 +1,134 @@
+import {
+  axiosCabinetById,
+  axiosLentId,
+  axiosMyLentInfo,
+  axiosReturn,
+} from "@/api/axios/axios.custom";
 import ModalContainer from "@/containers/ModalContainer";
 import { ModalInterface } from "@/containers/ModalContainer";
+import {
+  currentCabinetIdState,
+  isMyCabinetIdChangedState,
+  myCabinetInfoState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
+import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 
 const Modal = (props: {
   modalObj: ModalInterface;
   onClose: React.MouseEventHandler;
 }) => {
-  return <ModalContainer {...props} />;
+  const confirmMessage = props.modalObj.confirmMessage;
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  const [myInfo, setMyInfo] = useRecoilState(userState);
+  const setMyLentInfo =
+    useSetRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
+  const [targetCabinetInfo, setTargetCabinetInfo] = useRecoilState(
+    targetCabinetInfoState
+  );
+  const setIsMyCabinetIdChanged = useSetRecoilState(isMyCabinetIdChangedState);
+  let expireDate = new Date();
+  const addDays = targetCabinetInfo?.lent_type === "SHARE" ? 41 : 20;
+  expireDate.setDate(expireDate.getDate() + addDays);
+  const padTo2Digits = (num: number) => {
+    return num.toString().padStart(2, "0");
+  };
+  const formatDate = (date: Date) => {
+    return [
+      date.getFullYear(),
+      padTo2Digits(date.getMonth() + 1),
+      padTo2Digits(date.getDate()),
+    ].join("/");
+  };
+  const formattedExpireDate = formatDate(expireDate);
+  const lentDetail = `
+    대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
+    대여 후 72시간 이내 취소(반납) 시,
+    72시간의 대여 불가 패널티가 적용됩니다.
+    “메모 내용”은 공유 인원끼리 공유됩니다.
+    귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.
+  `;
+  const returnDetail = `
+    대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
+    지금 반납 하시겠습니까?
+  `;
+  const onClickLent = async () => {
+    try {
+      await axiosLentId(currentCabinetId);
+      //userCabinetId 세팅
+      setMyInfo({ ...myInfo, cabinet_id: currentCabinetId });
+      setIsMyCabinetIdChanged(true);
+
+      // 캐비닛 상세정보 바꾸는 곳
+      try {
+        const { data } = await axiosCabinetById(currentCabinetId);
+        setTargetCabinetInfo(data);
+      } catch (error) {
+        console.log(error);
+      }
+      // 내 대여정보 바꾸는 곳
+      try {
+        const { data: myLentInfo } = await axiosMyLentInfo();
+        setMyLentInfo(myLentInfo);
+      } catch (error) {
+        console.error(error);
+      }
+    } catch (error: any) {
+      if (error.response.status !== 401) {
+        alert(error.response.data.message);
+      }
+      console.log(error);
+    }
+  };
+  const onClickReturn = async () => {
+    try {
+      await axiosReturn();
+      //userCabinetId 세팅
+      setMyInfo({ ...myInfo, cabinet_id: -1 });
+      setIsMyCabinetIdChanged(true);
+      // 캐비닛 상세정보 바꾸는 곳
+      try {
+        const { data } = await axiosCabinetById(currentCabinetId);
+        setTargetCabinetInfo(data);
+      } catch (error) {
+        console.log(error);
+      }
+      //userLentInfo 세팅
+      try {
+        const { data: myLentInfo } = await axiosMyLentInfo();
+        setMyLentInfo(myLentInfo);
+      } catch (error) {
+        console.error(error);
+      }
+    } catch (error: any) {
+      if (error.response.status !== 401) {
+        alert(error.response.data.message);
+      }
+      console.log(error);
+    }
+  };
+  return (
+    <ModalContainer
+      modalObj={props.modalObj}
+      onClose={props.onClose}
+      onClickProceed={
+        confirmMessage.includes("대여")
+          ? onClickLent
+          : confirmMessage.includes("반납")
+          ? onClickReturn
+          : null
+      }
+      detail={
+        confirmMessage.includes("대여")
+          ? lentDetail
+          : confirmMessage.includes("반납")
+          ? returnDetail
+          : null
+      }
+    />
+  );
 };
 
 export default Modal;

--- a/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
+++ b/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
@@ -7,7 +7,12 @@ import cabiLogo from "@/assets/images/logo.svg";
 import Modal from "@/components/Modal";
 import ModalPortal from "@/components/ModalPortal";
 import MemoModal from "@/components/MemoModal";
-import { modalPropsMap } from "@/maps";
+import {
+  cabinetIconSrcMap,
+  cabinetLabelColorMap,
+  cabinetStatusColorMap,
+  modalPropsMap,
+} from "@/maps";
 export interface ISelectedCabinetInfo {
   floor: number;
   section: string;
@@ -132,30 +137,6 @@ const CabinetInfoAreaContainer: React.FC<{
 };
 
 export default CabinetInfoAreaContainer;
-
-const cabinetStatusColorMap = {
-  [CabinetStatus.AVAILABLE]: "var(--available)",
-  [CabinetStatus.SET_EXPIRE_FULL]: "var(--full)",
-  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "var(--available)",
-  [CabinetStatus.EXPIRED]: "var(--expired)",
-  [CabinetStatus.BROKEN]: "var(--broken)",
-  [CabinetStatus.BANNED]: "var(--banned)",
-};
-
-const cabinetIconSrcMap = {
-  [CabinetType.PRIVATE]: "src/assets/images/privateIcon.svg",
-  [CabinetType.SHARE]: "src/assets/images/shareIcon.svg",
-  [CabinetType.CIRCLE]: "src/assets/images/circleIcon.svg",
-};
-
-const cabinetLabelColorMap = {
-  [CabinetStatus.AVAILABLE]: "var(--white)",
-  [CabinetStatus.SET_EXPIRE_FULL]: "var(--black)",
-  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "var(--white)",
-  [CabinetStatus.EXPIRED]: "var(--white)",
-  [CabinetStatus.BROKEN]: "var(--white)",
-  [CabinetStatus.BANNED]: "var(--white)",
-};
 
 const NotSelectedStyled = styled.div`
   height: 100%;

--- a/frontend_v4/src/containers/ModalContainer.tsx
+++ b/frontend_v4/src/containers/ModalContainer.tsx
@@ -7,18 +7,23 @@ import React from "react";
 export interface ModalInterface {
   type: string; //"confirm" : 진행 가능한 모달(메모, 대여, 반납 등에 사용) "erorr": 진행 불가능한 모달(문구와 닫기버튼만 존재)
   title: string | null; //모달 제목
-  detail: string | null | JSX.Element; //안내문구 (confirm 타입 모달만 가짐)
   confirmMessage: string; //확인 버튼의 텍스트
-  onClickProceed: () => (void | Promise<any>) | null;
 }
 
 interface ModalContainerInterface {
   modalObj: ModalInterface;
   onClose: React.MouseEventHandler;
+  onClickProceed: (() => Promise<void>) | null;
+  detail: string | null;
 }
 
-const ModalContainer = ({ modalObj, onClose }: ModalContainerInterface) => {
-  const { type, title, detail, confirmMessage, onClickProceed } = modalObj;
+const ModalContainer = ({
+  modalObj,
+  onClose,
+  onClickProceed,
+  detail,
+}: ModalContainerInterface) => {
+  const { type, title, confirmMessage } = modalObj;
   return (
     <>
       <BackgroundStyled onClick={onClose} />
@@ -33,14 +38,15 @@ const ModalContainer = ({ modalObj, onClose }: ModalContainerInterface) => {
           onClick={type !== "confirm" ? onClose : undefined}
         />
         <H2Styled>{title}</H2Styled>
-        {detail}
+        {type === "confirm" && (
+          <DetailStyled dangerouslySetInnerHTML={{ __html: detail! }} />
+        )}
         {type === "confirm" && (
           <ButtonWrapperStyled>
             <ButtonContainer onClick={onClose} text="취소" theme="line" />
-
             <ButtonContainer
               onClick={(e) => {
-                onClickProceed();
+                onClickProceed!();
                 onClose(e);
               }}
               text={confirmMessage}
@@ -66,7 +72,7 @@ const ModalContainerStyled = styled.div<{ type: string }>`
   justify-content: space-around;
   align-items: center;
   text-align: center;
-  padding: 40px 30px;
+  padding: 40px 20px;
 `;
 
 export const DetailStyled = styled.p`

--- a/frontend_v4/src/maps.ts
+++ b/frontend_v4/src/maps.ts
@@ -1,0 +1,73 @@
+import CabinetStatus from "./types/enum/cabinet.status.enum";
+import CabinetType from "./types/enum/cabinet.type.enum";
+
+export const cabinetIconSrcMap = {
+  [CabinetType.PRIVATE]: "src/assets/images/privateIcon.svg",
+  [CabinetType.SHARE]: "src/assets/images/shareIcon.svg",
+  [CabinetType.CIRCLE]: "src/assets/images/circleIcon.svg",
+};
+
+export const cabinetLabelColorMap = {
+  [CabinetStatus.AVAILABLE]: "var(--white)",
+  [CabinetStatus.SET_EXPIRE_FULL]: "var(--black)",
+  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "var(--white)",
+  [CabinetStatus.EXPIRED]: "var(--white)",
+  [CabinetStatus.BROKEN]: "var(--white)",
+  [CabinetStatus.BANNED]: "var(--white)",
+};
+
+export const cabinetStatusColorMap = {
+  [CabinetStatus.AVAILABLE]: "var(--available)",
+  [CabinetStatus.SET_EXPIRE_FULL]: "var(--full)",
+  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "var(--available)",
+  [CabinetStatus.EXPIRED]: "var(--expired)",
+  [CabinetStatus.BROKEN]: "var(--broken)",
+  [CabinetStatus.BANNED]: "var(--banned)",
+};
+
+export const modalPropsMap = {
+  [CabinetStatus.AVAILABLE]: {
+    type: "confirm",
+    title: "이용 시 주의 사항",
+    confirmMessage: "네, 대여할게요",
+  },
+  [CabinetStatus.SET_EXPIRE_FULL]: {
+    type: "error",
+    title: "이미 사용 중인 사물함입니다",
+    confirmMessage: "",
+  },
+  [CabinetStatus.SET_EXPIRE_AVAILABLE]: {
+    type: "confirm",
+    title: "이용 시 주의 사항",
+    confirmMessage: "네, 대여할게요",
+  },
+  [CabinetStatus.EXPIRED]: {
+    type: "error",
+    title: `반납이 지연되고 있어\n현재 대여가 불가합니다`,
+    confirmMessage: "",
+  },
+  [CabinetStatus.BROKEN]: {
+    type: "error",
+    title: "사용이 불가한 사물함입니다",
+    confirmMessage: "",
+  },
+  [CabinetStatus.BANNED]: {
+    type: "error",
+    title: "사용이 불가한 사물함입니다",
+    confirmMessage: "",
+  },
+  return: {
+    type: "confirm",
+    title: "사물함 반납하기",
+    confirmMessage: "네, 반납할게요",
+  },
+};
+
+export const cabinetFilterMap = {
+  [CabinetStatus.AVAILABLE]: "brightness(100)",
+  [CabinetStatus.SET_EXPIRE_FULL]: "none",
+  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "brightness(100)",
+  [CabinetStatus.EXPIRED]: "brightness(100)",
+  [CabinetStatus.BROKEN]: "brightness(100)",
+  [CabinetStatus.BANNED]: "brightness(100)",
+};


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>기존에 캐비넷 상태에 따라 달라지던 modalProps를 json형태로 밖으로 maps.ts에 빼서 필요한 컴포넌트에서 import해오는 방식으로 바꾸었습니다. 또 대여, 반납 api호출을 담당하는 함수를 ModalContainer.tsx에서 빼내서 Modal.tsx에서 담당하게 하였고 모달 컨테이너에 전달하는 프롭스 구조를 간략화 하여 static한 정보만 담을 수 있게하여 재사용성을 높였습니다. 

closes #763 