### PR TITLE
[FE] 루트로 접근 시 login으로 리다이렉션되면서 Nav 보이는 버그 #892

### DIFF
--- a/frontend/src/components/LeftNav/LeftNav.tsx
+++ b/frontend/src/components/LeftNav/LeftNav.tsx
@@ -7,12 +7,10 @@ const LeftNav: React.FC<{ isVisible: boolean; isAdmin?: boolean }> = ({
   isVisible,
 }) => {
   return (
-    <>
-      <LeftNavWrapStyled id="leftNavWrap">
-        <LeftMainNavContainer isAdmin={isAdmin} />
-        <LeftSectionNavContainer isVisible={isVisible} />
-      </LeftNavWrapStyled>
-    </>
+    <LeftNavWrapStyled id="leftNavWrap">
+      <LeftMainNavContainer isAdmin={isAdmin} />
+      <LeftSectionNavContainer isVisible={isVisible} />
+    </LeftNavWrapStyled>
   );
 };
 

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -26,20 +26,20 @@ const Layout = (): JSX.Element => {
   const isLoginPage: boolean = location.pathname === "/login";
   const isMainPage: boolean = location.pathname === "/main";
 
+  const getMyInfo = async () => {
+    try {
+      const { data: myInfo } = await axiosMyInfo();
+      setUser(myInfo);
+      setIsValidToken(true);
+      if (isRootPath || isLoginPage) navigate("/home");
+    } catch (error) {
+      navigate("/login");
+    }
+  };
+
   useEffect(() => {
     if (!token && !isLoginPage) navigate("/login");
-
-    if (token) {
-      const getMyInfo = async () => {
-        try {
-          const { data: myInfo } = await axiosMyInfo();
-          setUser(myInfo);
-          setIsValidToken(true);
-          if (isRootPath || isLoginPage) navigate("/home");
-        } catch (error) {
-          navigate("/login");
-        }
-      };
+    else if (token) {
       getMyInfo();
     }
   }, []);

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -15,7 +15,7 @@ import useMenu from "@/hooks/useMenu";
 import MapInfoContainer from "@/components/MapInfo/MapInfo.container";
 
 const Layout = (): JSX.Element => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isValidToken, setIsValidToken] = useState<boolean>(false);
   const setUser = useSetRecoilState<UserDto>(userState);
   const navigate = useNavigate();
@@ -30,7 +30,6 @@ const Layout = (): JSX.Element => {
     if (!token && !isLoginPage) navigate("/login");
 
     if (token) {
-      setIsLoading(true);
       const getMyInfo = async () => {
         try {
           const { data: myInfo } = await axiosMyInfo();

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -11,7 +11,7 @@ import useMenu from "@/hooks/useMenu";
 import MapInfoContainer from "@/components/MapInfo/MapInfo.container";
 
 const Layout = (): JSX.Element => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isValidToken, setIsValidToken] = useState<boolean>(false);
   const navigate = useNavigate();
   const location = useLocation();
@@ -30,7 +30,6 @@ const Layout = (): JSX.Element => {
   useEffect(() => {
     if (!token && !isLoginPage) navigate("/admin/login");
     if (token) {
-      setIsLoading(true);
       setIsValidToken(true);
       if (checkPath()) navigate("/admin/home");
     }

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -12,7 +12,6 @@ import MapInfoContainer from "@/components/MapInfo/MapInfo.container";
 
 const Layout = (): JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [isValidToken, setIsValidToken] = useState<boolean>(false);
   const navigate = useNavigate();
   const location = useLocation();
   const token = getCookie("admin_access_token");
@@ -29,8 +28,8 @@ const Layout = (): JSX.Element => {
 
   useEffect(() => {
     if (!token && !isLoginPage) navigate("/admin/login");
-    if (token) {
-      setIsValidToken(true);
+    else if (token) {
+      setIsLoading(true);
       if (checkPath()) navigate("/admin/home");
     }
   }, []);
@@ -45,7 +44,7 @@ const Layout = (): JSX.Element => {
     <Outlet />
   ) : (
     <React.Fragment>
-      {isValidToken && <AdminTopNavContainer setIsLoading={setIsLoading} />}
+      {token && <AdminTopNavContainer setIsLoading={setIsLoading} />}
       {isLoading ? (
         <LoadingAnimation />
       ) : (


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/892

isLoading 상태의 초기 값을 true로 두어서 처음 들어왔을때 무조건 Loading 애니메이션이 보이도록 변경하였습니다.

해당 상태는 TopNavContainer에서 getLocationsData api가 성공적으로 불러와지는 경우에 false가 되면서 모든 레이아웃이 정상적으로 보이게 됩니다.

Closes #892 
