### PR TITLE
[BE] 어드민 페이지 검색 시 검색된 유저의 대여 정보 받아오는 API 구현 #921

### DIFF
--- a/backend/src/admin/dto/cabinet.info.dto.ts
+++ b/backend/src/admin/dto/cabinet.info.dto.ts
@@ -43,6 +43,18 @@ export class CabinetInfoDto {
   status: CabinetStatusType; // 사물함의 현재 상태
 
   @ApiProperty({
+    description: '사물함의 사물함 건물',
+    example: '새롬관',
+  })
+  location: string; // 사물함 건물
+
+  @ApiProperty({
+    description: '사물함의 위치 (층)',
+    example: 2,
+  })
+  floor: number; // 사물함의 위치 (층)
+
+  @ApiProperty({
     description: '사물함의 섹션 종류 (오아시스 등)',
     example: 'Oasis',
   })

--- a/backend/src/admin/dto/user.cabinet.info.dto.ts
+++ b/backend/src/admin/dto/user.cabinet.info.dto.ts
@@ -1,0 +1,40 @@
+import { UserDto } from 'src/dto/user.dto';
+import { CabinetDto } from './cabinet.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import LentType from 'src/enums/lent.type.enum';
+import CabinetStatusType from 'src/enums/cabinet.status.type.enum';
+
+export class UserCabinetInfoDto {
+  @ApiProperty({
+    description: '유저 정보 배열',
+    example: [
+      {
+        user_id: 1,
+        intra_id: 'sichoi',
+      },
+      {
+        user_id: 2,
+        intra_id: 'sanan',
+      },
+      {
+        user_id: 3,
+        intra_id: 'eunbikim',
+      },
+    ],
+  })
+  userInfo?: UserDto[];
+
+  @ApiProperty({
+    description: '해당 유저들이 대여중인 사물함 정보',
+    example: {
+      cabinet_id: 1,
+      cabinet_num: 81,
+      lent_type: LentType.SHARE,
+      cabinet_title: '푸주와 아이들이 사용하는 사물함입니다',
+      max_user: 3,
+      status: CabinetStatusType.SET_EXPIRE_FULL,
+      section: 'Oasis',
+    },
+  })
+  cabinetInfo?: CabinetDto;
+}

--- a/backend/src/admin/dto/user.cabinet.info.pagenation.dto.ts
+++ b/backend/src/admin/dto/user.cabinet.info.pagenation.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserCabinetInfoDto } from './user.cabinet.info.dto';
+
+/**
+ * intraId로 검색했을 때, 해당 유저가 대여중인 사물함 정보와 해당 사물함을 대여한 유저들의 정보를 반환합니다.
+ * pagination을 위해 검색 결과의 총 길이도 함께 반환합니다.
+ */
+export class UserCabinetInfoPagenationDto {
+  @ApiProperty({
+    description: '유저 & 사물함 정보 배열',
+    type: [UserCabinetInfoDto],
+  })
+  result: UserCabinetInfoDto[];
+
+  @ApiProperty({
+    description: 'DB에 저장된 총 결과의 길이',
+    example: 42,
+  })
+  total_length: number;
+}

--- a/backend/src/admin/search/repository/search.repository.interface.ts
+++ b/backend/src/admin/search/repository/search.repository.interface.ts
@@ -1,6 +1,7 @@
 import { BlockedUserInfoPagenationDto } from 'src/admin/dto/blocked.user.info.pagenation.dto';
 import { BrokenCabinetInfoPagenationDto } from 'src/admin/dto/broken.cabinet.info.pagenation.dto';
 import { CabinetInfoPagenationDto } from 'src/admin/dto/cabinet.info.pagenation.dto';
+import { UserCabinetInfoPagenationDto } from 'src/admin/dto/user.cabinet.info.pagenation.dto';
 import { UserInfoPagenationDto } from 'src/admin/dto/user.info.pagenation.dto';
 import LentType from 'src/enums/lent.type.enum';
 
@@ -18,6 +19,20 @@ export interface IAdminSearchRepository {
     page: number,
     length: number,
   ): Promise<UserInfoPagenationDto>;
+
+  /**
+   * intraId를 포함하는 유저들을 찾아서 대여중인 사물함 정보와 사물함을 대여중인 유저들의 정보를 반환합니다.
+   *
+   * @param intraId 인트라 아이디
+   * @param page 가져올 데이터 페이지
+   * @param length 가져올 데이터 길이
+   * @returns UserCabinetInfoPagenationDto
+   */
+  searchUserCabinetListByIntraId(
+    intraId: string,
+    page: number,
+    length: number,
+  ): Promise<UserCabinetInfoPagenationDto>;
 
   /**
    * 특정 캐비넷 타입인 사물함 리스트를 가지고 옵니다.

--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -127,6 +127,8 @@ export class AdminSearchRepository implements IAdminSearchRepository {
         cabinet_title: cabinet.title,
         max_user: cabinet.max_user,
         status: cabinet.status,
+        location: cabinet.location,
+        floor: cabinet.floor,
         section: cabinet.section,
         lent_info: cabinet.lent.map((lent) => ({
           user_id: lent.user.user_id,
@@ -159,6 +161,8 @@ export class AdminSearchRepository implements IAdminSearchRepository {
         cabinet_title: cabinet.title,
         max_user: cabinet.max_user,
         status: cabinet.status,
+        location: cabinet.location,
+        floor: cabinet.floor,
         section: cabinet.section,
         lent_info: cabinet.lent.map((lent) => ({
           user_id: lent.user.user_id,
@@ -194,6 +198,8 @@ export class AdminSearchRepository implements IAdminSearchRepository {
         cabinet_title: cabinet.title,
         max_user: cabinet.max_user,
         status: cabinet.status,
+        location: cabinet.location,
+        floor: cabinet.floor,
         section: cabinet.section,
         lent_info: cabinet.lent.map((lent) => ({
           user_id: lent.user.user_id,

--- a/backend/src/admin/search/search.controller.ts
+++ b/backend/src/admin/search/search.controller.ts
@@ -25,6 +25,7 @@ import { BrokenCabinetInfoPagenationDto } from '../dto/broken.cabinet.info.pagen
 import { BlockedUserInfoPagenationDto } from '../dto/blocked.user.info.pagenation.dto';
 import { AdminSearchService } from './search.service';
 import { AdminJwtAuthGuard } from 'src/admin/auth/jwt/guard/jwtauth.guard';
+import { UserCabinetInfoPagenationDto } from '../dto/user.cabinet.info.pagenation.dto';
 
 @ApiTags('(Admin) Search')
 @ApiBearerAuth()
@@ -63,6 +64,42 @@ export class SearchController {
     this.logger.debug(`Called ${this.getUserListByIntraId.name}`);
     try {
       return await this.adminSearchService.searchByIntraId(
+        intraId,
+        page,
+        length,
+      );
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
+  @ApiOperation({
+    summary: '인트라 아이디 검색',
+    description:
+      'intraId를 포함하는 유저들을 찾아서 대여중인 사물함 정보와 사물함을 대여중인 유저들의 정보를 반환합니다.',
+  })
+  @ApiQuery({
+    name: 'page',
+    description: '(페이지네이션) 가져올 데이터 페이지',
+  })
+  @ApiQuery({
+    name: 'length',
+    description: '(페이지네이션) 가져올 데이터 길이',
+  })
+  @ApiParam({
+    name: 'intraId',
+    description: '인트라 아이디',
+  })
+  @Get(':intraId')
+  async searchUserCabinetListByIntraId(
+    @Param('intraId') intraId: string,
+    @Query('page', ParseIntPipe) page: number,
+    @Query('length', ParseIntPipe) length: number,
+  ): Promise<UserCabinetInfoPagenationDto> {
+    this.logger.debug(`Called ${this.searchUserCabinetListByIntraId.name}`);
+    try {
+      return await this.adminSearchService.searchUserCabinetListByIntraId(
         intraId,
         page,
         length,

--- a/backend/src/admin/search/search.service.ts
+++ b/backend/src/admin/search/search.service.ts
@@ -6,7 +6,6 @@ import { BrokenCabinetInfoPagenationDto } from '../dto/broken.cabinet.info.pagen
 import { BlockedUserInfoPagenationDto } from '../dto/blocked.user.info.pagenation.dto';
 import { IAdminSearchRepository } from './repository/search.repository.interface';
 import { UserCabinetInfoPagenationDto } from '../dto/user.cabinet.info.pagenation.dto';
-import { UserCabinetInfoDto } from '../dto/user.cabinet.info.dto';
 
 @Injectable()
 export class AdminSearchService {
@@ -90,7 +89,6 @@ export class AdminSearchService {
 
   /**
    * 해당 사물함 번호를 가진 사물함 리스트를 반환합니다.
-   * FIXME: location, floor 정보도 제공해주도록 수정해야 합니다.
    * @param visibleNum 사물함 번호
    * @returns CabinetInfoPagenationDto
    * @throw HTTPError

--- a/backend/src/admin/search/search.service.ts
+++ b/backend/src/admin/search/search.service.ts
@@ -5,6 +5,8 @@ import { CabinetInfoPagenationDto } from '../dto/cabinet.info.pagenation.dto';
 import { BrokenCabinetInfoPagenationDto } from '../dto/broken.cabinet.info.pagenation.dto';
 import { BlockedUserInfoPagenationDto } from '../dto/blocked.user.info.pagenation.dto';
 import { IAdminSearchRepository } from './repository/search.repository.interface';
+import { UserCabinetInfoPagenationDto } from '../dto/user.cabinet.info.pagenation.dto';
+import { UserCabinetInfoDto } from '../dto/user.cabinet.info.dto';
 
 @Injectable()
 export class AdminSearchService {
@@ -39,6 +41,30 @@ export class AdminSearchService {
   }
 
   /**
+   * intraId를 포함하는 유저들을 찾아서 대여중인 사물함 정보와 사물함을 대여중인 유저들의 정보를 반환합니다.
+   *
+   * @param intraId 인트라 아이디
+   * @param page 가져올 데이터 페이지
+   * @param length 가져올 데이터 길이
+   * @returns UserCabinetInfoPagenationDto
+   * @throw HTTPError
+   */
+  async searchUserCabinetListByIntraId(
+    intraId: string,
+    page: number,
+    length: number,
+  ): Promise<UserCabinetInfoPagenationDto> {
+    this.logger.debug(
+      `Called ${AdminSearchService.name} ${this.searchUserCabinetListByIntraId.name}`,
+    );
+    return await this.adminSearchRepository.searchUserCabinetListByIntraId(
+      intraId,
+      page,
+      length,
+    );
+  }
+
+  /**
    * 특정 캐비넷 타입인 사물함 리스트를 가지고 옵니다.
    *
    * @param lentType 대여 타입
@@ -64,7 +90,7 @@ export class AdminSearchService {
 
   /**
    * 해당 사물함 번호를 가진 사물함 리스트를 반환합니다.
-   *
+   * FIXME: location, floor 정보도 제공해주도록 수정해야 합니다.
    * @param visibleNum 사물함 번호
    * @returns CabinetInfoPagenationDto
    * @throw HTTPError


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

`/api/admin/search/:intraId` 라는 API가 추가되었습니다.
해당 API를 요청하면 intraId를 포함하는 유저들을 찾아서 대여중인 사물함 정보와 사물함을 대여중인 유저들의 정보를 반환합니다.
아래는 응답 예시입니다.
```
{
    "result": [
        {
            "userInfo": [
                {
                    "user_id": 85330,
                    "intra_id": "sichoi"
                },
                {
                    "user_id": 1,
                    "intra_id": "test1"
                }
            ],
            "cabinetInfo": {
                "cabinet_id": 81,
                "cabinet_num": 1,
                "lent_type": "SHARE",
                "cabinet_title": null,
                "max_user": 3,
                "status": "AVAILABLE",
                "section": "End of Cluster 1",
                "status_note": null
            }
        },
        {
            "userInfo": [
                {
                    "user_id": 3,
                    "intra_id": "test3"
                }
            ],
            "cabinetInfo": {
                "cabinet_id": 82,
                "cabinet_num": 2,
                "lent_type": "SHARE",
                "cabinet_title": null,
                "max_user": 3,
                "status": "AVAILABLE",
                "section": "End of Cluster 1",
                "status_note": null
            }
        },
        null
    ],
    "total_length": 3
}
```
param으로 `test`라는 값을 주었을 때, 아래와 같이 test1이라는 유저가 빌린 사물함 정보와 그 사물함을 대여중인 유저들의 정보가 제공됩니다.
test3도 마찬가지로 정보가 제공되고, test2의 경우, 대여중인 사물함이 없어 null이 제공됩니다.

또한 null이 아닌 값들이 우선적으로 제공되며, cabinet_num을 기준으로 오름차순 정렬됩니다.

https://github.com/innovationacademy-kr/42cabi/issues/
