### PR TITLE
[FE] FIX: mapInfo 폴더의 컴포넌트, 데이터 분리 및 CSS 조정 #805

### DIFF
--- a/frontend/src/assets/data/mapPositionData.ts
+++ b/frontend/src/assets/data/mapPositionData.ts
@@ -1,0 +1,161 @@
+/*
+    클러스터 사물함 위치 더미 데이터
+    grid col : 가로 , grid row : 세로
+
+    colStart : grid 가로 시작 위치 1부터 시작
+    colEnd   : grid 가로 마지막 위치
+    rowStart : grid 세로 시작 위치 2부터 시작
+    rowEnd   : grid 세로 마지막 위치
+    name     : 사물함 이름 정보
+    type     : 사물함과 엘레베이터 타입 구분자
+*/
+
+export interface ISectionInfo {
+  rowStart: number;
+  rowEnd: number;
+  colStart: number;
+  colEnd: number;
+  name: string;
+  type: string;
+}
+
+export interface IFloorSectionsInfo {
+  [index: string]: ISectionInfo[];
+}
+
+export const mapPostionData: IFloorSectionsInfo = {
+  "2": [
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 1,
+      rowEnd: 2,
+      name: "End of Cluster 2",
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 3,
+      rowEnd: 4,
+      name: `Oasis`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 2,
+      rowStart: 4,
+      rowEnd: 5,
+      name: `E/V`,
+      type: "elevator",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 6,
+      rowEnd: 7,
+      name: "Cluster 1 - OA",
+      type: "cabinet",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 8,
+      rowEnd: 9,
+      name: `End of Cluster 1`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 2,
+      rowStart: 6,
+      rowEnd: 9,
+      name: "Cluster 1 - Terrace",
+      type: "cabinet",
+    },
+  ],
+  "4": [
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 1,
+      rowEnd: 2,
+      name: `End of Cluster 4`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 3,
+      rowEnd: 4,
+      name: `Oasis`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 2,
+      rowStart: 4,
+      rowEnd: 5,
+      name: `E/V`,
+      type: "elevator",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 6,
+      rowEnd: 7,
+      name: `Cluster 3 - OA`,
+      type: "cabinet",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 8,
+      rowEnd: 9,
+      name: `End of Cluster 3`,
+      type: "cabinet",
+    },
+  ],
+  "5": [
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 1,
+      rowEnd: 2,
+      name: `End of Cluster 6`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 3,
+      rowStart: 3,
+      rowEnd: 4,
+      name: `Oasis`,
+      type: "cabinet",
+    },
+    {
+      colStart: 1,
+      colEnd: 2,
+      rowStart: 4,
+      rowEnd: 5,
+      name: `E/V`,
+      type: "elevator",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 6,
+      rowEnd: 7,
+      name: "Cluster 5 - OA",
+      type: "cabinet",
+    },
+    {
+      colStart: 4,
+      colEnd: 6,
+      rowStart: 8,
+      rowEnd: 9,
+      name: "End of Cluster 5",
+      type: "cabinet",
+    },
+  ],
+};

--- a/frontend/src/components/MapInfo/MapFloorSelect/MapFloorSelect.tsx
+++ b/frontend/src/components/MapInfo/MapFloorSelect/MapFloorSelect.tsx
@@ -44,7 +44,7 @@ const MapFloorSelect = ({ floor, setFloor, floorInfo }: IMapFloorSelect) => {
 
 const OptionStyled = styled.div`
   width: 65px;
-  height: 35px;
+  height: 40px;
   border-bottom: 1px solid #e6e6e6;
   display: flex;
   justify-content: center;
@@ -60,11 +60,11 @@ const CurrentFloorStyled = styled.div`
   color: white;
   cursor: pointer;
   width: 65px;
-  height: 35px;
-  line-height: 35px;
+  height: 40px;
+  line-height: 40px;
   text-indent: 12px;
   border-radius: 10px;
-  margin-bottom: 50px;
+  margin: 30px 0;
   &:hover {
     opacity: 0.9;
   }
@@ -73,7 +73,7 @@ const CurrentFloorStyled = styled.div`
 const OptionsContainerStyled = styled.div`
   position: absolute;
   left: 0;
-  top: 40px;
+  top: 75px;
   background: white;
   border-radius: 10px;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);

--- a/frontend/src/components/MapInfo/MapFloorSelect/MapFloorSelect.tsx
+++ b/frontend/src/components/MapInfo/MapFloorSelect/MapFloorSelect.tsx
@@ -1,25 +1,11 @@
 import styled from "styled-components";
+import MapFloorSelectOption from "@/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption";
 
 interface IMapFloorSelect {
   floor: number;
   setFloor: React.Dispatch<React.SetStateAction<number>>;
   floorInfo: number[];
 }
-
-const OptionsContainer: React.FC<{
-  selectFloor: Function;
-  floorInfo: number[];
-}> = ({ floorInfo, selectFloor }) => {
-  return (
-    <OptionsContainerStyled id="mapFloorOptionBox">
-      {floorInfo.map((info, idx) => (
-        <OptionStyled onClick={() => selectFloor(info)} key={idx}>
-          {info}층
-        </OptionStyled>
-      ))}
-    </OptionsContainerStyled>
-  );
-};
 
 const MapFloorSelect = ({ floor, setFloor, floorInfo }: IMapFloorSelect) => {
   const onClickFloorOption = () => {
@@ -34,27 +20,15 @@ const MapFloorSelect = ({ floor, setFloor, floorInfo }: IMapFloorSelect) => {
 
   return (
     <div style={{ position: "relative" }}>
-      <CurrentFloorStyled onClick={onClickFloorOption}>
+      <MapFloorSelectStyled onClick={onClickFloorOption}>
         {`${floor}층`}
-      </CurrentFloorStyled>
-      <OptionsContainer selectFloor={selectFloor} floorInfo={floorInfo} />
+      </MapFloorSelectStyled>
+      <MapFloorSelectOption selectFloor={selectFloor} floorInfo={floorInfo} />
     </div>
   );
 };
 
-const OptionStyled = styled.div`
-  width: 65px;
-  height: 40px;
-  border-bottom: 1px solid #e6e6e6;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: var(--white);
-  color: black;
-  cursor: pointer;
-`;
-
-const CurrentFloorStyled = styled.div`
+const MapFloorSelectStyled = styled.div`
   background: url("src/assets/images/select.svg") var(--main-color) no-repeat
     80% 55%;
   color: white;
@@ -67,21 +41,6 @@ const CurrentFloorStyled = styled.div`
   margin: 30px 0;
   &:hover {
     opacity: 0.9;
-  }
-`;
-
-const OptionsContainerStyled = styled.div`
-  position: absolute;
-  left: 0;
-  top: 75px;
-  background: white;
-  border-radius: 10px;
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
-  overflow: hidden;
-  z-index: 99;
-  display: none;
-  &.on {
-    display: block;
   }
 `;
 

--- a/frontend/src/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
+++ b/frontend/src/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+
+const MapFloorSelectOption: React.FC<{
+  selectFloor: Function;
+  floorInfo: number[];
+}> = ({ floorInfo, selectFloor }) => {
+  return (
+    <OptionWrapperStyled id="mapFloorOptionBox">
+      {floorInfo.map((info, idx) => (
+        <OptionStyled onClick={() => selectFloor(info)} key={idx}>
+          {info}층
+        </OptionStyled>
+      ))}
+    </OptionWrapperStyled>
+  );
+};
+
+const OptionWrapperStyled = styled.div`
+  position: absolute;
+  left: 0;
+  top: 75px;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  z-index: 99;
+  display: none;
+  &.on {
+    display: block;
+  }
+`;
+
+const OptionStyled = styled.div`
+  width: 65px;
+  height: 40px;
+  border-bottom: 1px solid #e6e6e6;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--white);
+  color: black;
+  cursor: pointer;
+`;
+
+export default MapFloorSelectOption;

--- a/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
+++ b/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
@@ -9,167 +9,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import useDetailInfo from "@/hooks/useDetailInfo";
-
-/*
-    클러스터 사물함 위치 더미 데이터
-    grid col : 가로 , grid row : 세로
-
-    colStart : grid 가로 시작 위치 1부터 시작
-    colEnd   : grid 가로 마지막 위치
-    rowStart : grid 세로 시작 위치 2부터 시작
-    rowEnd   : grid 세로 마지막 위치
-    name     : 사물함 이름 정보
-    type     : 사물함과 엘레베이터 타입 구분자
-*/
-
-interface IFloorSectionInfo {
-  [index: string]: IFloorMapInfo[];
-}
-const data: IFloorSectionInfo = {
-  "2": [
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 1,
-      rowEnd: 2,
-      name: "End of Cluster 2",
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 3,
-      rowEnd: 4,
-      name: `Oasis`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 2,
-      rowStart: 4,
-      rowEnd: 5,
-      name: `E/V`,
-      type: "elevator",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 6,
-      rowEnd: 7,
-      name: "Cluster 1 - OA",
-      type: "cabinet",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 8,
-      rowEnd: 9,
-      name: `End of Cluster 1`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 2,
-      rowStart: 6,
-      rowEnd: 9,
-      name: "Cluster 1 - Terrace",
-      type: "cabinet",
-    },
-  ],
-  "4": [
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 1,
-      rowEnd: 2,
-      name: `End of Cluster 4`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 3,
-      rowEnd: 4,
-      name: `Oasis`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 2,
-      rowStart: 4,
-      rowEnd: 5,
-      name: `E/V`,
-      type: "elevator",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 6,
-      rowEnd: 7,
-      name: `Cluster 3 - OA`,
-      type: "cabinet",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 8,
-      rowEnd: 9,
-      name: `End of Cluster 3`,
-      type: "cabinet",
-    },
-  ],
-  "5": [
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 1,
-      rowEnd: 2,
-      name: `End of Cluster 6`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 3,
-      rowStart: 3,
-      rowEnd: 4,
-      name: `Oasis`,
-      type: "cabinet",
-    },
-    {
-      colStart: 1,
-      colEnd: 2,
-      rowStart: 4,
-      rowEnd: 5,
-      name: `E/V`,
-      type: "elevator",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 6,
-      rowEnd: 7,
-      name: "Cluster 5 - OA",
-      type: "cabinet",
-    },
-    {
-      colStart: 4,
-      colEnd: 6,
-      rowStart: 8,
-      rowEnd: 9,
-      name: "End of Cluster 5",
-      type: "cabinet",
-    },
-  ],
-};
-
-interface IFloorMapInfo {
-  rowStart: number;
-  rowEnd: number;
-  colStart: number;
-  colEnd: number;
-  name: string;
-  type: string;
-}
+import { ISectionInfo, mapPostionData } from "@/assets/data/mapPositionData";
 
 const MapGrid = ({ floor }: { floor: number }) => {
   const setSection = useSetRecoilState(currentSectionNameState);
@@ -184,7 +24,7 @@ const MapGrid = ({ floor }: { floor: number }) => {
   return (
     <MapGridStyled>
       {floor &&
-        data[floor].map((value: any, idx: any) => (
+        mapPostionData[floor].map((value: any, idx: any) => (
           <MapItem
             key={idx}
             floor={floor}
@@ -198,7 +38,7 @@ const MapGrid = ({ floor }: { floor: number }) => {
 
 const MapItem: React.FC<{
   floor: number;
-  info: IFloorMapInfo;
+  info: ISectionInfo;
   selectSection: Function;
 }> = ({ floor, info, selectSection }) => {
   const navigate = useNavigate();
@@ -221,7 +61,7 @@ const MapItem: React.FC<{
 
 const ItemStyled = styled.div<{
   onClick: React.MouseEventHandler;
-  info: IFloorMapInfo;
+  info: ISectionInfo;
 }>`
   font-size: 0.8rem;
   cursor: pointer;

--- a/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
+++ b/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
@@ -1,22 +1,17 @@
+import styled from "styled-components";
+import { useSetRecoilState } from "recoil";
 import {
-  currentFloorNumberState,
   currentSectionNameState,
   isCurrentSectionRenderState,
 } from "@/recoil/atoms";
-import { currentLocationFloorState } from "@/recoil/selectors";
-import React from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { useRecoilValue, useSetRecoilState } from "recoil";
-import styled from "styled-components";
-import useDetailInfo from "@/hooks/useDetailInfo";
-import { ISectionInfo, mapPostionData } from "@/assets/data/mapPositionData";
+import { mapPostionData } from "@/assets/data/mapPositionData";
+import MapItem from "@/components/MapInfo/MapItem/MapItem";
 
 const MapGrid = ({ floor }: { floor: number }) => {
   const setSection = useSetRecoilState(currentSectionNameState);
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
   );
-
   const selectSection = (section: string) => {
     setIsCurrentSectionRender(true);
     setSection(section);
@@ -35,52 +30,6 @@ const MapGrid = ({ floor }: { floor: number }) => {
     </MapGridStyled>
   );
 };
-
-const MapItem: React.FC<{
-  floor: number;
-  info: ISectionInfo;
-  selectSection: Function;
-}> = ({ floor, info, selectSection }) => {
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
-  const setCurrentFloor = useSetRecoilState(currentFloorNumberState);
-  const floors = useRecoilValue<Array<number>>(currentLocationFloorState);
-  const { closeMap } = useDetailInfo();
-  const onClick = () => {
-    if (pathname === "/home") navigate("/main");
-    setCurrentFloor(floor ? floor : floors[0]);
-    selectSection(info.name);
-    closeMap();
-  };
-  return (
-    <ItemStyled onClick={onClick} info={info}>
-      {info.name}
-    </ItemStyled>
-  );
-};
-
-const ItemStyled = styled.div<{
-  onClick: React.MouseEventHandler;
-  info: ISectionInfo;
-}>`
-  font-size: 0.8rem;
-  cursor: pointer;
-  color: white;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 10px;
-  letter-spacing: -0.05rem;
-  grid-column-start: ${({ info }) => info.colStart};
-  grid-column-end: ${({ info }) => info.colEnd};
-  grid-row-start: ${({ info }) => info.rowStart};
-  grid-row-end: ${({ info }) => info.rowEnd};
-  background: ${({ info }) =>
-    info.type === "cabinet" ? "#9747ff" : "#bcb9b9"};
-  &:hover {
-    opacity: ${({ info }) => (info.type === "cabinet" ? 0.9 : 1)};
-  }
-`;
 
 const MapGridStyled = styled.div`
   width: 100%;

--- a/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
+++ b/frontend/src/components/MapInfo/MapGrid/MapGrid.tsx
@@ -243,9 +243,9 @@ const ItemStyled = styled.div<{
 `;
 
 const MapGridStyled = styled.div`
-  width: 80%;
+  width: 100%;
   max-height: 580px;
-  height: 65%;
+  height: 100%;
   background: #e7e7e7;
   display: grid;
   grid-template-columns: repeat(5, 1fr);

--- a/frontend/src/components/MapInfo/MapInfo.tsx
+++ b/frontend/src/components/MapInfo/MapInfo.tsx
@@ -36,7 +36,6 @@ const HeaderStyled = styled.div`
   justify-content: space-between;
   width: 100%;
   align-items: center;
-  padding: 40px 20px 40px 40px;
   color: black;
   font-weight: bold;
 `;
@@ -48,6 +47,7 @@ const MapInfoContainerStyled = styled.div`
   min-width: 330px;
   width: 330px;
   height: calc(100% - 80px);
+  padding: 40px;
   z-index: 9;
   transform: translateX(120%);
   transition: transform 0.3s ease-in-out;

--- a/frontend/src/components/MapInfo/MapItem/MapItem.tsx
+++ b/frontend/src/components/MapInfo/MapItem/MapItem.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { currentLocationFloorState } from "@/recoil/selectors";
+import { currentFloorNumberState } from "@/recoil/atoms";
+import { ISectionInfo } from "@/assets/data/mapPositionData";
+import useDetailInfo from "@/hooks/useDetailInfo";
+
+const MapItem: React.FC<{
+  floor: number;
+  info: ISectionInfo;
+  selectSection: Function;
+}> = ({ floor, info, selectSection }) => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const setCurrentFloor = useSetRecoilState(currentFloorNumberState);
+  const floors = useRecoilValue<Array<number>>(currentLocationFloorState);
+  const { closeMap } = useDetailInfo();
+  const onClick = () => {
+    if (pathname === "/home") navigate("/main");
+    setCurrentFloor(floor ? floor : floors[0]);
+    selectSection(info.name);
+    closeMap();
+  };
+  return (
+    <ItemStyled onClick={onClick} info={info}>
+      {info.name}
+    </ItemStyled>
+  );
+};
+
+const ItemStyled = styled.div<{
+  onClick: React.MouseEventHandler;
+  info: ISectionInfo;
+}>`
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 10px;
+  letter-spacing: -0.05rem;
+  grid-column-start: ${({ info }) => info.colStart};
+  grid-column-end: ${({ info }) => info.colEnd};
+  grid-row-start: ${({ info }) => info.rowStart};
+  grid-row-end: ${({ info }) => info.rowEnd};
+  background: ${({ info }) =>
+    info.type === "cabinet" ? "#9747ff" : "#bcb9b9"};
+  &:hover {
+    opacity: ${({ info }) => (info.type === "cabinet" ? 0.9 : 1)};
+  }
+`;
+
+export default MapItem;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/805

### 작업 내용
- 한 파일에 있던 여러 컴포넌트들 분리
- 모바일 맞춤을 위한 CSS 조정
- 섹션위치 데이터 별도로 파일 분리

Closes #805 