### PR TITLE
[FE] BUG: 내 사물함 보기 클릭 시 깜빡임 증상 처리 #817

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -107,17 +107,11 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       }
     : null;
 
-  const handleCancle = () => {
-    resetTargetCabinetInfo();
-    resetCurrentCabinetId();
-    closeCabinet();
-  };
-
   return (
     <CabinetInfoArea
       selectedCabinetInfo={cabinetViewData}
       myCabinetId={myCabinetInfo?.cabinet_id}
-      closeCabinet={handleCancle}
+      closeCabinet={closeCabinet}
     />
   );
 };

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -31,7 +31,7 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
   );
   const [showUnavailableModal, setShowUnavailableModal] =
     useState<boolean>(false);
-  const { openCabinet } = useMenu();
+  const { openCabinet, closeCabinet } = useMenu();
   const isMine = MY_INFO ? MY_INFO.cabinet_id === props.cabinet_id : false;
 
   let cabinetLabelText = "";
@@ -58,12 +58,17 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
     )
       setShowUnavailableModal(true);
   };
+
   const handleCloseUnavailableModal = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     setShowUnavailableModal(false);
   };
 
   const selectCabinetOnClick = (status: CabinetStatus, cabinetId: number) => {
+    if (currentCabinetId === cabinetId) {
+      closeCabinet();
+      return;
+    }
     if (
       !isMine &&
       status !== CabinetStatus.AVAILABLE &&

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -32,12 +32,9 @@ const TopNavButtonGroup = () => {
   }
 
   const clickMyCabinet = () => {
-    if (myInfo.cabinet_id === -1) {
-      return;
-    }
-
-    setTargetCabinetInfoToMyCabinet();
+    if (myInfo.cabinet_id === -1) return;
     if (currentCabinetId !== myInfo.cabinet_id) {
+      setTargetCabinetInfoToMyCabinet();
       openCabinet();
     } else {
       toggleCabinet();

--- a/frontend/src/hooks/useMenu.ts
+++ b/frontend/src/hooks/useMenu.ts
@@ -16,7 +16,8 @@ const useMenu = () => {
   };
 
   const openLeftNav = () => {
-    closeAll();
+    closeCabinet();
+    closeMap();
     document.getElementById("menuBg")?.classList.add("on");
     document.getElementById("leftNavWrap")?.classList.add("on");
   };
@@ -39,7 +40,8 @@ const useMenu = () => {
   };
 
   const openMap = () => {
-    closeAll();
+    closeLeftNav();
+    closeCabinet();
     document.getElementById("mapInfo")?.classList.add("on");
     document.getElementById("menuBg")?.classList.add("on");
   };
@@ -64,7 +66,8 @@ const useMenu = () => {
   };
 
   const openCabinet = () => {
-    closeAll();
+    closeLeftNav();
+    closeMap();
     document.getElementById("cabinetDetailArea")?.classList.add("on");
     document.getElementById("menuBg")?.classList.add("on");
   };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/817

useMenu에서 클릭된 사물함 값을 reset해주면서 이전의 코드에서 잘 작동하던 부분에 이상증상이 있었습니다.
내 사물함 보기 클릭 시, reset이 되었다가 다시 set이 되는 현상이 있어서 깜빡이는 것 처럼 보이는 증상이 있었고,
사물함 클릭 후 다른 사물함 클릭 시에도 깜빡이는 증상이 있었습니다.

더불어, 클릭된 사물함을 다시 클릭했을 때 api를 계속 호출하고 있었는데, 
사용자 경험에 더 맞게 다시 클릭 시에는 상세보기가 닫히도록 처리했습니다.

[**해결 사항**]
- 내 사물함 버튼 클릭 시 reset, set이 동시에 적용되는 문제 처리
- 사물함 클릭 후 다른 사물함 클릭 시, 클릭 UI 적용 안되는 문제 처리
- 클릭된 사물함 다시 클릭 시 상세보기 꺼짐

Closes #817 
