### PR TITLE
[FE] BUG: 삼성 인터넷 앱에서 버튼 클릭 시 블루 하이라이트 유지되는 버그 #905

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -151,3 +151,7 @@ input {
   background: var(--main-color);
   color: var(--white) !important;
 }
+
+.cabiButton {
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/905

아래의 코드를 사용할 시 하이라이트를 막아준다는 stackoverflow의 내용을 보고 적용중입니다. 적용 후 삼성핸드폰으로 확인을 거치도록 하겠습니다.

```
-webkit-tap-highlight-color: transparent;
```
