### PR TITLE
[BE] FEAT: admin 로그인 실패시 리디렉션 및 로거 추가 #834

### DIFF
--- a/backend/src/admin/auth/auth.controller.ts
+++ b/backend/src/admin/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Req,
   Res,
+  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
@@ -25,6 +26,7 @@ import { AdminJwtAuthGuard } from './jwt/guard/jwtauth.guard';
 import { GoogleOAuthGuard } from 'src/admin/auth/google/guard/google.guard';
 import { AdminUserDto } from '../dto/admin.user.dto';
 import { AdminAuthService } from './auth.service';
+import { GoogleAuthFilter } from 'src/admin/auth/google/google.auth.filter';
 
 @ApiTags('Auth')
 @Controller('/api/admin/auth')
@@ -63,8 +65,9 @@ export class AdminAuthController {
   })
   @Get('login/callback')
   @UseGuards(GoogleOAuthGuard, AdminJWTSignGuard)
+  @UseFilters(GoogleAuthFilter)
   async loginCallback(@Res() res: Response, @User() adminUser: AdminUserDto) {
-    this.logger.log('Login -> callback');
+    this.logger.log(`${adminUser.email} has logged in.`);
     return res.redirect(`${this.configService.get<string>('fe_host')}/home`);
   }
 

--- a/backend/src/admin/auth/google/google.auth.filter.ts
+++ b/backend/src/admin/auth/google/google.auth.filter.ts
@@ -1,0 +1,23 @@
+import {
+    ArgumentsHost,
+    Catch,
+    ExceptionFilter,
+    ForbiddenException,
+    HttpException,
+    Logger,
+  } from '@nestjs/common';
+  import { Request, Response } from 'express';
+  
+  @Catch(ForbiddenException)
+  export class GoogleAuthFilter implements ExceptionFilter {
+    private logger = new Logger(GoogleAuthFilter.name);
+    catch(exception: HttpException, host: ArgumentsHost) {
+      const ctx = host.switchToHttp();
+      const response = ctx.getResponse<Response>();
+      const request = ctx.getRequest<Request>();
+      const status = exception.getStatus();
+      
+      response.status(status).redirect('api/admin/auth/login/failure');
+    }
+  }
+  

--- a/backend/src/admin/auth/google/google.auth.filter.ts
+++ b/backend/src/admin/auth/google/google.auth.filter.ts
@@ -4,20 +4,23 @@ import {
     ExceptionFilter,
     ForbiddenException,
     HttpException,
-    Logger,
+    Inject,
   } from '@nestjs/common';
-  import { Request, Response } from 'express';
+import { ConfigService } from '@nestjs/config';
+  import { Response } from 'express';
   
   @Catch(ForbiddenException)
   export class GoogleAuthFilter implements ExceptionFilter {
-    private logger = new Logger(GoogleAuthFilter.name);
+    constructor(
+        @Inject(ConfigService)
+        private configService: ConfigService,
+    ){}
     catch(exception: HttpException, host: ArgumentsHost) {
       const ctx = host.switchToHttp();
       const response = ctx.getResponse<Response>();
-      const request = ctx.getRequest<Request>();
       const status = exception.getStatus();
       
-      response.status(status).redirect('api/admin/auth/login/failure');
+      response.status(status).redirect(`${this.configService.get<string>('FE_HOST')}/admin/login/failure`);
     }
   }
   

--- a/backend/src/admin/auth/jwt/guard/jwtsign.guard.ts
+++ b/backend/src/admin/auth/jwt/guard/jwtsign.guard.ts
@@ -40,17 +40,18 @@ export class AdminJWTSignGuard implements CanActivate {
   ): Promise<boolean> {
     const user = request.user as AdminUserDto | undefined;
     if (user === undefined) {
-      this.logger.debug(`can't generate JWTToken`);
+      this.logger.debug(`can't generate ${user.email}'s admin_access Token`);
       return false;
     }
     await this.adminAuthService.addUserIfNotExists(user);
     const role = await this.adminAuthService.getAdminUserRole(user.email);
     if (role === AdminUserRole.AUTHORIZE_WAITING) {
+      this.logger.log(`${user.email} has failed to login due to role.`);
       return false;
     }
     user.role = role;
     const token = this.jwtService.sign(user);
-    this.logger.debug(`generete ${user.email}'s token`);
+    this.logger.debug(`generated ${user.email}'s token`);
     if (this.configService.get<boolean>('is_local') === true) {
       response.cookie('admin_access_token', token);
     } else {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/834

어드민 로그인 실패시(잘못된 로그인 또는 로그인 하였으나 role이 권한 승인 대기상태 : 0 인 경우,
api/admin/auth/login/failure로 리디렉션 하게끔 설정하였습니다.

더해서, 로거를 추가하고 기존의 로깅 문장을 조금 다듬었습니다.

++
어드민 로그인 실패에 대한 페이지도 만들어 주시면 감사하겠습니다!
'승인 되지 않은 사용자'인 것을 인지하게끔 해주시고, 
다시 로그인 할 수 있게끔 ('api/admin/auth/login')으로 연결되는 버튼이 있으면 좋을 것 같습니다!
