### PR TITLE
[FE] FEAT: search페이지 검색을 위한 기능 및 컴포넌트 추가 #868

### DIFF
--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -70,36 +70,32 @@ export class AdminSearchRepository implements IAdminSearchRepository {
     const rtn = {
       result: result[0].map(
         (user) =>
-          user.Lent &&
-          user.Lent.cabinet && {
-            userInfo: user.Lent.cabinet.lent.map((lent) => ({
-              user_id: lent.user.user_id,
-              intra_id: lent.user.intra_id,
-            })),
-            cabinetInfo: {
-              cabinet_id: user.Lent.cabinet.cabinet_id,
-              cabinet_num: user.Lent.cabinet.cabinet_num,
-              lent_type: user.Lent.cabinet.lent_type,
-              cabinet_title: user.Lent.cabinet.title,
-              max_user: user.Lent.cabinet.max_user,
-              status: user.Lent.cabinet.status,
-              section: user.Lent.cabinet.section,
-              status_note: user.Lent.cabinet.status_note,
-            },
+          user && {
+            user_id: user.user_id,
+            intra_id: user.intra_id,
+            cabinetInfo: user.Lent &&
+              user.Lent.cabinet && {
+                cabinet_id: user.Lent.cabinet.cabinet_id,
+                cabinet_num: user.Lent.cabinet.cabinet_num,
+                lent_type: user.Lent.cabinet.lent_type,
+                cabinet_title: user.Lent.cabinet.title,
+                max_user: user.Lent.cabinet.max_user,
+                status: user.Lent.cabinet.status,
+                section: user.Lent.cabinet.section,
+                status_note: user.Lent.cabinet.status_note,
+              },
           },
       ),
       total_length: result[1],
     };
     // lent가 있는 값들을 우선적으로 하며, cabinet_num을 오름차순으로 정렬
     rtn.result.sort((a, b) => {
-      if (a && b) {
-        if (a.cabinetInfo.cabinet_num > b.cabinetInfo.cabinet_num) return 1;
+      if (a.cabinetInfo && b.cabinetInfo) {
+        if (a.cabinetInfo.cabinet_num > b.cabinetInfo.cabinet_num) return -1;
         else if (a.cabinetInfo.cabinet_num < b.cabinetInfo.cabinet_num)
-          return -1;
+          return 1;
         else return 0;
-      } else if (a) return -1;
-      else if (b) return 1;
-      else return 0;
+      }
     });
 
     return rtn;

--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -88,13 +88,18 @@ export class AdminSearchRepository implements IAdminSearchRepository {
       ),
       total_length: result[1],
     };
-    // lent가 있는 값들을 우선적으로 하며, cabinet_num을 오름차순으로 정렬
+    // lent가 있는 값들을 우선적으로 하며, cabinet_id를 오름차순으로 정렬
     rtn.result.sort((a, b) => {
       if (a.cabinetInfo && b.cabinetInfo) {
-        if (a.cabinetInfo.cabinet_num > b.cabinetInfo.cabinet_num) return -1;
-        else if (a.cabinetInfo.cabinet_num < b.cabinetInfo.cabinet_num)
+        return a.cabinetInfo.cabinet_id - b.cabinetInfo.cabinet_id;
+      } else if (!a.cabinetInfo && !b.cabinetInfo) {
+        if (a.intra_id < b.intra_id) {
+          return -1;
+        } else if (a.intra_id > b.intra_id) {
           return 1;
-        else return 0;
+        } else {
+          return 0;
+        }
       }
     });
 

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -164,3 +164,21 @@ export const axiosSearchByCabinetNum = async (number: number) => {
     throw error;
   }
 };
+
+const axiosSearchDetailByIntraIdURL = "/api/admin/search/";
+export const axiosSearchDetailByIntraId = async (
+  intraId: string,
+  page: number
+) => {
+  try {
+    const response = await instance.get(
+      axiosSearchDetailByIntraIdURL + intraId,
+      {
+        params: { page: page, length: 10 },
+      }
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/frontend/src/assets/images/logoBlack.svg
+++ b/frontend/src/assets/images/logoBlack.svg
@@ -1,0 +1,7 @@
+<svg width="37" height="37" viewBox="0 0 37 37" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 8.5L18.5 16L27.25 12.25L36 8.5L18.5 1L9.75 4.75L1 8.5Z" fill="white"/>
+<path d="M18.5 36V16L1 8.5V28.5L18.5 36Z" fill="white"/>
+<path d="M18.5 16V36L36 28.5V8.5L27.25 12.25L18.5 16Z" fill="#222222"/>
+<path d="M18.5 36V16M18.5 36L1 28.5V8.5M18.5 36L36 28.5V8.5M18.5 16L27.25 12.25M18.5 16L1 8.5M1 8.5L9.75 4.75M36 8.5L27.25 12.25M36 8.5L18.5 1L9.75 4.75M27.25 12.25L9.75 4.75" stroke="#222222" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M25.5 18.5L30 16.5" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/images/selectPurple.svg
+++ b/frontend/src/assets/images/selectPurple.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="9" viewBox="0 0 13 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L6.5 7L12 1" stroke="#9747ff" stroke-width="1"/>
+</svg>

--- a/frontend/src/components/Search/NoSearch.tsx
+++ b/frontend/src/components/Search/NoSearch.tsx
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+const NoSearch = () => (
+  <WraaperStyled>
+    <NoSearchStyled>
+      <img src="/src/assets/images/logoBlack.svg" alt="로고 블랙" />
+      <p>검색 결과가 없습니다</p>
+    </NoSearchStyled>
+  </WraaperStyled>
+);
+
+const WraaperStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const NoSearchStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  & > img {
+    width: 35px;
+    height: 35px;
+  }
+  & > p {
+    margin-top: 10px;
+    font-size: 1.125rem;
+    color: var(--gray-color);
+  }
+`;
+
+export default NoSearch;

--- a/frontend/src/components/Search/SearchDefault.tsx
+++ b/frontend/src/components/Search/SearchDefault.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+const SearchDefault = () => (
+  <WraaperStyled>
+    <SearchDefaultStyled>
+      <img src="/src/assets/images/logo.svg" alt="로고" />
+      <p>
+        Intra ID 또는 사물함 번호를
+        <br />
+        입력하세요
+      </p>
+    </SearchDefaultStyled>
+  </WraaperStyled>
+);
+
+const WraaperStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SearchDefaultStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  & > img {
+    width: 35px;
+    height: 35px;
+  }
+  & > p {
+    margin-top: 10px;
+    font-size: 1.125rem;
+    color: var(--gray-color);
+    text-align: center;
+    line-height: 1.75rem;
+  }
+`;
+
+export default SearchDefault;

--- a/frontend/src/components/Search/SearchItemByIntraId.tsx
+++ b/frontend/src/components/Search/SearchItemByIntraId.tsx
@@ -1,0 +1,118 @@
+import { cabinetIconSrcMap, cabinetStatusColorMap } from "@/assets/data/maps";
+import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+import styled from "styled-components";
+import ChangeToHTML from "../TopNav/SearchBar/SearchListItem/ChangeToHTML";
+
+interface ISearchDetail {
+  intra_id: string;
+  user_id: number;
+  cabinetInfo?: CabinetInfo;
+  searchValue: string;
+}
+
+const SearchItemByIntraId = (props: ISearchDetail) => {
+  const { intra_id, cabinetInfo, searchValue } = props;
+
+  return cabinetInfo ? (
+    <WrapperStyled className="cabiButton">
+      <RectangleStyled status={cabinetInfo.status}>
+        {cabinetInfo.cabinet_num}
+      </RectangleStyled>
+      <TextWrapper>
+        <LocationStyled>{`${cabinetInfo.floor}층 - ${cabinetInfo.section}`}</LocationStyled>
+        <NameWrapperStyled>
+          <IconStyled lent_type={cabinetInfo.lent_type} />
+          <NameStyled>
+            <ChangeToHTML origin={intra_id} replace={searchValue} />
+          </NameStyled>
+        </NameWrapperStyled>
+      </TextWrapper>
+    </WrapperStyled>
+  ) : (
+    <WrapperStyled className="cabiButton">
+      <RectangleStyled>-</RectangleStyled>
+      <TextWrapper>
+        <LocationStyled>대여 중이 아닌 사용자</LocationStyled>
+        <NameWrapperStyled>
+          <IconStyled />
+          <NameStyled>
+            <ChangeToHTML origin={intra_id} replace={searchValue} />
+          </NameStyled>
+        </NameWrapperStyled>
+      </TextWrapper>
+    </WrapperStyled>
+  );
+};
+
+const WrapperStyled = styled.div`
+  width: 350px;
+  height: 110px;
+  border-radius: 10px;
+  padding: 25px;
+  background-color: var(--lightgary-color);
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  &:hover {
+    outline: 2px solid var(--main-color);
+  }
+`;
+
+const RectangleStyled = styled.div<{ status?: CabinetStatus }>`
+  width: 60px;
+  height: 60px;
+  border-radius: 10px;
+  background-color: ${(props) =>
+    props.status ? cabinetStatusColorMap[props.status] : "var(--full)"};
+  font-size: 26px;
+  color: var(--white);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 10px;
+`;
+
+const LocationStyled = styled.p`
+  font-size: 14px;
+  line-height: 28px;
+  color: var(--gray-color);
+`;
+
+const NameWrapperStyled = styled.div`
+  position: relative;
+  height: 28px;
+  line-height: 28px;
+  display: flex;
+  justify-content: flex-start;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+
+const IconStyled = styled.div<{ lent_type?: CabinetType }>`
+  width: 18px;
+  height: 28px;
+  background: url(${(props) =>
+      props.lent_type
+        ? cabinetIconSrcMap[props.lent_type]
+        : cabinetIconSrcMap[CabinetType.PRIVATE]})
+    no-repeat center center / contain;
+`;
+
+const NameStyled = styled.span`
+  line-height: 28px;
+  font-size: 14px;
+  margin-left: 4px;
+  & strong {
+    color: var(--main-color);
+  }
+`;
+
+export default SearchItemByIntraId;

--- a/frontend/src/components/Search/SearchItemByNum.tsx
+++ b/frontend/src/components/Search/SearchItemByNum.tsx
@@ -1,19 +1,29 @@
 import { cabinetIconSrcMap, cabinetStatusColorMap } from "@/assets/data/maps";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import { LentDto } from "@/types/dto/lent.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import styled from "styled-components";
 
-const SearchItem = (props: CabinetInfo) => {
+const handleIntraId = (lent_info: LentDto[]) => {
+  if (lent_info.length === 0) {
+    return "-";
+  } else {
+    const intra_id = lent_info.map((item) => item.intra_id);
+    return intra_id.join(", ");
+  }
+};
+
+const SearchItemByNum = (props: CabinetInfo) => {
   const { floor, section, cabinet_num, status, lent_type, lent_info } = props;
   return (
     <WrapperStyled className="cabiButton">
       <RectangleStyled status={status}>{cabinet_num}</RectangleStyled>
       <TextWrapper>
-        <LocationStyled>{`${floor} - ${section}`}</LocationStyled>
+        <LocationStyled>{`${floor}층 - ${section}`}</LocationStyled>
         <NameWrapperStyled>
           <IconStyled lent_type={lent_type} />
-          <NameStyled>42cabi, seycho, yooh</NameStyled>
+          <NameStyled>{handleIntraId(lent_info)}</NameStyled>
         </NameWrapperStyled>
       </TextWrapper>
     </WrapperStyled>
@@ -39,7 +49,7 @@ const RectangleStyled = styled.div<{ status: CabinetStatus }>`
   height: 60px;
   border-radius: 10px;
   background-color: ${(props) => cabinetStatusColorMap[props.status]};
-  font-size: 32px;
+  font-size: 26px;
   color: var(--white);
   display: flex;
   justify-content: center;
@@ -82,4 +92,4 @@ const NameStyled = styled.span`
   margin-left: 4px;
 `;
 
-export default SearchItem;
+export default SearchItemByNum;

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -72,7 +72,7 @@ const SearchBar = () => {
           console.log(searchResult.data.result);
           setSearchListByNum([]);
           setSearchListById(searchResult.data.result);
-          setTotalLength(searchResult.data.result.length);
+          setTotalLength(searchResult.data.total_length);
         }
       } else {
         // cabinetnumber 검색
@@ -85,7 +85,7 @@ const SearchBar = () => {
           );
           setSearchListById([]);
           setSearchListByNum(searchResult.data.result);
-          setTotalLength(searchResult.data.result.length);
+          setTotalLength(searchResult.data.total_length);
         }
       }
     }
@@ -106,12 +106,15 @@ const SearchBar = () => {
       ></SearchBarStyled>
       <SearchButtonStyled onClick={SearchBarButtonHandler} />
       {searchInput.current?.value && totalLength > 0 && (
-        <SearchBarList
-          searchListById={searchListById}
-          searchListByNum={searchListByNum}
-          searchWord={searchInput.current?.value}
-          searchClear={searchClear}
-        />
+        <>
+          <SearchBarList
+            searchListById={searchListById}
+            searchListByNum={searchListByNum}
+            searchWord={searchInput.current?.value}
+            searchClear={searchClear}
+            totalLength={totalLength}
+          />
+        </>
       )}
     </SearchBarWrapperStyled>
   );

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -12,25 +12,29 @@ const SearchBar = () => {
   const searchInput = useRef<HTMLInputElement>(null);
   const [searchListById, setSearchListById] = useState<any[]>([]);
   const [searchListByNum, setSearchListByNum] = useState<any[]>([]);
-  const totalLength = useRef<number>(0);
+  const [totalLength, setTotalLength] = useState<number>(0);
 
   const searchClear = () => {
+    setSearchListById([]);
+    setSearchListByNum([]);
+    setTotalLength(0);
     if (searchInput.current) {
-      setSearchListById([]);
-      setSearchListByNum([]);
-      totalLength.current = 0;
       searchInput.current.value = "";
     }
   };
 
   const SearchBarButtonHandler = () => {
     if (searchInput.current) {
-      if (searchInput.current && searchInput.current.value.length <= 0) return;
-      navigate({
-        pathname: "search",
-        search: `?q=${searchInput.current.value}`,
-      });
-      searchClear();
+      if (searchInput.current.value.length <= 0) {
+        searchClear();
+        return alert("검색어를 입력해주세요.");
+      } else {
+        navigate({
+          pathname: "search",
+          search: `?q=${searchInput.current.value}`,
+        });
+        searchClear();
+      }
     }
   };
 
@@ -48,30 +52,40 @@ const SearchBar = () => {
   };
 
   const searchInputHandler = async () => {
+    console.log("searchInputHandler");
+
     if (searchInput.current) {
       const searchValue = searchInput.current.value;
-
+      if (searchValue.length <= 0) {
+        setSearchListById([]);
+        setSearchListByNum([]);
+        setTotalLength(0);
+        return;
+      }
       if (isNaN(Number(searchValue))) {
         // intra_ID 검색
         if (searchValue.length <= 1) {
           setSearchListById([]);
-          totalLength.current = 0;
+          setTotalLength(0);
         } else {
           const searchResult = await axiosSearchByIntraId(searchValue);
+          console.log(searchResult.data.result);
+          setSearchListByNum([]);
           setSearchListById(searchResult.data.result);
-          totalLength.current = searchResult.data.result.length;
+          setTotalLength(searchResult.data.result.length);
         }
       } else {
         // cabinetnumber 검색
         if (searchValue.length <= 0) {
           setSearchListByNum([]);
-          totalLength.current = 0;
+          setTotalLength(0);
         } else {
           const searchResult = await axiosSearchByCabinetNum(
             Number(searchValue)
           );
+          setSearchListById([]);
           setSearchListByNum(searchResult.data.result);
-          totalLength.current = searchResult.data.result.length;
+          setTotalLength(searchResult.data.result.length);
         }
       }
     }
@@ -91,7 +105,7 @@ const SearchBar = () => {
         }}
       ></SearchBarStyled>
       <SearchButtonStyled onClick={SearchBarButtonHandler} />
-      {totalLength.current > 0 && (
+      {searchInput.current?.value && totalLength > 0 && (
         <SearchBarList
           searchListById={searchListById}
           searchListByNum={searchListByNum}

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -25,9 +25,13 @@ const SearchBar = () => {
 
   const SearchBarButtonHandler = () => {
     if (searchInput.current) {
-      if (searchInput.current.value.length <= 0) {
+      const searchValue = searchInput.current.value;
+      if (searchValue.length <= 0) {
         searchClear();
         return alert("검색어를 입력해주세요.");
+      } else if (isNaN(Number(searchValue)) && searchValue.length <= 1) {
+        searchClear();
+        return alert("두 글자 이상의 검색어를 입력해주세요.");
       } else {
         navigate({
           pathname: "search",

--- a/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
@@ -44,6 +44,7 @@ const SearchBarList = ({
         return (
           <SearchListItem
             key={index}
+            floor={item.floor}
             inputText={searchWord}
             resultText={item.cabinet_num.toString()}
             isNum={true}

--- a/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
@@ -22,11 +22,13 @@ const SearchBarList = ({
   searchListByNum,
   searchWord,
   searchClear,
+  totalLength,
 }: {
   searchListById: ISearchListByIntraId[];
   searchListByNum: CabinetInfo[];
   searchClear: () => void;
   searchWord?: string;
+  totalLength: number;
 }) => {
   return (
     <UlStyled>
@@ -52,6 +54,7 @@ const SearchBarList = ({
           />
         );
       })}
+      {<TotalStyled>검색 결과: {totalLength}</TotalStyled>}
     </UlStyled>
   );
 };
@@ -70,6 +73,13 @@ const UlStyled = styled.ul`
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
   opacity: 0.9;
   overflow: hidden;
+`;
+
+const TotalStyled = styled.li`
+  font-size: 0.875rem;
+  color: var(--gray-color);
+  text-align: right;
+  padding: 10px;
 `;
 
 export default SearchBarList;

--- a/frontend/src/components/TopNav/SearchBar/SearchListItem/SearchListItem.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchListItem/SearchListItem.tsx
@@ -4,12 +4,13 @@ import { useNavigate } from "react-router-dom";
 
 const SearchListItem = (props: {
   key: number;
+  floor?: number;
   inputText?: string;
   resultText: string;
   isNum?: boolean;
   searchClear: () => void;
 }) => {
-  const { resultText, inputText, isNum, searchClear } = props;
+  const { floor, resultText, inputText, isNum, searchClear } = props;
   const navigate = useNavigate();
 
   const imageHandler = (isCabinet: boolean | undefined) => {
@@ -28,6 +29,7 @@ const SearchListItem = (props: {
       }}
     >
       <ImgStyled src={imageHandler(isNum)} alt="유저" />
+      {isNum && <span>{floor}F - </span>}
       <ChangeToHTML origin={resultText} replace={inputText} />
     </LiStyled>
   );

--- a/frontend/src/pages/admin/SearchPage.tsx
+++ b/frontend/src/pages/admin/SearchPage.tsx
@@ -97,10 +97,9 @@ const SearchPage = () => {
   return (
     <>
       {isLoading && <LoadingAnimation />}
-      <WrapperStyled>
-        {!isLoading &&
-          (searchListByIntraId.length !== 0 ||
-            searchListByNum.length !== 0) && (
+      {!isLoading &&
+        (searchListByIntraId.length !== 0 || searchListByNum.length !== 0) && (
+          <WrapperStyled>
             <ListWrapperStyled>
               {searchListByIntraId.length > 0 &&
                 searchListByIntraId.map((item, index) => (
@@ -116,23 +115,25 @@ const SearchPage = () => {
                   <SearchItemByNum {...item} key={index} />
                 ))}
             </ListWrapperStyled>
-          )}
-        {totalSearchList > 10 && currentPage * 10 < totalSearchList - 10 && (
-          <MoreButtonStyled onClick={handleMoreButton}>더보기</MoreButtonStyled>
+            {totalSearchList > 10 &&
+              currentPage * 10 < totalSearchList - 10 && (
+                <MoreButtonStyled onClick={handleMoreButton}>
+                  더보기
+                </MoreButtonStyled>
+              )}
+          </WrapperStyled>
         )}
-        {!isLoading && !searchParams.get("q") && <SearchDefault />}
-        {!isLoading &&
-          searchParams.get("q") &&
-          searchListByIntraId.length === 0 &&
-          searchListByNum.length === 0 && <NoSearch />}
-      </WrapperStyled>
+      {!isLoading && !searchParams.get("q") && <SearchDefault />}
+      {!isLoading &&
+        searchParams.get("q") &&
+        searchListByIntraId.length === 0 &&
+        searchListByNum.length === 0 && <NoSearch />}
     </>
   );
 };
 
 const WrapperStyled = styled.div`
   padding: 60px 0;
-  height: 100%;
   min-height: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/admin/SearchPage.tsx
+++ b/frontend/src/pages/admin/SearchPage.tsx
@@ -1,46 +1,145 @@
-import { axiosSearchByCabinetNum } from "@/api/axios/axios.custom";
-import SearchItem from "@/components/Search/SearchItem";
+import {
+  axiosSearchByCabinetNum,
+  axiosSearchDetailByIntraId,
+} from "@/api/axios/axios.custom";
+import SearchItemByNum from "@/components/Search/SearchItemByNum";
+import SearchItemByIntraId from "@/components/Search/SearchItemByIntraId";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
+import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import NoSearch from "@/components/Search/NoSearch";
+import SearchDefault from "@/components/Search/SearchDefault";
+
+interface ISearchDetail {
+  intra_id: string;
+  user_id: number;
+  cabinetInfo?: CabinetInfo;
+}
 
 const SearchPage = () => {
-  const [searchList, setSearchList] = useState<CabinetInfo[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [searchListByNum, setSearchListByNum] = useState<CabinetInfo[]>([]);
+  const [searchListByIntraId, setSearchListByIntraId] = useState<
+    ISearchDetail[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [totalSearchList, setTotalSearchList] = useState(0);
+  const [currentPage, setCurrentPage] = useState(0);
+  const searchValue = useRef("");
+
+  // 검색 초기화
+  const initialize = () => {
+    setIsLoading(true);
+    setSearchListByIntraId([]);
+    setSearchListByNum([]);
+    setTotalSearchList(0);
+    setCurrentPage(0);
+    searchValue.current = searchParams.get("q") ?? "";
+  };
+
+  // intra_id 검색
+  const handleSearchDetailByIntraId = async () => {
+    const searchResult = await axiosSearchDetailByIntraId(
+      searchValue.current,
+      currentPage
+    );
+    console.log(searchResult.data);
+    setSearchListByIntraId(searchResult.data.result);
+    setTotalSearchList(searchResult.data.total_length);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 500);
+  };
+
+  // cabinet_num 검색
+  const handleSearchByCabinetNum = async () => {
+    const searchResult = await axiosSearchByCabinetNum(
+      Number(searchValue.current)
+    );
+    console.log(searchResult.data);
+    setSearchListByNum(searchResult.data.result);
+    setTotalSearchList(searchResult.data.total_length);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 500);
+  };
 
   useEffect(() => {
-    setSearchList([]);
-    const searchValue = searchParams.get("q");
-    if (searchValue !== null) {
-      if (isNaN(Number(searchValue))) {
-        // intra_id 검색
+    initialize();
+    if (searchValue.current === "") {
+      setIsLoading(false);
+    } else {
+      if (isNaN(Number(searchValue.current))) {
+        handleSearchDetailByIntraId();
       } else {
-        // cabinet_num 검색
-        const handleSearch = async () => {
-          const searchResult = await axiosSearchByCabinetNum(
-            Number(searchValue)
-          );
-          setSearchList(searchResult.data.result);
-        };
-        handleSearch();
+        handleSearchByCabinetNum();
       }
     }
   }, [searchParams]);
 
+  // intra_id 검색 더보기
+  const handleMoreSearchDetailByIntraId = async () => {
+    const searchResult = await axiosSearchDetailByIntraId(
+      searchValue.current,
+      currentPage + 1
+    );
+    console.log(searchResult.data);
+    setSearchListByIntraId((prev) => [...prev, ...searchResult.data.result]);
+    setCurrentPage((prev) => prev + 1);
+  };
+
+  const handleMoreButton = () => {
+    handleMoreSearchDetailByIntraId();
+  };
+
   return (
-    <WrapperStyled>
-      {searchList.length > 0 ? (
-        searchList.map((item, index) => <SearchItem {...item} key={index} />)
-      ) : (
-        <div>검색 기록이 없습니다.</div>
-      )}
-    </WrapperStyled>
+    <>
+      {isLoading && <LoadingAnimation />}
+      <WrapperStyled>
+        {!isLoading &&
+          (searchListByIntraId.length !== 0 ||
+            searchListByNum.length !== 0) && (
+            <ListWrapperStyled>
+              {searchListByIntraId.length > 0 &&
+                searchListByIntraId.map((item, index) => (
+                  <SearchItemByIntraId
+                    {...item}
+                    key={index}
+                    searchValue={searchValue.current}
+                  />
+                ))}
+
+              {searchListByNum.length > 0 &&
+                searchListByNum.map((item, index) => (
+                  <SearchItemByNum {...item} key={index} />
+                ))}
+            </ListWrapperStyled>
+          )}
+        {totalSearchList > 10 && currentPage * 10 < totalSearchList - 10 && (
+          <MoreButtonStyled onClick={handleMoreButton}>더보기</MoreButtonStyled>
+        )}
+        {!isLoading && !searchParams.get("q") && <SearchDefault />}
+        {!isLoading &&
+          searchParams.get("q") &&
+          searchListByIntraId.length === 0 &&
+          searchListByNum.length === 0 && <NoSearch />}
+      </WrapperStyled>
+    </>
   );
 };
 
 const WrapperStyled = styled.div`
-  margin: 60px auto;
+  padding: 60px 0;
+  height: 100%;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ListWrapperStyled = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, 350px);
   grid-auto-flow: row;
@@ -48,6 +147,29 @@ const WrapperStyled = styled.div`
   min-width: 350px;
   grid-gap: 20px;
   width: 100%;
+`;
+
+const MoreButtonStyled = styled.button`
+  width: 240px;
+  height: 60px;
+  margin: 20px auto;
+  border: 1px solid var(--main-color);
+  border-radius: 30px;
+  text-indent: -20px;
+  background-color: var(--white);
+  color: var(--main-color);
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: 55%;
+    top: 50%;
+    transform: translateY(-40%);
+    width: 20px;
+    height: 20px;
+    background: url(/src/assets/images/selectPurple.svg) no-repeat 100%;
+  }
 `;
 
 export default SearchPage;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/868

[[BE] FIX: 검색 API 수정](https://github.com/innovationacademy-kr/42cabi/commit/9ad9ff95ecc4390ae41ccaa82502e78850800a93) 이 머지되어야 제대로 동작하므로, 깃 상태를 해당 PR과 같은 위치에서 시작하도록 설정하였습니다.

### 변경사항
- 최초 검색페이지 들어갔을때 필요한 SearchDefault 컴포넌트 추가
- 검색 시 숫자와 문자를 분리하여 검색하며, 검색이 없는 경우 NoSearch 컴포넌트가 나오게 처리했습니다.
- 검색한 내용이 SearchDetail 에서도 bold처리되도록 변경했습니다.
- 숫자로 검색 시 검색바 리스트에서 층도 나오도록 수정했습니다.
- total_length를 받아 "더보기"가 나오는 조건을 추가했으며, 클릭 시 다음 api를 호출하여 출력하도록 처리했습니다.
- 검색어가 없는 경우 alert 처리
- 검색바 리스트에 총 검색 수 뜨도록 처리