### PR TITLE
[FE] FIX: 페이지네이션 바 z-index 1로 조정, 우측 구역 9로 복구 #782

### DIFF
--- a/frontend_v4/src/containers/MapInfoContainer.tsx
+++ b/frontend_v4/src/containers/MapInfoContainer.tsx
@@ -48,7 +48,7 @@ const MapInfoContainerStyled = styled.div`
   min-width: 330px;
   width: 330px;
   height: calc(100% - 80px);
-  z-index: 10;
+  z-index: 9;
   transform: translateX(120%);
   transition: transform 0.3s ease-in-out;
   box-shadow: 0 0 40px 0 var(--bg-shadow);

--- a/frontend_v4/src/containers/SectionPaginationContainer.tsx
+++ b/frontend_v4/src/containers/SectionPaginationContainer.tsx
@@ -56,7 +56,7 @@ const SectionPaginationStyled = styled.div`
   position: sticky;
   top: 0;
   background: rgba(255, 255, 255, 0.95);
-  z-index: 10;
+  z-index: 1;
 `;
 
 const SectionBarStyled = styled.div`


### PR DESCRIPTION
## Issue
- #782 

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.
모바일에서 동일한 문제가 생겨서 페이지네이션 바의 z-index를 1로 조정했습니다.
우측 구역은 다시 9로 복구했습니다.
