### PR TITLE
[FE] FEAT: 공유사물함 정원 찬 경우 리스트에 제목 출력

### DIFF
--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -45,7 +45,7 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
       const cabinetTitle = props.cabinet_title ?? "FULL";
 
       cabinetLabelText =
-        headcount === parseInt(import.meta.env.VITE_SHARE_MAX_USER)
+        headcount === props.max_user
           ? cabinetTitle
           : headcount + " / " + props.max_user;
     } else if (props.lent_type === "CLUB")

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -40,9 +40,15 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
     //사용불가가 아닌 모든 경우
     if (props.lent_type === "PRIVATE")
       cabinetLabelText = props.lent_info[0]?.intra_id;
-    else if (props.lent_type === "SHARE")
-      cabinetLabelText = props.lent_info.length + " / " + props.max_user;
-    else if (props.lent_type === "CLUB")
+    else if (props.lent_type === "SHARE") {
+      const headcount = props.lent_info.length;
+      const cabinetTitle = props.cabinet_title ?? "FULL";
+
+      cabinetLabelText =
+        headcount === parseInt(import.meta.env.VITE_SHARE_MAX_USER)
+          ? cabinetTitle
+          : headcount + " / " + props.max_user;
+    } else if (props.lent_type === "CLUB")
       cabinetLabelText = props.cabinet_title ? props.cabinet_title : "";
   } else {
     //사용불가인 경우

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -42,14 +42,15 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
       cabinetLabelText = props.lent_info[0]?.intra_id;
     else if (props.lent_type === "SHARE") {
       const headcount = props.lent_info.length;
-      const cabinetTitle = props.cabinet_title ?? "FULL";
+      const cabinetTitle =
+        props.cabinet_title ?? `${props.max_user} / ${props.max_user}`;
 
       cabinetLabelText =
         headcount === props.max_user
           ? cabinetTitle
           : headcount + " / " + props.max_user;
     } else if (props.lent_type === "CLUB")
-      cabinetLabelText = props.cabinet_title ? props.cabinet_title : "";
+      cabinetLabelText = props.cabinet_title ?? "동아리";
   } else {
     //사용불가인 경우
     cabinetLabelText = "사용불가";

--- a/frontend/src/components/Home/ServiceManual.tsx
+++ b/frontend/src/components/Home/ServiceManual.tsx
@@ -37,7 +37,8 @@ const ServiceManual = ({
           </div>
           <h3>공유 사물함</h3>
           <p>
-            1개의 사물함을 최대 <span>3인</span>이 사용합니다.
+            1개의 사물함을 최대{" "}
+            <span>{import.meta.env.VITE_SHARE_MAX_USER}인</span>이 사용합니다.
             <br />
             <span>{import.meta.env.VITE_SHARE_LENT_PERIOD}일간</span> 대여할 수
             있습니다.

--- a/frontend/src/components/Modals/MemoModal/MemoModal.container.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.container.tsx
@@ -31,7 +31,9 @@ const MemoModalContainer = (props: {
     );
     const targetSectionCabinetList = updatedCabinetList.find(
       (floor) => floor.section === myCabinetInfo.section
-    )!.cabinets;
+    )?.cabinets;
+    if (targetSectionCabinetList === undefined) return;
+
     let targetCabinet = targetSectionCabinetList.find(
       (section) => section.cabinet_id === myCabinetInfo.cabinet_id
     );

--- a/frontend/src/components/Modals/MemoModal/MemoModal.container.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.container.tsx
@@ -3,8 +3,11 @@ import {
   axiosUpdateCabinetTitle,
 } from "@/api/axios/axios.custom";
 import MemoModal from "@/components/Modals/MemoModal/MemoModal";
-import { myCabinetInfoState } from "@/recoil/atoms";
-import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
+import { myCabinetInfoState, currentFloorCabinetState } from "@/recoil/atoms";
+import {
+  CabinetInfoByLocationFloorDto,
+  MyCabinetInfoResponseDto,
+} from "@/types/dto/cabinet.dto";
 import React from "react";
 import { useRecoilState } from "recoil";
 
@@ -13,11 +16,30 @@ const MemoModalContainer = (props: {
 }) => {
   const [myCabinetInfo, setMyCabinetInfo] =
     useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
+  const [currentFloorCabinet, setCurrentFloorCabinet] = useRecoilState(
+    currentFloorCabinetState
+  );
   const memoModalProps = {
     cabinetType: myCabinetInfo.lent_type,
     cabinetTitle: myCabinetInfo.cabinet_title,
     cabinetMemo: myCabinetInfo.cabinet_memo,
   };
+
+  const updateCabinetTitleInList = (newTitle: string | null) => {
+    const updatedCabinetList: CabinetInfoByLocationFloorDto[] = JSON.parse(
+      JSON.stringify(currentFloorCabinet)
+    );
+    const targetSectionCabinetList = updatedCabinetList.find(
+      (floor) => floor.section === myCabinetInfo.section
+    )!.cabinets;
+    let targetCabinet = targetSectionCabinetList.find(
+      (section) => section.cabinet_id === myCabinetInfo.cabinet_id
+    );
+
+    targetCabinet!.cabinet_title = newTitle;
+    setCurrentFloorCabinet(updatedCabinetList);
+  };
+
   const onSaveEditMemo = (newTitle: string | null, newMemo: string) => {
     if (newTitle !== myCabinetInfo.cabinet_title) {
       //수정사항이 있으면
@@ -28,6 +50,8 @@ const MemoModalContainer = (props: {
             cabinet_title: newTitle,
             cabinet_memo: newMemo,
           });
+          // list에서 제목 업데이트
+          updateCabinetTitleInList(newTitle);
         })
         .catch((error) => {
           console.log(error);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738
- #859 

공유사물함 정원이 가득차면 3/3 대신 제목 출력하도록 수정하였습니다.

해당 이슈 작업하면서 공유사물함 정원도 정책 관련한 부분이라 생각되어 환경변수로 처리했습니다.
노션에 frontend env 업데이트 된 부분 참고 부탁드립니다!
기존 ServiceManual에서 3으로 고정되어 있던 부분만 환경변수로 대체되었습니다.
CabinetListItem에서는 환경변수 값이 아니라 props에 max_user값을 사용합니다.(사물함마다 정원이 달라질 수 있을 가능성)

내 사물함 제목 수정시에도 바로 반영될 수 있도록 상태 업데이트하는 부분이 추가되었습니다.
