### PR TITLE
[FE] FEAT: 이미 대여 중일 때 대여 버튼 클릭 방지, gray 테마 버튼 추가 #760

### DIFF
--- a/frontend_v4/src/components/CabinetInfoArea.tsx
+++ b/frontend_v4/src/components/CabinetInfoArea.tsx
@@ -120,6 +120,7 @@ const CabinetInfoArea = (): JSX.Element => {
   return (
     <CabinetInfoAreaContainer
       selectedCabinetInfo={cabinetViewData}
+      alreadyLent={!!myCabinetInfo}
       closeCabinet={handleCancle}
     />
   );

--- a/frontend_v4/src/containers/ButtonContainer.tsx
+++ b/frontend_v4/src/containers/ButtonContainer.tsx
@@ -5,11 +5,16 @@ interface ButtonInterface {
   onClick(event: React.MouseEvent<HTMLButtonElement>): void;
   text: string;
   theme: string;
+  disabled?: boolean;
 }
 
 const ButtonContainer = (props: ButtonInterface) => {
   return (
-    <ButtonContainerStyled onClick={props.onClick} theme={props.theme}>
+    <ButtonContainerStyled
+      onClick={props.onClick}
+      theme={props.theme}
+      disabled={props.disabled}
+    >
       {props.text}
     </ButtonContainerStyled>
   );
@@ -23,6 +28,9 @@ const ButtonContainerStyled = styled.button`
   align-items: center;
   border-radius: 10px;
   margin-bottom: 15px;
+  &:disabled {
+    cursor: not-allowed;
+  }
   &:last-child {
     margin-bottom: 0;
   }
@@ -40,11 +48,18 @@ const ButtonContainerStyled = styled.button`
       border: 1px solid var(--main-color);
     `}
   ${(props) =>
-    props.theme === "grayLine" &&
+    props.theme === "lightGrayLine" &&
     css`
       background: var(--white);
       color: var(--line-color);
       border: 1px solid var(--line-color);
+    `}
+  ${(props) =>
+    props.theme === "grayLine" &&
+    css`
+      background: var(--white);
+      color: var(--gray-color);
+      border: 1px solid var(--gray-color);
     `}
 `;
 

--- a/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
+++ b/frontend_v4/src/containers/CabinetInfoAreaContainer.tsx
@@ -28,9 +28,10 @@ export interface ISelectedCabinetInfo {
 
 const CabinetInfoAreaContainer: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
+  alreadyLent: boolean;
   closeCabinet: () => void;
 }> = (props) => {
-  const { selectedCabinetInfo, closeCabinet } = props;
+  const { selectedCabinetInfo, alreadyLent, closeCabinet } = props;
   const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
 
@@ -99,7 +100,8 @@ const CabinetInfoAreaContainer: React.FC<{
             <ButtonContainer
               onClick={handleOpenReturnModal}
               text="대여"
-              theme="fill"
+              theme={alreadyLent ? "lightGrayLine" : "fill"}
+              disabled={alreadyLent}
             />
             <ButtonContainer onClick={closeCabinet} text="취소" theme="line" />
           </>

--- a/frontend_v4/src/containers/MemoModalContainer.tsx
+++ b/frontend_v4/src/containers/MemoModalContainer.tsx
@@ -94,7 +94,7 @@ const MemoModalContainer = ({
                   }
             }
             text={mode === "read" ? "닫기" : "취소"}
-            theme={mode === "read" ? "grayLine" : "line"}
+            theme={mode === "read" ? "lightGrayLine" : "line"}
           />
         </ButtonWrapperStyled>
       </ModalContainerStyled>


### PR DESCRIPTION
## Issue
- #760

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
대여 중일 때 대여 버튼을 disabled 처리 했습니다.
gray-color가 추가됨에 따라 버튼도 grayLine을 추가하고 기존 grayLine을 lightGrayLine으로 변경했습니다.
disabled -> lightGrayLine, 클릭 가능 -> grayLine 으로 적용했습니다.
