### PR TITLE
[BE] FEAT: 서울 카뎃만 42 인증이 가능하게끔 기능 및 문구 추가 #738

### DIFF
--- a/backend/src/auth/42/ft.strategy.ts
+++ b/backend/src/auth/42/ft.strategy.ts
@@ -36,8 +36,9 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
    * cb(null, user); 콜백함수는 res 객체의 user라는 필드로 user의 객체를 넘깁니다.
    */
   async validate(req, access_token, refreshToken, profile, cb) {
+    const userEmail = profile.email.split('.');
     if (!profile.staff && !profile.cursus_users[1] ||
-        profile.email.split('.')[2] !== 'kr') {
+        userEmail[userEmail.length - 1] !== 'kr') {
       cb(null, undefined);
     }
     let blackholed_at: Date;

--- a/backend/src/auth/42/ft.strategy.ts
+++ b/backend/src/auth/42/ft.strategy.ts
@@ -36,7 +36,8 @@ export class FtStrategy extends PassportStrategy(Strategy, '42') {
    * cb(null, user); 콜백함수는 res 객체의 user라는 필드로 user의 객체를 넘깁니다.
    */
   async validate(req, access_token, refreshToken, profile, cb) {
-    if (!profile.staff && !profile.cursus_users[1]) {
+    if (!profile.staff && !profile.cursus_users[1] ||
+        profile.email.split('.')[2] !== 'kr') {
       cb(null, undefined);
     }
     let blackholed_at: Date;

--- a/backend/src/auth/42/guard/ft.guard.ts
+++ b/backend/src/auth/42/guard/ft.guard.ts
@@ -1,8 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 /**
  * passport-42의 기본 인증을 사용합니다. 현재는 커스텀이 불필요하므로 커스텀하지 않습니다.
  */
 @Injectable()
-export class FtGuard extends AuthGuard('42') {}
+export class FtGuard extends AuthGuard('42') {
+    handleRequest<TUser = any>(err: any, user: any): TUser {
+        if (err || !user) {
+          throw (
+            err ||
+            new UnauthorizedException(
+              'Sorry 🥲 Cabi only services in korea.\nfeel free to contact us in slack : #42seoul_club_cabinet',
+            )
+          );
+        }
+        return user;
+      }
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/738

다른 지역의 카뎃이 캐비닛을 대여하는 상황이 발생하여, 서울 카뎃만 인증이 가능하게끔 email의 끝자리('kr')을 기준으로 인증하는 로직을 추가하였고, 인증이 안 되었을시에 (다른 나라의 카뎃인 경우에) 인증에러 문구를 추가하였습니다.