### PR TITLE
[FE] 제목 없는 공유 사물함 메모 모달에서 제목 박스가 안보이던 버그 수정 #809

### DIFF
--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -36,7 +36,7 @@ const MemoModal = ({
   const handleClickSave = (e: React.MouseEvent) => {
     //사물함 제목, 사물함 비밀메모 update api 호출
     // onClose(e);
-    if (newTitle) {
+    if (newTitle.current!.value) {
       onSave(newTitle.current!.value, newMemo.current!.value);
     } else {
       onSave(null, newMemo.current!.value);

--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -36,7 +36,7 @@ const MemoModal = ({
   const handleClickSave = (e: React.MouseEvent) => {
     //사물함 제목, 사물함 비밀메모 update api 호출
     // onClose(e);
-    if (cabinetTitle) {
+    if (newTitle) {
       onSave(newTitle.current!.value, newMemo.current!.value);
     } else {
       onSave(null, newMemo.current!.value);
@@ -55,18 +55,17 @@ const MemoModal = ({
           <ContentItemSectionStyled>
             <ContentItemWrapperStyled isVisible={cabinetType !== "PRIVATE"}>
               <ContentItemTitleStyled>사물함 이름</ContentItemTitleStyled>
-              {cabinetTitle && (
-                <ContentItemInputStyled
-                  placeholder={cabinetTitle}
-                  mode={mode}
-                  defaultValue={cabinetTitle}
-                  readOnly={mode === "read" ? true : false}
-                  ref={newTitle}
-                  onFocus={(e) => {
-                    e.currentTarget.select();
-                  }}
-                />
-              )}
+
+              <ContentItemInputStyled
+                placeholder={cabinetTitle ? cabinetTitle : ""}
+                mode={mode}
+                defaultValue={cabinetTitle ? cabinetTitle : ""}
+                readOnly={mode === "read" ? true : false}
+                ref={newTitle}
+                onFocus={(e) => {
+                  e.currentTarget.select();
+                }}
+              />
             </ContentItemWrapperStyled>
             <ContentItemWrapperStyled isVisible={true}>
               <ContentItemTitleStyled>비밀 메모</ContentItemTitleStyled>

--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -36,7 +36,7 @@ const MemoModal = ({
   const handleClickSave = (e: React.MouseEvent) => {
     //사물함 제목, 사물함 비밀메모 update api 호출
     // onClose(e);
-    if (newTitle.current!.value) {
+    if (cabinetType === "SHARE" && newTitle.current!.value) {
       onSave(newTitle.current!.value, newMemo.current!.value);
     } else {
       onSave(null, newMemo.current!.value);

--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -14,7 +14,7 @@ interface MemoModalContainerInterface {
   onClose: React.MouseEventHandler;
   onSave: (newTitle: string | null, newMemo: string) => void;
 }
-const MemoModalContainer = ({
+const MemoModal = ({
   memoModalObj,
   onClose,
   onSave,
@@ -220,4 +220,4 @@ const ButtonWrapperStyled = styled.div<{ mode: string }>`
   }
 `;
 
-export default MemoModalContainer;
+export default MemoModal;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738
제목없는 공유 사물함의 메모 관리 모달에서 제목이 null일 때 제목 박스가 아예 안보이던 버그를 수정하였습니다. 
https://github.com/innovationacademy-kr/42cabi/issues/809
closes #809 
