### PR TITLE
[FE] FEAT: location 선택 버튼 useOutsideClick hook 적용 #931

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="src/assets/images/logo.ico" type="image/x-icon" />
-    <link rel="shortcut icon" href="src/assets/images/logo.png" />
-    <link rel="apple-touch-icon" href="src/assets/images/logo.png" />
+    <link rel="icon" href="/src/assets/images/logo.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/src/assets/images/logo.png" />
+    <link rel="apple-touch-icon" href="/src/assets/images/logo.png" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=0.875, maximum-scale=0.875, user-scalable=no"

--- a/frontend/src/components/TopNav/TopNav.tsx
+++ b/frontend/src/components/TopNav/TopNav.tsx
@@ -3,6 +3,7 @@ import { SetterOrUpdater } from "recoil";
 import styled from "styled-components";
 import TopNavButtonGroup from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 import SearchBar from "@/components/TopNav/SearchBar/SearchBar";
+import useOutsideClick from "@/hooks/useOutsideClick";
 
 interface ILocationListItem {
   location: string;
@@ -47,6 +48,11 @@ const TopNav: React.FC<{
     isAdmin,
   } = props;
 
+  const locationDom = React.useRef<HTMLElement>(null);
+  useOutsideClick(locationDom, () => {
+    if (locationClicked) setLocationClicked(false);
+  });
+
   return (
     <TopNavContainerStyled id="topNavWrap">
       <LogoStyled className="cabiButton">
@@ -58,7 +64,7 @@ const TopNav: React.FC<{
             alt=""
           />
         </LogoDivStyled>
-        <LocationSelectBoxStyled className="cabiButton">
+        <LocationSelectBoxStyled ref={locationDom} className="cabiButton">
           <div
             className="cabiButton"
             onClick={() => setLocationClicked(!locationClicked)}

--- a/frontend/src/hooks/useOutsideClick.ts
+++ b/frontend/src/hooks/useOutsideClick.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+const useOutsideClick = (ref: any, callback: any) => {
+  const handleClick = (e: any) => {
+    if (ref.current && !ref.current.contains(e.target)) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleClick);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  });
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/931

TopNav에 있는 건물 선택 버튼에 다른 곳을 클릭할 시 해당 리스트가 닫힐 수 있도록 커스텀훅을 추가했습니다.
