### PR TITLE
[FE] 외국 카뎃 로그인에 따른 /login/failure 페이지 추가 #840

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Layout from "./pages/Layout";
+import Layout from "@/pages/Layout";
 import LoginPage from "@/pages/LoginPage";
 import HomePage from "@/pages/HomePage";
 import MainPage from "@/pages/MainPage";
 import NotFoundPage from "@/pages/NotFoundPage";
+import LoginFailurePage from "@/pages/LoginFailurePage";
 
 function App(): React.ReactElement {
   return (
@@ -13,7 +14,7 @@ function App(): React.ReactElement {
         <Route path="/" element={<Layout />}>
           <Route path="home" element={<HomePage />} />
           <Route path="main" element={<MainPage />} />
-          <Route path="login" element={<LoginPage />} />
+          <Route path="login/" element={<LoginPage />} />
         </Route>
         {/* admin용 라우터 */}
         <Route path="/admin/" element={<Layout />}>
@@ -21,6 +22,7 @@ function App(): React.ReactElement {
           <Route path="main" element={<MainPage />} />
           <Route path="login" element={<LoginPage />} />
         </Route>
+        <Route path="/login/failure" element={<LoginFailurePage />} />
         <Route path="/*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/assets/css/media.css
+++ b/frontend/src/assets/css/media.css
@@ -51,25 +51,3 @@
   transform: translateX(0%);
 }
 
-@media screen and (max-width: 768px) {
-  /* 404 notFoundPage  */
-  #notFoundPage > h1 {
-    font-size: 3.25rem;
-  }
-  #notFoundPage > h2 {
-    font-size: 1.5rem;
-  }
-  #notFoundPage > div {
-    width: 160px;
-    height: 160px;
-    margin: 5% 0;
-  }
-  #notFoundPage > p {
-    font-size: 1rem;
-    line-height: 1.5rem;
-    margin-bottom: 30px;
-  }
-  #notFoundPage > p > span {
-    display: block;
-  }
-}

--- a/frontend/src/components/Error/ErrorTemplate.tsx
+++ b/frontend/src/components/Error/ErrorTemplate.tsx
@@ -1,0 +1,113 @@
+import { useNavigate } from "react-router-dom";
+import styled, { keyframes } from "styled-components";
+
+interface Itext {
+  id?: string;
+  title: string;
+  subTitle: string;
+  content: string;
+  subContent?: string;
+  buttonText: string;
+  buttonHandler: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const ErrorTemplate = (props: Itext) => {
+  const {
+    id,
+    title,
+    subTitle,
+    content,
+    subContent,
+    buttonText,
+    buttonHandler,
+  } = props;
+
+  return (
+    <ErrorTemplateStyled id={id}>
+      <TitleStyled>{title}</TitleStyled>
+      <CabiImgStyled>
+        <img src="/src/assets/images/sadCcabiWhite.png" alt="sad_cabi" />
+      </CabiImgStyled>
+      <SubTitleStyled>{subTitle}</SubTitleStyled>
+      <ContentStyled>
+        {content}
+        {!!subContent && <span>{subContent}</span>}
+      </ContentStyled>
+      <ButtonStyled onClick={buttonHandler}>{buttonText}</ButtonStyled>
+    </ErrorTemplateStyled>
+  );
+};
+
+const ErrorTemplateStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  background-color: var(--main-color);
+  color: var(--white);
+`;
+
+const TitleStyled = styled.h1`
+  font-size: 5rem;
+  color: var(--mine);
+  font-family: "Do Hyeon", sans-serif;
+  filter: drop-shadow(0 0 0.75rem var(--mine));
+  text-align: center;
+  @media screen and (max-width: 768px) {
+    font-size: 3.25rem;
+  }
+`;
+
+const SubTitleStyled = styled.h2`
+  font-size: 2rem;
+  margin: 1.5rem 0;
+  font-weight: 700;
+  text-align: center;
+  @media screen and (max-width: 768px) {
+    font-size: 1.5rem;
+  }
+`;
+
+const ContentStyled = styled.p`
+  font-size: 1.25rem;
+  margin-bottom: 60px;
+  font-weight: 300;
+  text-align: center;
+  @media screen and (max-width: 768px) {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    margin-bottom: 30px;
+    & > span {
+      display: block;
+    }
+  }
+`;
+
+const rotate = keyframes`
+  from {
+    transform: translateY(5%);
+  }
+  to {
+    transform: translateY(-5%) scale(1.1);
+  }
+`;
+
+const CabiImgStyled = styled.div`
+  width: 200px;
+  height: 200px;
+  margin: 3% 0;
+  animation: ${rotate} 0.5s infinite ease alternate;
+  @media screen and (max-width: 768px) {
+    width: 160px;
+    height: 160px;
+    margin: 5% 0;
+  }
+`;
+
+const ButtonStyled = styled.button`
+  box-shadow: 10px 10px 40px 0px rgba(0, 0, 0, 0.25);
+`;
+
+export default ErrorTemplate;

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -39,7 +39,7 @@ const Layout = (): JSX.Element => {
           setIsValidToken(true);
           if (isRootPath || isLoginPage) navigate("/home");
         } catch (error) {
-          console.log(error);
+          navigate("/login");
         }
       };
       getMyInfo();

--- a/frontend/src/pages/LoginFailurePage.tsx
+++ b/frontend/src/pages/LoginFailurePage.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import ErrorTemplate from "@/components/Error/ErrorTemplate";
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <ErrorTemplate
+      title="Unfortunately"
+      subTitle="You cannot access the Cabi."
+      content="This site is provided "
+      subContent="only to 42seoul students."
+      buttonText="Go to Sign In"
+      buttonHandler={() => navigate("/login")}
+    />
+  );
+};
+
+export default NotFoundPage;

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,73 +1,20 @@
 import { useNavigate } from "react-router-dom";
-import styled, { keyframes } from "styled-components";
+import ErrorTemplate from "@/components/Error/ErrorTemplate";
 
 const NotFoundPage = () => {
   const navigate = useNavigate();
 
   return (
-    <NotFoundPageStyled id="notFoundPage">
-      <TitleStyled>404 Not Found</TitleStyled>
-      <CabiImgStyled>
-        <img src="/src/assets/images/sadCcabiWhite.png" alt="sad_cabi" />
-      </CabiImgStyled>
-      <SubTitleStyled> 원하시는 페이지를 찾을 수 없습니다.</SubTitleStyled>
-      <ContentStyled>
-        요청하신 페이지가 사라졌거나,{" "}
-        <span>잘못된 경로를 이용하셨습니다 :(</span>
-      </ContentStyled>
-      <ButtonStyled onClick={() => navigate("/")}>홈으로 가기</ButtonStyled>
-    </NotFoundPageStyled>
+    <ErrorTemplate
+      id="notFoundPage"
+      title="404 Not Found"
+      subTitle="원하시는 페이지를 찾을 수 없습니다."
+      content="요청하신 페이지가 사라졌거나, "
+      subContent="잘못된 경로를 이용하셨습니다 :("
+      buttonText="홈으로 가기"
+      buttonHandler={() => navigate("/home")}
+    />
   );
 };
-
-const NotFoundPageStyled = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  background-color: var(--main-color);
-  color: var(--white);
-`;
-
-const TitleStyled = styled.h1`
-  font-size: 5rem;
-  color: var(--mine);
-  font-family: "Do Hyeon", sans-serif;
-  filter: drop-shadow(0 0 0.75rem var(--mine));
-`;
-
-const SubTitleStyled = styled.h2`
-  font-size: 2rem;
-  margin: 1.5rem 0;
-  font-weight: 700;
-`;
-
-const ContentStyled = styled.p`
-  font-size: 1.25rem;
-  margin-bottom: 60px;
-  font-weight: 300;
-`;
-
-const rotate = keyframes`
-  from {
-    transform: translateY(5%);
-  }
-  to {
-    transform: translateY(-5%) scale(1.1);
-  }
-`;
-
-const CabiImgStyled = styled.div`
-  width: 200px;
-  height: 200px;
-  margin: 3% 0;
-  animation: ${rotate} 0.5s infinite ease alternate;
-`;
-
-const ButtonStyled = styled.button`
-  box-shadow: 10px 10px 40px 0px rgba(0, 0, 0, 0.25);
-`;
 
 export default NotFoundPage;

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -6,7 +6,6 @@ const NotFoundPage = () => {
 
   return (
     <ErrorTemplate
-      id="notFoundPage"
       title="404 Not Found"
       subTitle="원하시는 페이지를 찾을 수 없습니다."
       content="요청하신 페이지가 사라졌거나, "


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/840

기존의 404 페이지의 스타일을 component화하여 재사용할 수 있도록 변경하였습니다.

라우트는 기존 login에 넣으려 했으나, layout의 useEffect 영향이 있기에 밖으로 뺐습니다.

media.css에 있던 NotFoundPage 미디어쿼리를 공통으로 사용하기 위해 컴포넌트 내부로 이동하였습니다.


Closes #840 