### PR TITLE
[FE] FEAT: 모바일을 위한 검색 레이아웃 수정 #933

### DIFF
--- a/frontend/src/assets/css/media.css
+++ b/frontend/src/assets/css/media.css
@@ -58,12 +58,26 @@
   }
 
   #searchBar.on {
-    display: block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   #searchButton {
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  #topNavWrap.pushOut {
+    justify-content: center;
+  }
+
+  #topNavLogo.pushOut {
+    display: none;
+  }
+
+  #topNavButtonGroup.pushOut {
+    display: none;
   }
 }

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -95,6 +95,13 @@ const SearchBar = () => {
     }
   };
 
+  const cancelHandler = () => {
+    document.getElementById("searchBar")!.classList.remove("on");
+    document.getElementById("topNavLogo")!.classList.remove("pushOut");
+    document.getElementById("topNavButtonGroup")!.classList.remove("pushOut");
+    document.getElementById("topNavWrap")!.classList.remove("pushOut");
+  };
+
   return (
     <SearchBarWrapperStyled id="searchBar">
       <SearchBarStyled
@@ -120,6 +127,7 @@ const SearchBar = () => {
           />
         </>
       )}
+      <CancelButtonStyled onClick={cancelHandler}>취소</CancelButtonStyled>
     </SearchBarWrapperStyled>
   );
 };
@@ -148,7 +156,16 @@ const SearchButtonStyled = styled.button`
   height: 32px;
   position: absolute;
   top: 4px;
-  right: 14px;
+  left: 256px;
+`;
+
+const CancelButtonStyled = styled.button`
+  width: 60px;
+  height: 32px;
+  display: none;
+  @media screen and (max-width: 768px) {
+    display: block;
+  }
 `;
 
 export default SearchBar;

--- a/frontend/src/components/TopNav/TopNav.tsx
+++ b/frontend/src/components/TopNav/TopNav.tsx
@@ -49,7 +49,7 @@ const TopNav: React.FC<{
 
   return (
     <TopNavContainerStyled id="topNavWrap">
-      <LogoStyled className="cabiButton">
+      <LogoStyled id="topNavLogo" className="cabiButton">
         <LogoDivStyled>
           <img
             className="cabiButton"

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -10,7 +10,7 @@ import useMenu from "@/hooks/useMenu";
 import { axiosCabinetById } from "@/api/axios/axios.custom";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import instance from "@/api/axios/axios.instance";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
   const { toggleCabinet, toggleMap, openCabinet, closeAll } = useMenu();
@@ -21,6 +21,8 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
     targetCabinetInfoState
   );
   const myInfo = useRecoilValue(userState);
+  const { pathname } = useLocation();
+  const navigator = useNavigate();
 
   async function setTargetCabinetInfoToMyCabinet() {
     setCurrentCabinetId(myInfo.cabinet_id);
@@ -53,14 +55,21 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
     }
   };
 
-  const navigator = useNavigate();
+  const searchBarOn = () => {
+    document.getElementById("searchBar")!.classList.add("on");
+    document.getElementById("topNavLogo")!.classList.add("pushOut");
+    document.getElementById("topNavButtonGroup")!.classList.add("pushOut");
+    document.getElementById("topNavWrap")!.classList.add("pushOut");
+  };
+
   const clickSearchButton = () => {
+    if (!pathname.includes("search")) navigator("search");
     closeAll();
-    navigator("search");
+    searchBarOn();
   };
 
   return (
-    <NaviButtonsStyled>
+    <NaviButtonsStyled id="topNavButtonGroup">
       {import.meta.env.VITE_UNBAN === "true" && (
         <TopNavButton
           onClick={axiosRemovePenalty}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/933

<img width="409" alt="image" src="https://user-images.githubusercontent.com/72684256/216809496-dab2ba38-5d4c-4aad-a7fa-53bbc6d3146d.png">

검색 페이지를 들어가면 위와 같은 모양으로 나옵니다.
취소를 누르면 이전 탑네비가 나옵니다.
다시 검색버튼을 눌렸을 때 검색을 할 수 있습니다.
