### PR TITLE
[FE] BUG: 뒤로가기, 앞으로가기 시, 캐비닛정보를 못받아오는 이슈 #814

### DIFF
--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -70,6 +70,14 @@ const LeftMainNav = () => {
   const onClickFloorButton = (floor: number) => {
     setCurrentFloor(floor);
     if (pathname == "/home") {
+      if (floor === currentFloor) {
+        axiosCabinetByLocationFloor(currentLocation, currentFloor).then(
+          (response) => {
+            setCurrentFloorData(response.data);
+            setCurrentSection(response.data[0].section);
+          }
+        );
+      }
       navigator("/main");
     }
   };
@@ -102,7 +110,11 @@ const LeftMainNav = () => {
           </TopBtnStyled>
           {floors.map((floor, index) => (
             <TopBtnStyled
-              className={floor === currentFloor ? "leftNavButtonActive" : ""}
+              className={
+                pathname != "/home" && floor === currentFloor
+                  ? "leftNavButtonActive"
+                  : ""
+              }
               onClick={() => onClickFloorButton(floor)}
               key={index}
             >

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,20 +1,15 @@
 import { useEffect } from "react";
 import ServiceManual from "@/components/Home/ServiceManual";
 import { useNavigate } from "react-router-dom";
-import {
-  currentFloorNumberState,
-  currentSectionNameState,
-} from "@/recoil/atoms";
+import { currentFloorNumberState } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import "@/assets/css/homePage.css";
 import useMenu from "@/hooks/useMenu";
 
 const HomePage = () => {
   const floors = useRecoilValue<Array<number>>(currentLocationFloorState);
   const setCurrentFloor = useSetRecoilState<number>(currentFloorNumberState);
-  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
-  const resetCurrentSection = useResetRecoilState(currentSectionNameState);
   const { closeLeftNav, closeAll } = useMenu();
   const navigator = useNavigate();
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -20,8 +20,6 @@ const HomePage = () => {
 
   useEffect(() => {
     closeLeftNav();
-    resetCurrentFloor();
-    resetCurrentSection();
 
     return () => {
       closeAll();


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/814

home의 useEffect에서 층, 섹션을 reset하는 부분을 삭제하여 기존의 값을 유지하는 방식으로 코드를 수정하였습니다.

home으로 이동하더라도 이전의 값을 지니고 있기 때문에 뒤로가기나 앞으로가기로 main으로 이동 시 이전의 위치로 돌아갑니다.

층, 섹션 정보를 가지고 있기 때문에 이전에 있던 층과 같은 층을 클릭 시 useEffect가 동작하지 않으므로 같을 때의 조건에만 api를 사용하는 방식으로 코드를 작성하였습니다.

또한, home에서 활성화된 버튼 조건식을 수정하였습니다.

Closes #814 