### PR TITLE
[FE] FIX: 모바일 섹션 스와이프 기능 파일 위치 수정 #796

### DIFF
--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Outlet } from "react-router";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { userState } from "@/recoil/atoms";
 import TopNav from "@/components/TopNav/TopNav.container";
 import LeftNav from "@/components/LeftNav/LeftNav";
@@ -12,8 +12,6 @@ import { UserDto } from "@/types/dto/user.dto";
 import styled, { css } from "styled-components";
 import CabinetInfoAreaContainer from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import MapInfo from "@/components/MapInfo/MapInfo";
-import { currentFloorSectionState } from "@/recoil/selectors";
-import { currentSectionNameState } from "@/recoil/atoms";
 
 const Layout = (): JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -46,38 +44,6 @@ const Layout = (): JSX.Element => {
     }
   }, []);
 
-  const [touchOffset, setTouchOffset] = useState(0);
-
-  const sectionList = useRecoilValue<Array<string>>(currentFloorSectionState);
-  const [currentSectionName, setCurrentSectionName] = useRecoilState<string>(
-    currentSectionNameState
-  );
-  const currentSectionIdx = sectionList.findIndex(
-    (sectionName) => sectionName === currentSectionName
-  );
-  const moveToLeftSection = () => {
-    if (currentSectionIdx <= 0) {
-      setCurrentSectionName(sectionList[sectionList.length - 1]);
-    } else {
-      setCurrentSectionName(sectionList[currentSectionIdx - 1]);
-    }
-  };
-
-  const moveToRightSection = () => {
-    if (currentSectionIdx >= sectionList.length - 1) {
-      setCurrentSectionName(sectionList[0]);
-    } else {
-      setCurrentSectionName(sectionList[currentSectionIdx + 1]);
-    }
-  };
-
-  const swipeSection = (last: number) => {
-    const swipeDistance = Math.round(last - touchOffset);
-    if (Math.abs(swipeDistance) < 50) return;
-    if (last > touchOffset) moveToLeftSection();
-    else moveToRightSection();
-  };
-
   return isLoginPage ? (
     <Outlet />
   ) : (
@@ -88,14 +54,7 @@ const Layout = (): JSX.Element => {
       ) : (
         <WrapperStyled>
           <LeftNav isVisible={!isHomePage} />
-          <MainStyled
-            onTouchStart={(e: React.TouchEvent) =>
-              setTouchOffset(e.changedTouches[0].screenX)
-            }
-            onTouchEnd={(e: React.TouchEvent) =>
-              swipeSection(e.changedTouches[0].screenX)
-            }
-          >
+          <MainStyled>
             <Outlet />
           </MainStyled>
           <DetailInfoContainerStyled

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,20 +1,68 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import styled from "styled-components";
+import { currentFloorSectionState } from "@/recoil/selectors";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { currentSectionNameState } from "@/recoil/atoms";
 import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
 import CabinetListContainer from "@/components/CabinetList/CabinetList.container";
 
 const MainPage = () => {
-  const CabinetListWrapperRef = useRef<HTMLDivElement>(null);
+  const [touchOffset, setTouchOffset] = useState(0);
+  const sectionList = useRecoilValue<Array<string>>(currentFloorSectionState);
+  const [currentSectionName, setCurrentSectionName] = useRecoilState<string>(
+    currentSectionNameState
+  );
+
+  const currentSectionIdx = sectionList.findIndex(
+    (sectionName) => sectionName === currentSectionName
+  );
+
+  const moveToLeftSection = () => {
+    if (currentSectionIdx <= 0) {
+      setCurrentSectionName(sectionList[sectionList.length - 1]);
+    } else {
+      setCurrentSectionName(sectionList[currentSectionIdx - 1]);
+    }
+  };
+
+  const moveToRightSection = () => {
+    if (currentSectionIdx >= sectionList.length - 1) {
+      setCurrentSectionName(sectionList[0]);
+    } else {
+      setCurrentSectionName(sectionList[currentSectionIdx + 1]);
+    }
+  };
+
+  const swipeSection = (last: number) => {
+    const swipeDistance = Math.round(last - touchOffset);
+    if (Math.abs(swipeDistance) < 50) return;
+    if (last > touchOffset) moveToLeftSection();
+    else moveToRightSection();
+  };
 
   return (
-    <>
+    <WapperStyled
+      onTouchStart={(e: React.TouchEvent) =>
+        setTouchOffset(e.changedTouches[0].screenX)
+      }
+      onTouchEnd={(e: React.TouchEvent) =>
+        swipeSection(e.changedTouches[0].screenX)
+      }
+    >
       <SectionPaginationContainer />
-      <CabinetListWrapperStyled ref={CabinetListWrapperRef}>
+      <CabinetListWrapperStyled>
         <CabinetListContainer />
       </CabinetListWrapperStyled>
-    </>
+    </WapperStyled>
   );
 };
+
+const WapperStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  user-select: none;
+`;
 
 const CabinetListWrapperStyled = styled.div`
   display: flex;

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -7,7 +7,8 @@ import SectionPaginationContainer from "@/components/SectionPagination/SectionPa
 import CabinetListContainer from "@/components/CabinetList/CabinetList.container";
 
 const MainPage = () => {
-  const [touchOffset, setTouchOffset] = useState(0);
+  let touchStartPosX: number;
+
   const sectionList = useRecoilValue<Array<string>>(currentFloorSectionState);
   const [currentSectionName, setCurrentSectionName] = useRecoilState<string>(
     currentSectionNameState
@@ -33,18 +34,18 @@ const MainPage = () => {
     }
   };
 
-  const swipeSection = (last: number) => {
-    const swipeDistance = Math.round(last - touchOffset);
-    if (Math.abs(swipeDistance) < 50) return;
-    if (last > touchOffset) moveToLeftSection();
+  const swipeSection = (touchEndPosX: number) => {
+    const touchOffset = Math.round(touchEndPosX - touchStartPosX);
+    if (Math.abs(touchOffset) < 50) return;
+    if (touchEndPosX > touchStartPosX) moveToLeftSection();
     else moveToRightSection();
   };
 
   return (
     <WapperStyled
-      onTouchStart={(e: React.TouchEvent) =>
-        setTouchOffset(e.changedTouches[0].screenX)
-      }
+      onTouchStart={(e: React.TouchEvent) => {
+        touchStartPosX = e.changedTouches[0].screenX;
+      }}
       onTouchEnd={(e: React.TouchEvent) =>
         swipeSection(e.changedTouches[0].screenX)
       }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/796

- Layout에 있을 때 모든 컴포넌트가 리렌더링 되는 현상이 있어서 기존의 위치에서 MainPage 로 위치 변경했습니다.
- 기존의 터치 시작 위치를 나타내는 "touchOffset" 변수를 useState 상태값으로 잡고 있어서 클릭만 했을때도 하위의 모든 컴포넌트에 리렌더링이 있었습니다. 해당 변수는 useState 대신 일반 변수로 바꿔서 렌더링 이슈를 해결했습니다.
- 변수들 각각이 지닌 값의 의미를 명확히하기 위해서 변수 이름을 변경하였습니다.

Closes #796 