### PR TITLE
[FE] BUG: 사파리에서 메모 수정하기 버튼이 잘려보이는 이슈 해결 #771

### DIFF
--- a/frontend_v4/src/containers/MemoModalContainer.tsx
+++ b/frontend_v4/src/containers/MemoModalContainer.tsx
@@ -173,10 +173,8 @@ const BackgroundStyled = styled.div`
 const WriteModeButtonStyled = styled.button<{ mode: string }>`
   display: ${({ mode }) => (mode === "read" ? "block" : "none")};
   position: absolute;
-  left: 74.44%;
-  right: 11.11%;
-  top: 8%;
-  bottom: 88.6%;
+  right: 40px;
+  padding: 0;
   font-style: normal;
   font-weight: 400;
   font-size: 14px;

--- a/frontend_v4/src/index.css
+++ b/frontend_v4/src/index.css
@@ -106,6 +106,7 @@ input {
   font-size: 1rem;
   outline: none;
   background: none;
+  box-sizing: border-box;
 }
 
 .modal {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>수정하기 버튼이 `position: absolute`로 적용되어 있었는데 `top, left, right, bottom`이 동시에 프로퍼티로 들어가 있어서 사파리에서 반정도 잘려 보였습니다. right:40px로 줘서 해결하였습니다. 
>추가로 input태그에 기본 패딩이 적용되어 있어 input태그에 대한 글로벌 스타일로 `box-sizing:border-box;`로 설정해주었습니다. 
closes #771 
