### PR TITLE
[BE] 42AuthGuard에 kr 이메일 주소를 갖는 카뎃만 토큰 발급하도록 기능 추가 #738

### DIFF
--- a/backend/src/admin/cabinet/cabinet.controller.ts
+++ b/backend/src/admin/cabinet/cabinet.controller.ts
@@ -25,7 +25,6 @@ import { CabinetInfoService } from 'src/cabinet/cabinet.info.service';
 import CabinetStatusType from 'src/enums/cabinet.status.type.enum';
 import LentType from 'src/enums/lent.type.enum';
 import { AdminJwtAuthGuard } from '../auth/jwt/guard/jwtauth.guard';
-import { CabinetFloorDto } from '../dto/cabinet.floor.dto';
 import { CabinetInfoResponseDto } from '../dto/cabinet.info.response.dto';
 import { CabinetStatusNoteRequestDto } from '../dto/cabinet.status.note.request.dto';
 import { AdminCabinetService } from './cabinet.service';

--- a/backend/src/auth/42/ft.strategy.ts
+++ b/backend/src/auth/42/ft.strategy.ts
@@ -36,7 +36,8 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
    * cb(null, user); 콜백함수는 res 객체의 user라는 필드로 user의 객체를 넘깁니다.
    */
   async validate(req, access_token, refreshToken, profile, cb) {
-    if (!profile.staff && !profile.cursus_users[1]) {
+    if (!profile.staff && !profile.cursus_users[1] ||
+        profile.email.split('.')[2] !== 'kr') {
       cb(null, undefined);
     }
     let blackholed_at: Date;

--- a/backend/src/auth/42/guard/ft.guard.ts
+++ b/backend/src/auth/42/guard/ft.guard.ts
@@ -1,8 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
-/**
- * passport-42의 기본 인증을 사용합니다. 현재는 커스텀이 불필요하므로 커스텀하지 않습니다.
- */
 @Injectable()
-export class FtGuard extends AuthGuard('42') {}
+export class FtGuard extends AuthGuard('42') {
+    handleRequest<TUser = any>(err: any, user: any): TUser {
+        if (err || !user) {
+          throw (
+            err ||
+            new UnauthorizedException(
+              '🚨 Cabi service is only available in Korea🥲 🚨\nif you need any information, contact us with slack link below\nhttps://42born2code.slack.com/archives/C02V6GE8LD7.',
+            )
+          );
+        }
+        return user;
+      }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>중대한 사항이라면 상세히 적어주세요.

https://github.com/innovationacademy-kr/42cabi/issues/738
에서 제기해주셨던 이슈에 맞춰서 42 패스포트를 통해서 profile에 적힌 이메일의 끝 주소가 kr 인지 판별하는 방식으로
외국 카뎃이 토큰을 발급받지 못하도록 기능을 추가하였습니다!
