### PR TITLE
[FE] 아이폰 메모 수정모드 진입 시 키보드 활성화가 안되던 이슈 해결 #853

### DIFF
--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -26,16 +26,15 @@ const MemoModal = ({
   const handleClickWriteMode = (e: any) => {
     setMode("write");
     if (cabinetType === "PRIVATE" && newMemo.current) {
-      newMemo.current.focus();
       newMemo.current.select();
     } else if (newTitle.current) {
-      newTitle.current.focus();
+      newTitle.current.select();
     }
   };
-
   const handleClickSave = (e: React.MouseEvent) => {
     //사물함 제목, 사물함 비밀메모 update api 호출
     // onClose(e);
+    document.getElementById("unselect-input")?.focus();
     if (cabinetType === "SHARE" && newTitle.current!.value) {
       onSave(newTitle.current!.value, newMemo.current!.value);
     } else {
@@ -55,16 +54,12 @@ const MemoModal = ({
           <ContentItemSectionStyled>
             <ContentItemWrapperStyled isVisible={cabinetType !== "PRIVATE"}>
               <ContentItemTitleStyled>사물함 이름</ContentItemTitleStyled>
-
               <ContentItemInputStyled
                 placeholder={cabinetTitle ? cabinetTitle : ""}
                 mode={mode}
                 defaultValue={cabinetTitle ? cabinetTitle : ""}
                 readOnly={mode === "read" ? true : false}
                 ref={newTitle}
-                onFocus={(e) => {
-                  e.currentTarget.select();
-                }}
               />
             </ContentItemWrapperStyled>
             <ContentItemWrapperStyled isVisible={true}>
@@ -75,13 +70,11 @@ const MemoModal = ({
                 defaultValue={cabinetMemo}
                 readOnly={mode === "read" ? true : false}
                 ref={newMemo}
-                onFocus={(e) => {
-                  e.currentTarget.select();
-                }}
               />
             </ContentItemWrapperStyled>
           </ContentItemSectionStyled>
         </ContentSectionStyled>
+        <input id="unselect-input" readOnly style={{ height: 0, width: 0 }} />
         <ButtonWrapperStyled mode={mode}>
           {mode === "write" && (
             <Button onClick={handleClickSave} text="저장" theme="fill" />


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
아이폰에서는 readOnly 속성이 있는 인풋 태그에서는 select나 focus가 안먹는것 같습니다. writeMode에 진입과 동시에 readOnly가 false가 되는데 아이폰에서는 무슨이유에서인지 모르게 readOnly가 false가 되지 않는것 같았습니다. 그래서 focus를 지우고 select로 통합했더니 아이폰에서도 인풋 박스를 터치하면 키보드가 올라오게 됩니다. 

#853 
Closes #853 
