### PR TITLE
[FE] 관리자 로그인 페이지 추가 #873

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import HomePage from "@/pages/HomePage";
 import MainPage from "@/pages/MainPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import LoginFailurePage from "@/pages/LoginFailurePage";
+import AdminLoginPage from "./pages/admin/AdminLoginPage";
 
 function App(): React.ReactElement {
   return (
@@ -17,11 +18,11 @@ function App(): React.ReactElement {
           <Route path="login/" element={<LoginPage />} />
         </Route>
         {/* admin용 라우터 */}
-        <Route path="/admin/" element={<Layout />}>
+        {/* <Route path="/admin/" element={<Layout />}>
           <Route path="home" element={<HomePage />} />
           <Route path="main" element={<MainPage />} />
-          <Route path="login" element={<LoginPage />} />
-        </Route>
+        </Route> */}
+        <Route path="/admin/login" element={<AdminLoginPage />} />
         <Route path="/login/failure" element={<LoginFailurePage />} />
         <Route path="/*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/components/Login/Login.tsx
+++ b/frontend/src/components/Login/Login.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import styled from "styled-components";
+import "@/assets/css/loginPage.css";
+import LoadingAnimation from "@/components/Common/LoadingAnimation";
+
+const LoginPage = () => {
+  const url = `${import.meta.env.VITE_BE_HOST}/auth/login`;
+  const [isClicked, setIsClicked] = useState(false);
+
+  return (
+    <LoginPageStyled id="loginPage">
+      <LeftSectionStyled className="leftLoginPage">
+        <TopContentsStyled>
+          <LoginTitleStyled color="var(--black)">
+            42서울 캐비닛 서비스
+          </LoginTitleStyled>
+          <LoginTitleStyled color="var(--lightpurple-color)">
+            여러분의 일상을 가볍게
+          </LoginTitleStyled>
+        </TopContentsStyled>
+        <LoginImgStyled>
+          <img src="/src/assets/images/loginImg.svg" alt="" />
+        </LoginImgStyled>
+        <BottomContentsStyled>
+          <p>
+            <CabiStyled>Cabi</CabiStyled>로
+          </p>
+          <p>일상의 무게를 덜어보세요.</p>
+        </BottomContentsStyled>
+      </LeftSectionStyled>
+      <RightSectionStyled className="rightLoginPage">
+        <LoginCardStyled className="modal">
+          <CardLogoStyled>
+            <img src="/src/assets/images/logo.svg" alt="" />
+          </CardLogoStyled>
+          <CardTitleBoxStyled>
+            <CardTitleStyled>42Cabi</CardTitleStyled>
+            <CardSubTitleStyled>여러분의 일상을 가볍게</CardSubTitleStyled>
+          </CardTitleBoxStyled>
+          <button
+            onClick={() => {
+              window.location.replace(url);
+              setIsClicked(true);
+            }}
+            disabled={isClicked}
+          >
+            {isClicked ? <LoadingAnimation></LoadingAnimation> : "L O G I N"}
+          </button>
+        </LoginCardStyled>
+      </RightSectionStyled>
+    </LoginPageStyled>
+  );
+};
+
+const LoginPageStyled = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 80px;
+  width: 100%;
+  height: 100%;
+`;
+
+const LeftSectionStyled = styled.section`
+  width: 50%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
+  padding-left: 7%;
+`;
+const TopContentsStyled = styled.div`
+  font-size: 2rem;
+  font-family: var(--main-font);
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const LoginTitleStyled = styled.p<{ color: string }>`
+  font-size: 2rem;
+  font-family: var(--main-font);
+  color: ${(props) => props.color};
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const LoginImgStyled = styled.div`
+  margin-top: 10%;
+  margin-bottom: 10%;
+`;
+
+const BottomContentsStyled = styled.div`
+  font-size: 1.75rem;
+  font-family: var(--main-font);
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const CabiStyled = styled.span`
+  color: var(--main-color);
+`;
+
+const RightSectionStyled = styled.section`
+  width: 50%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--main-color);
+`;
+
+const LoginCardStyled = styled.div`
+  width: 350px;
+  height: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: column;
+  padding: 85px 0;
+  background-color: var(--white);
+`;
+
+const CardLogoStyled = styled.div`
+  width: 70px;
+  height: 70px;
+`;
+
+const CardTitleBoxStyled = styled.div`
+  text-align: center;
+  margin-top: -40px;
+`;
+
+const CardTitleStyled = styled.h1`
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+`;
+
+const CardSubTitleStyled = styled.p`
+  color: var(--main-color);
+`;
+
+export default LoginPage;

--- a/frontend/src/components/Login/LoginTemplate.tsx
+++ b/frontend/src/components/Login/LoginTemplate.tsx
@@ -3,8 +3,12 @@ import styled from "styled-components";
 import "@/assets/css/loginPage.css";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
 
-const LoginPage = () => {
-  const url = `${import.meta.env.VITE_BE_HOST}/auth/login`;
+const LoginTemplate = (props: {
+  url: string;
+  pageTitle: string;
+  pageSubTitle: string;
+}) => {
+  const { url, pageTitle, pageSubTitle } = props;
   const [isClicked, setIsClicked] = useState(false);
 
   return (
@@ -34,8 +38,8 @@ const LoginPage = () => {
             <img src="/src/assets/images/logo.svg" alt="" />
           </CardLogoStyled>
           <CardTitleBoxStyled>
-            <CardTitleStyled>42Cabi</CardTitleStyled>
-            <CardSubTitleStyled>여러분의 일상을 가볍게</CardSubTitleStyled>
+            <CardTitleStyled>{pageTitle}</CardTitleStyled>
+            <CardSubTitleStyled>{pageSubTitle}</CardSubTitleStyled>
           </CardTitleBoxStyled>
           <button
             onClick={() => {
@@ -140,4 +144,4 @@ const CardSubTitleStyled = styled.p`
   color: var(--main-color);
 `;
 
-export default LoginPage;
+export default LoginTemplate;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,143 +1,16 @@
-import { useState } from "react";
-import styled from "styled-components";
 import "@/assets/css/loginPage.css";
-import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import LoginTemplate from "@/components/Login/LoginTemplate";
 
 const LoginPage = () => {
   const url = `${import.meta.env.VITE_BE_HOST}/auth/login`;
-  const [isClicked, setIsClicked] = useState(false);
 
   return (
-    <LoginPageStyled id="loginPage">
-      <LeftSectionStyled className="leftLoginPage">
-        <TopContentsStyled>
-          <LoginTitleStyled color="var(--black)">
-            42서울 캐비닛 서비스
-          </LoginTitleStyled>
-          <LoginTitleStyled color="var(--lightpurple-color)">
-            여러분의 일상을 가볍게
-          </LoginTitleStyled>
-        </TopContentsStyled>
-        <LoginImgStyled>
-          <img src="/src/assets/images/loginImg.svg" alt="" />
-        </LoginImgStyled>
-        <BottomContentsStyled>
-          <p>
-            <CabiStyled>Cabi</CabiStyled>로
-          </p>
-          <p>일상의 무게를 덜어보세요.</p>
-        </BottomContentsStyled>
-      </LeftSectionStyled>
-      <RightSectionStyled className="rightLoginPage">
-        <LoginCardStyled className="modal">
-          <CardLogoStyled>
-            <img src="/src/assets/images/logo.svg" alt="" />
-          </CardLogoStyled>
-          <CardTitleBoxStyled>
-            <CardTitleStyled>42Cabi</CardTitleStyled>
-            <CardSubTitleStyled>여러분의 일상을 가볍게</CardSubTitleStyled>
-          </CardTitleBoxStyled>
-          <button
-            onClick={() => {
-              window.location.replace(url);
-              setIsClicked(true);
-            }}
-            disabled={isClicked}
-          >
-            {isClicked ? <LoadingAnimation></LoadingAnimation> : "L O G I N"}
-          </button>
-        </LoginCardStyled>
-      </RightSectionStyled>
-    </LoginPageStyled>
+    <LoginTemplate
+      url={url}
+      pageTitle="42Cabi"
+      pageSubTitle="여러분의 일상을 가볍게"
+    />
   );
 };
-
-const LoginPageStyled = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 80px;
-  width: 100%;
-  height: 100%;
-`;
-
-const LeftSectionStyled = styled.section`
-  width: 50%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  flex-direction: column;
-  padding-left: 7%;
-`;
-const TopContentsStyled = styled.div`
-  font-size: 2rem;
-  font-family: var(--main-font);
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const LoginTitleStyled = styled.p<{ color: string }>`
-  font-size: 2rem;
-  font-family: var(--main-font);
-  color: ${(props) => props.color};
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const LoginImgStyled = styled.div`
-  margin-top: 10%;
-  margin-bottom: 10%;
-`;
-
-const BottomContentsStyled = styled.div`
-  font-size: 1.75rem;
-  font-family: var(--main-font);
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const CabiStyled = styled.span`
-  color: var(--main-color);
-`;
-
-const RightSectionStyled = styled.section`
-  width: 50%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--main-color);
-`;
-
-const LoginCardStyled = styled.div`
-  width: 350px;
-  height: 500px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: column;
-  padding: 85px 0;
-  background-color: var(--white);
-`;
-
-const CardLogoStyled = styled.div`
-  width: 70px;
-  height: 70px;
-`;
-
-const CardTitleBoxStyled = styled.div`
-  text-align: center;
-  margin-top: -40px;
-`;
-
-const CardTitleStyled = styled.h1`
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-`;
-
-const CardSubTitleStyled = styled.p`
-  color: var(--main-color);
-`;
 
 export default LoginPage;

--- a/frontend/src/pages/admin/AdminLoginPage.tsx
+++ b/frontend/src/pages/admin/AdminLoginPage.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import styled from "styled-components";
+import "@/assets/css/loginPage.css";
+import LoadingAnimation from "@/components/Common/LoadingAnimation";
+
+const LoginPage = () => {
+  const url = `${import.meta.env.VITE_BE_HOST}/auth/login`;
+  const [isClicked, setIsClicked] = useState(false);
+
+  return (
+    <LoginPageStyled id="loginPage">
+      <LeftSectionStyled className="leftLoginPage">
+        <TopContentsStyled>
+          <LoginTitleStyled color="var(--black)">
+            42서울 캐비닛 서비스
+          </LoginTitleStyled>
+          <LoginTitleStyled color="var(--lightpurple-color)">
+            여러분의 일상을 가볍게
+          </LoginTitleStyled>
+        </TopContentsStyled>
+        <LoginImgStyled>
+          <img src="/src/assets/images/loginImg.svg" alt="" />
+        </LoginImgStyled>
+        <BottomContentsStyled>
+          <p>
+            <CabiStyled>Cabi</CabiStyled>로
+          </p>
+          <p>일상의 무게를 덜어보세요.</p>
+        </BottomContentsStyled>
+      </LeftSectionStyled>
+      <RightSectionStyled className="rightLoginPage">
+        <LoginCardStyled className="modal">
+          <CardLogoStyled>
+            <img src="/src/assets/images/logo.svg" alt="" />
+          </CardLogoStyled>
+          <CardTitleBoxStyled>
+            <CardTitleStyled>42Cabi</CardTitleStyled>
+            <CardSubTitleStyled>여러분의 일상을 가볍게</CardSubTitleStyled>
+          </CardTitleBoxStyled>
+          <button
+            onClick={() => {
+              window.location.replace(url);
+              setIsClicked(true);
+            }}
+            disabled={isClicked}
+          >
+            {isClicked ? <LoadingAnimation></LoadingAnimation> : "L O G I N"}
+          </button>
+        </LoginCardStyled>
+      </RightSectionStyled>
+    </LoginPageStyled>
+  );
+};
+
+const LoginPageStyled = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 80px;
+  width: 100%;
+  height: 100%;
+`;
+
+const LeftSectionStyled = styled.section`
+  width: 50%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-direction: column;
+  padding-left: 7%;
+`;
+const TopContentsStyled = styled.div`
+  font-size: 2rem;
+  font-family: var(--main-font);
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const LoginTitleStyled = styled.p<{ color: string }>`
+  font-size: 2rem;
+  font-family: var(--main-font);
+  color: ${(props) => props.color};
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const LoginImgStyled = styled.div`
+  margin-top: 10%;
+  margin-bottom: 10%;
+`;
+
+const BottomContentsStyled = styled.div`
+  font-size: 1.75rem;
+  font-family: var(--main-font);
+  font-weight: 700;
+  line-height: 3rem;
+`;
+
+const CabiStyled = styled.span`
+  color: var(--main-color);
+`;
+
+const RightSectionStyled = styled.section`
+  width: 50%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--main-color);
+`;
+
+const LoginCardStyled = styled.div`
+  width: 350px;
+  height: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: column;
+  padding: 85px 0;
+  background-color: var(--white);
+`;
+
+const CardLogoStyled = styled.div`
+  width: 70px;
+  height: 70px;
+`;
+
+const CardTitleBoxStyled = styled.div`
+  text-align: center;
+  margin-top: -40px;
+`;
+
+const CardTitleStyled = styled.h1`
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+`;
+
+const CardSubTitleStyled = styled.p`
+  color: var(--main-color);
+`;
+
+export default LoginPage;

--- a/frontend/src/pages/admin/AdminLoginPage.tsx
+++ b/frontend/src/pages/admin/AdminLoginPage.tsx
@@ -1,143 +1,16 @@
-import { useState } from "react";
-import styled from "styled-components";
 import "@/assets/css/loginPage.css";
-import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import LoginTemplate from "@/components/Login/LoginTemplate";
 
 const LoginPage = () => {
-  const url = `${import.meta.env.VITE_BE_HOST}/auth/login`;
-  const [isClicked, setIsClicked] = useState(false);
+  const url = `${import.meta.env.VITE_BE_HOST}/api/admin/auth/login`;
 
   return (
-    <LoginPageStyled id="loginPage">
-      <LeftSectionStyled className="leftLoginPage">
-        <TopContentsStyled>
-          <LoginTitleStyled color="var(--black)">
-            42서울 캐비닛 서비스
-          </LoginTitleStyled>
-          <LoginTitleStyled color="var(--lightpurple-color)">
-            여러분의 일상을 가볍게
-          </LoginTitleStyled>
-        </TopContentsStyled>
-        <LoginImgStyled>
-          <img src="/src/assets/images/loginImg.svg" alt="" />
-        </LoginImgStyled>
-        <BottomContentsStyled>
-          <p>
-            <CabiStyled>Cabi</CabiStyled>로
-          </p>
-          <p>일상의 무게를 덜어보세요.</p>
-        </BottomContentsStyled>
-      </LeftSectionStyled>
-      <RightSectionStyled className="rightLoginPage">
-        <LoginCardStyled className="modal">
-          <CardLogoStyled>
-            <img src="/src/assets/images/logo.svg" alt="" />
-          </CardLogoStyled>
-          <CardTitleBoxStyled>
-            <CardTitleStyled>42Cabi</CardTitleStyled>
-            <CardSubTitleStyled>여러분의 일상을 가볍게</CardSubTitleStyled>
-          </CardTitleBoxStyled>
-          <button
-            onClick={() => {
-              window.location.replace(url);
-              setIsClicked(true);
-            }}
-            disabled={isClicked}
-          >
-            {isClicked ? <LoadingAnimation></LoadingAnimation> : "L O G I N"}
-          </button>
-        </LoginCardStyled>
-      </RightSectionStyled>
-    </LoginPageStyled>
+    <LoginTemplate
+      url={url}
+      pageTitle="42Cabi Admin"
+      pageSubTitle="관리자 페이지"
+    />
   );
 };
-
-const LoginPageStyled = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 80px;
-  width: 100%;
-  height: 100%;
-`;
-
-const LeftSectionStyled = styled.section`
-  width: 50%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  flex-direction: column;
-  padding-left: 7%;
-`;
-const TopContentsStyled = styled.div`
-  font-size: 2rem;
-  font-family: var(--main-font);
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const LoginTitleStyled = styled.p<{ color: string }>`
-  font-size: 2rem;
-  font-family: var(--main-font);
-  color: ${(props) => props.color};
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const LoginImgStyled = styled.div`
-  margin-top: 10%;
-  margin-bottom: 10%;
-`;
-
-const BottomContentsStyled = styled.div`
-  font-size: 1.75rem;
-  font-family: var(--main-font);
-  font-weight: 700;
-  line-height: 3rem;
-`;
-
-const CabiStyled = styled.span`
-  color: var(--main-color);
-`;
-
-const RightSectionStyled = styled.section`
-  width: 50%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: var(--main-color);
-`;
-
-const LoginCardStyled = styled.div`
-  width: 350px;
-  height: 500px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-direction: column;
-  padding: 85px 0;
-  background-color: var(--white);
-`;
-
-const CardLogoStyled = styled.div`
-  width: 70px;
-  height: 70px;
-`;
-
-const CardTitleBoxStyled = styled.div`
-  text-align: center;
-  margin-top: -40px;
-`;
-
-const CardTitleStyled = styled.h1`
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-`;
-
-const CardSubTitleStyled = styled.p`
-  color: var(--main-color);
-`;
 
 export default LoginPage;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/873

google Oauth 로그인을 위해  관리자용 login페이지를 만들었습니다.

기존의 login페이지의 style부분만 빼서 login/loginTemplate 로 넣고, LoginPage, AdminLoginPage에서 {url, title, subtitle} 로 props 넘겨서 재사용성을 높였습니다.

아직 Layout은 분리작업을 안했기 때문에 확인하기 위해서 admin용 나머지 Router는 주석처리하고 Login만 따로 빼어뒀습니다. 

이후 Layout 분리작업과 각 Page 들의 style 들을 분리하는 작업이 끝난 이후로 Router 조정이 있을 계획입니다

> ps) LoginPage과 AdminLoginPage 를 구분 짓기 위해 추후 현재의 모습과 달라질 수 있습니다..(먼저 기능부터 작업 후 추후에 작업할 예정)

Closes #873 
