### PR TITLE
[FE] BUG: 맵에서 다른 층의 섹션을 선택했을 때의 버그 수정 #765

### DIFF
--- a/frontend_v4/src/components/Modal.tsx
+++ b/frontend_v4/src/components/Modal.tsx
@@ -8,7 +8,7 @@ import ModalContainer from "@/containers/ModalContainer";
 import { ModalInterface } from "@/containers/ModalContainer";
 import {
   currentCabinetIdState,
-  isMyCabinetIdChangedState,
+  isCurrentSectionRenderState,
   myCabinetInfoState,
   targetCabinetInfoState,
   userState,
@@ -28,7 +28,9 @@ const Modal = (props: {
   const [targetCabinetInfo, setTargetCabinetInfo] = useRecoilState(
     targetCabinetInfoState
   );
-  const setIsMyCabinetIdChanged = useSetRecoilState(isMyCabinetIdChangedState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
   let expireDate = new Date();
   const addDays = targetCabinetInfo?.lent_type === "SHARE" ? 41 : 20;
   expireDate.setDate(expireDate.getDate() + addDays);
@@ -59,7 +61,7 @@ const Modal = (props: {
       await axiosLentId(currentCabinetId);
       //userCabinetId 세팅
       setMyInfo({ ...myInfo, cabinet_id: currentCabinetId });
-      setIsMyCabinetIdChanged(true);
+      setIsCurrentSectionRender(true);
 
       // 캐비닛 상세정보 바꾸는 곳
       try {
@@ -87,7 +89,7 @@ const Modal = (props: {
       await axiosReturn();
       //userCabinetId 세팅
       setMyInfo({ ...myInfo, cabinet_id: -1 });
-      setIsMyCabinetIdChanged(true);
+      setIsCurrentSectionRender(true);
       // 캐비닛 상세정보 바꾸는 곳
       try {
         const { data } = await axiosCabinetById(currentCabinetId);

--- a/frontend_v4/src/containers/LeftNavContainer.tsx
+++ b/frontend_v4/src/containers/LeftNavContainer.tsx
@@ -13,7 +13,7 @@ import {
   currentSectionNameState,
   currentLocationNameState,
   userState,
-  isMyCabinetIdChangedState,
+  isCurrentSectionRenderState,
 } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
 import { axiosCabinetByLocationFloor } from "@/api/axios/axios.custom";
@@ -41,8 +41,8 @@ const LeftNavContainer = () => {
   const navigator = useNavigate();
   const { pathname } = useLocation();
   const isMount = useIsMount();
-  const [isMyCabinetIdChanged, setIsMyCabinetIdChanged] = useRecoilState(
-    isMyCabinetIdChangedState
+  const [isCurrentSectionRender, setIsCurrentSectionRender] = useRecoilState(
+    isCurrentSectionRenderState
   );
 
   useEffect(() => {
@@ -50,7 +50,7 @@ const LeftNavContainer = () => {
     axiosCabinetByLocationFloor(currentLocation, currentFloor)
       .then((response) => {
         setCurrentFloorData(response.data);
-        if (isMount || isMyCabinetIdChanged) {
+        if (isMount || isCurrentSectionRender) {
           const recoilPersist = localStorage.getItem("recoil-persist");
           let recoilPersistObj;
           if (recoilPersist) recoilPersistObj = JSON.parse(recoilPersist);
@@ -59,7 +59,7 @@ const LeftNavContainer = () => {
               ? recoilPersistObj.CurrentSection
               : response.data[0].section
           );
-          setIsMyCabinetIdChanged(false);
+          setIsCurrentSectionRender(false);
         } else {
           setCurrentSection(response.data[0].section);
         }

--- a/frontend_v4/src/containers/MapGridContainer.tsx
+++ b/frontend_v4/src/containers/MapGridContainer.tsx
@@ -1,6 +1,7 @@
 import {
   currentFloorNumberState,
   currentSectionNameState,
+  isCurrentSectionRenderState,
 } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
 import React from "react";
@@ -172,7 +173,12 @@ interface IFloorMapInfo {
 
 const MapGridContainer = ({ floor }: { floor: number }) => {
   const setSection = useSetRecoilState(currentSectionNameState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+
   const selectSection = (section: string) => {
+    setIsCurrentSectionRender(true);
     setSection(section);
   };
   return (

--- a/frontend_v4/src/recoil/atoms.ts
+++ b/frontend_v4/src/recoil/atoms.ts
@@ -85,7 +85,7 @@ export const locationColNumState = atom<ILocationColNum[]>({
   default: staticColNumData,
 });
 
-export const isMyCabinetIdChangedState = atom<boolean>({
-  key: "isMyCabinetIdChanged",
+export const isCurrentSectionRenderState = atom<boolean>({
+  key: "isCurrentSectionRender",
   default: false,
 });


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

맵에서 다른 층의 섹션을 클릭했을 때, 해당 섹션으로 가기위해서 플래그가 필요했습니다.
이전의 비슷한 사유로 만든 `isMyCabinetIdChanged` recoil state와 같은 역할이 필요해서 
`isMyCabinetIdChanged` -> `isCurrentSectionRenderState` 로 이름을 바꿔서 처리했습니다.

Closes #765 