### PR TITLE
[FE] 라우터 이동 시 recoil 값 초기화 안되는 버그  #822

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,8 +2,9 @@ import { useEffect } from "react";
 import ServiceManual from "@/components/Home/ServiceManual";
 import { useNavigate } from "react-router-dom";
 import {
+  currentCabinetIdState,
   currentFloorNumberState,
-  currentSectionNameState,
+  targetCabinetInfoState,
 } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from "recoil";
@@ -13,18 +14,20 @@ import useMenu from "@/hooks/useMenu";
 const HomePage = () => {
   const floors = useRecoilValue<Array<number>>(currentLocationFloorState);
   const setCurrentFloor = useSetRecoilState<number>(currentFloorNumberState);
-  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
-  const resetCurrentSection = useResetRecoilState(currentSectionNameState);
-  const { closeLeftNav, closeAll } = useMenu();
+  const { closeAll } = useMenu();
   const navigator = useNavigate();
+  const resetTargetCabinetInfo = useResetRecoilState(targetCabinetInfoState);
+  const resetCurrentCabinetId = useResetRecoilState(currentCabinetIdState);
 
   useEffect(() => {
-    closeLeftNav();
-    resetCurrentFloor();
-    resetCurrentSection();
+    closeAll();
+    resetTargetCabinetInfo();
+    resetCurrentCabinetId();
 
     return () => {
       closeAll();
+      resetTargetCabinetInfo();
+      resetCurrentCabinetId();
     };
   }, []);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/822

#823 번의 PR을 다루면서 문제점을 발견 했습니다.

useEffect 내에서 커스텀 훅 사용시 커스텀 훅 내에 있는 recoil reset함수가 동작을 안하는 버그가 있습니다.

우선, 되게 끔 useEffect에서 마운트 시, 언마운트 시 recoil 상태를 reset을 하도록 처리해두었습니다.

하지만 왜 안 되는지 더 확실한 분석이 필요하므로 의견들내주시면 감사하겠습니다.

Closes #822 
