### PR TITLE
[BE] FEAT : cabinet/count/floor 구현 #879

### DIFF
--- a/backend/src/admin/cabinet/cabinet.controller.ts
+++ b/backend/src/admin/cabinet/cabinet.controller.ts
@@ -197,4 +197,13 @@ export class AdminCabinetController {
     this.logger.debug(`Called ${this.updateCabinetTitleByCabinetId.name}`);
     await this.adminCabinetService.updateCabinetTitle(cabinetId, title);
   }
+
+  @ApiOperation({
+    summary: '전 층의 사물함 정보를 가져옵니다.',
+  })
+  @Get('/count/floor')
+  async getCabinetCountFloor(): Promise<CabinetFloorDto[]> {
+    this.logger.log(`Called ${this.getCabinetCountFloor.name}`);
+    return await this.adminCabinetService.getCabinetCountFloor();
+  }
 }

--- a/backend/src/admin/cabinet/cabinet.service.ts
+++ b/backend/src/admin/cabinet/cabinet.service.ts
@@ -23,7 +23,7 @@ export class AdminCabinetService {
   ) {}
 
   async getCabinetCountFloor(): Promise<CabinetFloorDto[]> {
-    this.logger.debug('call getCabinetCountFloor');
+    this.logger.debug(`Called ${this.getCabinetCountFloor.name}`);
     const result = await this.adminCabinetRepository.getCabinetCountFloor();
     return result;
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/879

기존 어드민에서 사용하던 getCabinetCountFloor에 대한 API가 없어서 재구현했습니다.
