### PR TITLE
[BE] lent, return e2e test 코드 작성 #793

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -67,6 +67,7 @@
         "prettier": "^2.3.2",
         "source-map-support": "^0.5.20",
         "supertest": "^6.1.3",
+        "timekeeper": "^2.2.0",
         "ts-jest": "28.0.5",
         "ts-loader": "^9.2.3",
         "ts-node": "^10.0.0",
@@ -11121,6 +11122,12 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+      "dev": true
+    },
     "node_modules/tlds": {
       "version": "1.231.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.231.0.tgz",
@@ -20823,6 +20830,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
       "dev": true
     },
     "tlds": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -89,6 +89,7 @@
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
+    "timekeeper": "^2.2.0",
     "ts-jest": "28.0.5",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",

--- a/backend/src/admin/lent/lent.controller.ts
+++ b/backend/src/admin/lent/lent.controller.ts
@@ -37,6 +37,13 @@ export class AdminLentController {
     return await this.adminLentService.getLentOverdue();
   }
 
+  // FIXME: lentService에서 intraId 사용이 필요가 없으므로
+  //        param으로 cabinetId, userId만 받아도 될 것 같습니다.
+  //        user와 cabinet이 존재하는지 확인하는 로직이 없어 500이 발생합니다.
+  //        user와 cabinet이 존재하지 않는다면 지금은 400을 반환하는 것이 맞습니다.
+  //        하지만 400은 클라이언트의 요청 문법이 잘못되었을 때 사용하는 것이므로
+  //        409를 응답하도록 수정하는게 좋을 것 같습니다.
+  //        Return type이 any가 아닌 void로 수정해야 합니다.
   @Post('/cabinet/:cabinetId/:userId')
   @ApiOperation({})
   async postLentCabinet(

--- a/backend/src/admin/return/return.controller.ts
+++ b/backend/src/admin/return/return.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Delete, Logger, Param, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Param,
+  ParseArrayPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AdminJwtAuthGuard } from 'src/admin/auth/jwt/guard/jwtauth.guard';
 import { AdminReturnService } from 'src/admin/return/return.service';
@@ -32,10 +42,29 @@ export class AdminReturnController {
     return await this.adminReturnService.returnCabinetByUserId(userId);
   }
 
+  //FIXME: 하나 이상 반납 처리에 실패한 경우, 400이 응답되고 있습니다.
+  //       하지만 400은 클라이언트의 요청 문법이 잘못되었을 때 사용하는 것이므로
+  //       409를 응답하도록 수정하는게 좋을 것 같습니다.
   @Delete('/bundle/cabinet')
   @ApiOperation({})
   async returnCabinetBundle(
+    @Body(
+      'users',
+      new ParseArrayPipe({
+        optional: true,
+        items: Number,
+        separator: ',',
+      }),
+    )
     users: number[],
+    @Body(
+      'cabinets',
+      new ParseArrayPipe({
+        optional: true,
+        items: Number,
+        separator: ',',
+      }),
+    )
     cabinets: number[],
   ): Promise<void> {
     this.logger.debug(`Called ${this.returnCabinetBundle.name}`);

--- a/backend/src/admin/return/return.controller.ts
+++ b/backend/src/admin/return/return.controller.ts
@@ -10,6 +10,9 @@ export class AdminReturnController {
   private logger = new Logger(AdminReturnController.name);
   constructor(private adminReturnService: AdminReturnService) {}
 
+  //FIXME: 해당 사물함이 존재하지 않거나, 해당 사물함을 대여중인 유저가 없는 경우,
+  //       하지만 400은 클라이언트의 요청 문법이 잘못되었을 때 사용하는 것이므로
+  //       409를 응답하도록 수정하는게 좋을 것 같습니다.
   @Delete('/cabinet/:cabinetId')
   @ApiOperation({})
   async returnCabinetByCabinetId(
@@ -19,6 +22,9 @@ export class AdminReturnController {
     return await this.adminReturnService.returnCabinetByCabinetId(cabinetId);
   }
 
+  //FIXME: 해당 유저가 존재하지 않거나, 해당 유저가 대여중인 사물함이 없는 경우,
+  //       하지만 400은 클라이언트의 요청 문법이 잘못되었을 때 사용하는 것이므로
+  //       409를 응답하도록 수정하는게 좋을 것 같습니다.
   @Delete('/user/:userId')
   @ApiOperation({})
   async returnCabinetByUserId(@Param('userId') userId: number): Promise<void> {

--- a/backend/test/admin/lent.e2e-spec.ts
+++ b/backend/test/admin/lent.e2e-spec.ts
@@ -142,6 +142,7 @@ describe('Admin Lent 모듈 테스트 (e2e)', () => {
 
         // then
         // FIXME: 400이 응답되어야 하는데, 500이 응답됨
+        //        그러나 409를 응답하도록 하는 것이 적절해보임.
         expect(response.status).toBe(500);
       });
 
@@ -165,6 +166,7 @@ describe('Admin Lent 모듈 테스트 (e2e)', () => {
 
         // then
         // FIXME: 400이 응답되어야 하는데, 500이 응답됨
+        // FIXME: 그러나 409를 응답하도록 하는 것이 적절해보임.
         expect(response.status).toBe(500);
       });
     });
@@ -189,6 +191,7 @@ describe('Admin Lent 모듈 테스트 (e2e)', () => {
           .set('Authorization', `Bearer ${token}`);
 
         // then
+        // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
         expect(response.status).toBe(400);
       });
     });

--- a/backend/test/admin/lent.e2e-spec.ts
+++ b/backend/test/admin/lent.e2e-spec.ts
@@ -4,12 +4,19 @@ import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
 import { JwtService } from '@nestjs/jwt';
 import TypeOrmConfigService from 'src/config/typeorm.config';
-import { DataSource, QueryRunner } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { UserSessionDto } from 'src/dto/user.session.dto';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { initTestDB, loadSQL } from '../utils';
+import { AdminUserDto } from 'src/admin/dto/admin.user.dto';
 
-describe('Main Lent 모듈 테스트 (e2e)', () => {
+/**
+ * 실제 테스트에 사용할 DB 이름을 적습니다.
+ * 테스트 파일들이 각각 병렬적으로 실행되므로, DB 이름을 다르게 설정해야 합니다.
+ */
+const testDBName = 'test_admin_lent';
+
+describe('Admin Lent 모듈 테스트 (e2e)', () => {
   let app: INestApplication;
   let jwtService: JwtService;
 
@@ -20,7 +27,7 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
    * TypeOrmConfigService를 override하여 테스트용 DB에 연결되도록 합니다.
    */
   beforeAll(async () => {
-    await initTestDB('test_admin_lent');
+    await initTestDB(testDBName);
     initializeTransactionalContext();
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -36,7 +43,7 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
               username: 'test_user',
               port: 3310,
               password: 'test_password',
-              database: 'test_admin_lent',
+              database: testDBName,
               entities: ['src/**/*.entity.ts'],
               synchronize: true,
               dropSchema: true,
@@ -57,11 +64,6 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
     await app.init();
   });
 
-  it('db 연동 테스트', () => {
-    // app이 정상적으로 인스턴스화되는지 확인
-    expect(app).toBeDefined();
-  });
-
   /**
    * 각각의 테스트가 실행되기 전에 실행됩니다.
    * 테스트용 DB의 샘플 데이터를 초기화합니다.
@@ -77,6 +79,265 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
   it('db 연동 테스트', () => {
     // app이 정상적으로 인스턴스화되는지 확인
     expect(app).toBeDefined();
+  });
+
+  describe('/api/admin/lent/:cabinetId/:userId (POST)', () => {
+    describe('정상적인 요청 - 대여에 성공합니다.', () => {
+      it('PRIVATE & AVAILABLE 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 X 이며, ban 기록 없는 유저
+        const userId = 2;
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(201);
+        // TODO: 사물함의 상태가 SET_EXPIRE_FULL로 변경되는지 확인
+        // TODO: lent 테이블에 대여 기록이 추가되는지 확인
+      });
+    });
+
+    describe('비정상적인 요청 - 관리자 권한이 없는 경우', () => {
+      it('관리자 권한이 없는 유저의 대여 요청인 경우', async () => {
+        // given
+        // 대여 중인 사물함 X 이며, ban 기록 없는 유저
+        const userId = 2;
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = 'invalid_token';
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('비정상적인 요청 - 존재하지 않는 사물함 혹은 유저', () => {
+      it('존재하지 않는 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 X 이며, ban 기록 없는 유저
+        const userId = 2;
+        // 존재하지 않는 사물함
+        const cabinetId = 99999;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 400이 응답되어야 하는데, 500이 응답됨
+        expect(response.status).toBe(500);
+      });
+
+      it('존재하지 않는 유저 ID로 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 존재하지 않는 유저
+        const userId = 99999;
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 400이 응답되어야 하는데, 500이 응답됨
+        expect(response.status).toBe(500);
+      });
+    });
+
+    describe('비정상적인 요청 - 이미 대여중인 사물함이 있는 경우', () => {
+      it('PRIVATE & AVAILABLE 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 5;
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(400);
+      });
+    });
+
+    // TODO: 관리자가 사용하는 API이므로 연체 사물함이나 임시 밴, 고장 사물함 대여 요청을
+    //       정상적인 것으로 처리로 할 지 추후 논의가 필요할 것 같습니다.
+    describe('비정상적인 요청 - 이용 불가능한 사물함을 대여한 경우', () => {
+      it('BANNED 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // BANNED 사물함
+        const cabinetId = 7;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(403);
+      });
+
+      it('EXPIRED 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // EXPIRED 사물함
+        const cabinetId = 14;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(403);
+      });
+
+      it('BROKEN 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // BROKEN 사물함
+        const cabinetId = 6;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(403);
+      });
+    });
+
+    describe('비정상적인 요청 - 잔여 자리가 없는 경우', () => {
+      it('PRIVATE & SET_EXPIRE_FULL 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // PRIVATE & SET_EXPIRE_FULL 사물함
+        const cabinetId = 4;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(409);
+      });
+    });
+
+    describe('비정상적인 요청 - 동아리 사물함을 대여 시도한 경우', () => {
+      it('CLUB & SET_EXPIRE_FULL 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // CLUB & SET_EXPIRE_FULL 사물함
+        const cabinetId = 12;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(409);
+      });
+
+      it('CLUB & AVAILABLE 사물함을 대여 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // 대여 중인 사물함 O 이며, ban 기록 없는 유저
+        const userId = 2;
+        // CLUB & AVAILABLE 사물함
+        const cabinetId = 15;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/admin/lent/cabinet/${cabinetId}/${userId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(418);
+      });
+    });
   });
 
   afterAll(async () => {

--- a/backend/test/admin/lent.e2e-spec.ts
+++ b/backend/test/admin/lent.e2e-spec.ts
@@ -5,7 +5,6 @@ import { AppModule } from 'src/app.module';
 import { JwtService } from '@nestjs/jwt';
 import TypeOrmConfigService from 'src/config/typeorm.config';
 import { DataSource } from 'typeorm';
-import { UserSessionDto } from 'src/dto/user.session.dto';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { initTestDB, loadSQL } from '../utils';
 import { AdminUserDto } from 'src/admin/dto/admin.user.dto';
@@ -74,11 +73,6 @@ describe('Admin Lent 모듈 테스트 (e2e)', () => {
     await queryRunner.connect();
     await loadSQL(queryRunner, 'test/test_db.sql');
     await queryRunner.release();
-  });
-
-  it('db 연동 테스트', () => {
-    // app이 정상적으로 인스턴스화되는지 확인
-    expect(app).toBeDefined();
   });
 
   describe('/api/admin/lent/:cabinetId/:userId (POST)', () => {

--- a/backend/test/admin/return.e2e-spec.ts
+++ b/backend/test/admin/return.e2e-spec.ts
@@ -339,6 +339,91 @@ describe('Admin Return 모듈 테스트 (e2e)', () => {
         });
       });
     });
+
+    describe('/api/admin/return/bundle/cabinet (DELETE)', () => {
+      describe('일괄 반납에 부분 성공합니다.', () => {
+        it('전체 사물함을 반납합니다.', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // 전체 사물함
+          const cabinets: number[] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+          ];
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/bundle/cabinet`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ cabinets: cabinets });
+          // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
+          expect(response.status).toBe(400);
+          expect(response.body.user_failures.length).toBe(0);
+          // cabinet_failures에는 1, 5을 제외한 배열이 들어가야 함.
+          expect(response.body.cabinet_failures.length).toBe(8);
+          expect(response.body.cabinet_failures).toEqual(
+            expect.arrayContaining([1, 2, 3, 5, 6, 7, 12, 15]),
+          );
+        });
+
+        it('전체 유저를 반납합니다.', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // 전체 유저
+          const users: number[] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+          ];
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/bundle/cabinet`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({ users: users });
+          // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
+          expect(response.status).toBe(400);
+          expect(response.body.cabinet_failures.length).toBe(0);
+          // cabinet_failures에는 1, 5을 제외한 배열이 들어가야 함.
+          expect(response.body.user_failures.length).toBe(6);
+          expect(response.body.user_failures).toEqual(
+            expect.arrayContaining([1, 2, 3, 4, 7, 8]),
+          );
+        });
+
+        describe('일괄 반납에 부분 성공합니다.', () => {
+          it('반납에 성공하게 되는 사물함들만 반납 요청', async () => {
+            // given
+            // 승인받은 관리자 유저
+            const adminUser: AdminUserDto = {
+              email: 'normal@example.com',
+              role: 1,
+            };
+            // 반납에 성공하게 되는 사물함
+            const cabinets: number[] = [4, 8, 9, 10, 11, 13, 14];
+            const token = jwtService.sign(adminUser);
+
+            // when
+            const response = await request(app.getHttpServer())
+              .delete(`/api/admin/return/bundle/cabinet`)
+              .set('Authorization', `Bearer ${token}`)
+              .send({ cabinets: cabinets });
+            // then
+            // FIXME: 204가 응답되어야 하는데, 200이 응답되고 있음.
+            expect(response.status).toBe(200);
+          });
+        });
+      });
+    });
   });
 
   afterAll(async () => {

--- a/backend/test/admin/return.e2e-spec.ts
+++ b/backend/test/admin/return.e2e-spec.ts
@@ -217,6 +217,7 @@ describe('Admin Return 모듈 테스트 (e2e)', () => {
             .set('Authorization', `Bearer ${token}`);
 
           // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
           expect(response.status).toBe(400);
         });
 
@@ -237,6 +238,7 @@ describe('Admin Return 모듈 테스트 (e2e)', () => {
             .set('Authorization', `Bearer ${token}`);
 
           // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
           expect(response.status).toBe(400);
         });
       });
@@ -311,6 +313,7 @@ describe('Admin Return 모듈 테스트 (e2e)', () => {
             .set('Authorization', `Bearer ${token}`);
 
           // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
           expect(response.status).toBe(400);
         });
 
@@ -331,6 +334,7 @@ describe('Admin Return 모듈 테스트 (e2e)', () => {
             .set('Authorization', `Bearer ${token}`);
 
           // then
+          // FIXME: 400이 응답되고 있지만, 409를 응답하도록 하는 것이 적절해보임.
           expect(response.status).toBe(400);
         });
       });

--- a/backend/test/admin/return.e2e-spec.ts
+++ b/backend/test/admin/return.e2e-spec.ts
@@ -1,0 +1,343 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { JwtService } from '@nestjs/jwt';
+import TypeOrmConfigService from 'src/config/typeorm.config';
+import { DataSource } from 'typeorm';
+import { initializeTransactionalContext } from 'typeorm-transactional';
+import { initTestDB, loadSQL } from '../utils';
+import { AdminUserDto } from 'src/admin/dto/admin.user.dto';
+
+/**
+ * 실제 테스트에 사용할 DB 이름을 적습니다.
+ * 테스트 파일들이 각각 병렬적으로 실행되므로, DB 이름을 다르게 설정해야 합니다.
+ */
+const testDBName = 'test_admin_return';
+
+describe('Admin Return 모듈 테스트 (e2e)', () => {
+  let app: INestApplication;
+  let jwtService: JwtService;
+
+  /**
+   * 테스트 전에 한 번만 실행되는 함수
+   * typeorm-transactional를 초기화합니다.
+   * AppModule을 불러와 TestModule을 생성합니다.
+   * TypeOrmConfigService를 override하여 테스트용 DB에 연결되도록 합니다.
+   */
+  beforeAll(async () => {
+    await initTestDB(testDBName);
+    initializeTransactionalContext();
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(TypeOrmConfigService)
+      .useValue({
+        createTypeOrmOptions: jest
+          .spyOn(TypeOrmConfigService.prototype, 'createTypeOrmOptions')
+          .mockImplementation(() => {
+            return {
+              type: 'mysql',
+              host: '127.0.0.1',
+              username: 'test_user',
+              port: 3310,
+              password: 'test_password',
+              database: testDBName,
+              entities: ['src/**/*.entity.ts'],
+              synchronize: true,
+              dropSchema: true,
+            };
+          }),
+      })
+      .compile();
+
+    // jwt 토큰 발행을 위해 JwtService를 인스턴스화합니다.
+    jwtService = new JwtService({
+      secret: process.env.JWT_SECRETKEY,
+      signOptions: {
+        expiresIn: process.env.JWT_EXPIREIN,
+      },
+    });
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  /**
+   * 각각의 테스트가 실행되기 전에 실행됩니다.
+   * 테스트용 DB의 샘플 데이터를 초기화합니다.
+   */
+  beforeEach(async () => {
+    const dataSource = app.get(DataSource);
+    const queryRunner = dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await loadSQL(queryRunner, 'test/test_db.sql');
+    await queryRunner.release();
+  });
+
+  describe('/api/admin/return/cabinet/:cabinetId (DELETE)', () => {
+    describe('정상적인 요청 - 반납에 성공합니다.', () => {
+      it('PRIVATE & SET_EXPIRE_FULL 사물함을 반납 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // PRIVATE & SET_EXPIRE_FULL 사물함
+        const cabinetId = 13;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .delete(`/api/admin/return/cabinet/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 204가 응답되야 하는데 200이 응답됨
+        expect(response.status).toBe(200);
+        // TODO: 사물함의 상태가 AVAILABLE로 변경되는지 확인
+        // TODO: lent가 삭제되었는지 확인
+        // TODO: lent_log가 생성되었는지 확인
+      });
+
+      it('SHARE & SET_EXPIRE_FULL 사물함을 반납 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // SHARE & SET_EXPIRE_FULL 사물함
+        const cabinetId = 8;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .delete(`/api/admin/return/cabinet/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 204가 응답되야 하는데 200이 응답됨
+        expect(response.status).toBe(200);
+        // TODO: 사물함의 상태가 AVAILABLE로 변경되는지 확인
+        // TODO: lent가 삭제되었는지 확인
+        // TODO: lent_log가 생성되었는지 확인
+      });
+
+      it('SHARE & SET_EXPIRE_AVAILABLE(대여 중인 사람이 2명) 반납 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // SHARE & SET_EXPIRE_AVAILABLE 사물함
+        const cabinetId = 11;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .delete(`/api/admin/return/cabinet/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 204가 응답되야 하는데 200이 응답됨
+        expect(response.status).toBe(200);
+        // TODO: 사물함의 상태가 AVAILABLE로 변경되는지 확인
+        // TODO: lent가 삭제되었는지 확인
+        // TODO: lent_log가 생성되었는지 확인
+      });
+
+      it('PRIVATE & EXPIRED 반납 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // PRIVATE & EXPIRED 사물함
+        const cabinetId = 13;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .delete(`/api/admin/return/cabinet/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 204가 응답되야 하는데 200이 응답됨
+        expect(response.status).toBe(200);
+        // TODO: 사물함의 상태가 AVAILABLE로 변경되는지 확인
+        // TODO: lent가 삭제되었는지 확인
+        // TODO: lent_log가 생성되었는지 확인
+        // TODO: ban_log가 생성되었는지 확인
+      });
+
+      it('SHARE & EXPIRED(대여 중인 사람이 1명) 반납 시도', async () => {
+        // given
+        // 승인받은 관리자 유저
+        const adminUser: AdminUserDto = {
+          email: 'normal@example.com',
+          role: 1,
+        };
+        // SHARE & EXPIRED 사물함
+        const cabinetId = 14;
+        const token = jwtService.sign(adminUser);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .delete(`/api/admin/return/cabinet/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        // FIXME: 204가 응답되야 하는데 200이 응답됨
+        expect(response.status).toBe(200);
+        // TODO: 사물함의 상태가 AVAILABLE로 변경되는지 확인
+        // TODO: lent가 삭제되었는지 확인
+        // TODO: lent_log가 생성되었는지 확인
+        // TODO: ban_log가 생성되었는지 확인
+      });
+
+      describe('비정상적인 요청', () => {
+        it('존재하지 않는 사물함을 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // 존재하지 않는 사물함
+          const cabinetId = 99999;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/cabinet/${cabinetId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          expect(response.status).toBe(400);
+        });
+
+        it('대여중인 유저가 없는 사물함을 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // PRIVATE & AVAILABLE 사물함
+          const cabinetId = 1;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/cabinet/${cabinetId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          expect(response.status).toBe(400);
+        });
+      });
+    });
+
+    describe('/api/admin/return/user/:userId (DELETE)', () => {
+      describe('정상적인 요청 - 반납에 성공합니다.', () => {
+        it('PRIVATE & SET_EXPIRE_FULL 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // PRIVATE & SET_EXPIRE_FULL 사물함을 빌린 유저
+          const userId = 5;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/user/${userId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          // FIXME: 204가 응답되야 하는데 200이 응답됨
+          expect(response.status).toBe(200);
+          // TODO: 사물함의 상태가 AVAILABLE로 변경되었는지 확인
+          // TODO: lent가 삭제되었는지 확인(해당 유저가 대여중인지 확인)
+          // TODO: lent_log가 생성되었는지 확인
+        });
+
+        it('SHARE & SET_EXPIRE_FULL 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // SHARE & SET_EXPIRE_FULL 사물함을 빌린 유저
+          const userId = 13;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/user/${userId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          // FIXME: 204가 응답되야 하는데 200이 응답됨
+          expect(response.status).toBe(200);
+          // TODO: 사물함의 상태가 AVAILABLE로 변경되었는지 확인
+          // TODO: lent가 삭제되었는지 확인(해당 유저가 대여중인지 확인)
+          // TODO: lent_log가 생성되었는지 확인
+        });
+      });
+
+      describe('비정상적인 요청', () => {
+        it('존재하지 않는 유저로 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // 존재하지 않는 유저
+          const userId = 99999;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/user/${userId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          expect(response.status).toBe(400);
+        });
+
+        it('대여중인 사물함이 없는 유저로 반납 시도', async () => {
+          // given
+          // 승인받은 관리자 유저
+          const adminUser: AdminUserDto = {
+            email: 'normal@example.com',
+            role: 1,
+          };
+          // 대여중인 사물함이 없는 유저
+          const userId = 2;
+          const token = jwtService.sign(adminUser);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .delete(`/api/admin/return/user/${userId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          expect(response.status).toBe(400);
+        });
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/backend/test/main/lent.e2e-spec.ts
+++ b/backend/test/main/lent.e2e-spec.ts
@@ -8,6 +8,7 @@ import { DataSource } from 'typeorm';
 import { UserSessionDto } from 'src/dto/user.session.dto';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { initTestDB, loadSQL } from '../utils';
+/* eslint-disable */
 const timekeeper = require('timekeeper');
 
 /**

--- a/backend/test/main/lent.e2e-spec.ts
+++ b/backend/test/main/lent.e2e-spec.ts
@@ -8,6 +8,7 @@ import { DataSource } from 'typeorm';
 import { UserSessionDto } from 'src/dto/user.session.dto';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { initTestDB, loadSQL } from '../utils';
+const timekeeper = require('timekeeper');
 
 /**
  * 실제 테스트에 사용할 DB 이름을 적습니다.
@@ -166,6 +167,91 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
       });
     });
 
+    describe('비정상적인 요청 - 권한이 없는 경우', () => {
+      it('권한이 없는 유저의 대여 요청인 경우', async () => {
+        // given
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = 'invalid_token';
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/lent/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('패널티 | 밴인 유저에 대한 테스트', () => {
+      it('공유 사물함 패널티 기간중인 유저의 개인 사물함 대여 요청인 경우', async () => {
+        // given
+        timekeeper.freeze(new Date('2023-01-15T00:00:00Z'));
+        // 대여 중인 사물함 x 이며, 현재 공유사물함 패널티 기간중인 유저
+        const user: UserSessionDto = {
+          user_id: 3,
+          intra_id: 'penaltyuser1',
+        };
+        // PRIVATE & AVAILABLE 사물함
+        const cabinetId = 1;
+        const token = jwtService.sign(user);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/lent/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(201);
+        timekeeper.reset();
+      });
+
+      it('공유 사물함 패널티 기간중인 유저의 공유 사물함 대여 요청인 경우', async () => {
+        // given
+        timekeeper.freeze(new Date('2023-01-15T00:00:00Z'));
+        // 대여 중인 사물함 x 이며, 현재 공유사물함 패널티 기간중인 유저
+        const user: UserSessionDto = {
+          user_id: 3,
+          intra_id: 'penaltyuser1',
+        };
+        // SHARE & AVAILABLE 사물함
+        const cabinetId = 5;
+        const token = jwtService.sign(user);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/lent/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(403);
+        timekeeper.reset();
+      });
+
+      it('밴이 된 유저의 대여 요청', async () => {
+        // given
+        timekeeper.freeze(new Date('2023-01-15T00:00:00Z'));
+        // 대여 중인 사물함 x 이며, 밴 기간중인 유저
+        const user: UserSessionDto = {
+          user_id: 1,
+          intra_id: 'banuser1',
+        };
+        // SHARE & AVAILABLE 사물함
+        const cabinetId = 5;
+        const token = jwtService.sign(user);
+
+        // when
+        const response = await request(app.getHttpServer())
+          .post(`/api/lent/${cabinetId}`)
+          .set('Authorization', `Bearer ${token}`);
+
+        // then
+        expect(response.status).toBe(403);
+        timekeeper.reset();
+      });
+    });
+
     describe('비정상적인 요청 - 이미 대여중인 사물함이 있는 경우', () => {
       it('PRIVATE & AVAILABLE 사물함을 대여 시도', async () => {
         // given
@@ -309,8 +395,27 @@ describe('Main Lent 모듈 테스트 (e2e)', () => {
             .set('Authorization', `Bearer ${token}`);
 
           // then
-          // FIXME: 동아리 사물함 대여 시도 시 418이 응답되어야 하지만, 동아리 사물함의 lent_type을 SET_EXPIRE_FULL로 설정하여 409가 응답됨
           expect(response.status).toBe(409);
+        });
+
+        it('CLUB & AVAILABLE 사물함을 대여 시도', async () => {
+          // given
+          // 대여 중인 사물함 X 이며, ban 기록 없는 유저
+          const user: UserSessionDto = {
+            user_id: 2,
+            intra_id: 'banuser2',
+          };
+          // CLUB & AVAILABLE 사물함
+          const cabinetId = 15;
+          const token = jwtService.sign(user);
+
+          // when
+          const response = await request(app.getHttpServer())
+            .post(`/api/lent/${cabinetId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+          // then
+          expect(response.status).toBe(418);
         });
       });
     });

--- a/backend/test/test_db.sql
+++ b/backend/test/test_db.sql
@@ -93,7 +93,7 @@ CREATE TABLE `cabinet` (
   `status_note` varchar(64) DEFAULT NULL COMMENT '사물함 상태 메모',
   PRIMARY KEY (`cabinet_id`),
   UNIQUE KEY `cabinet_id` (`cabinet_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='사물함 정보';
+) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='사물함 정보';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -102,7 +102,7 @@ CREATE TABLE `cabinet` (
 
 LOCK TABLES `cabinet` WRITE;
 /*!40000 ALTER TABLE `cabinet` DISABLE KEYS */;
-INSERT INTO `cabinet` VALUES (1,1,'새롬관',2,'Oasis','AVAILABLE','PRIVATE',3,0,NULL,NULL,NULL),(2,2,'새롬관',2,'End of Cluster 2','BROKEN','PRIVATE',3,0,NULL,NULL,NULL),(3,3,'새롬관',4,'Oasis','BANNED','PRIVATE',3,0,NULL,NULL,NULL),(4,4,'새롬관',4,'End of Cluster 4','SET_EXPIRE_FULL','PRIVATE',3,0,NULL,NULL,NULL),(5,5,'새롬관',2,'Cluster 1 - OA','AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(6,6,'새롬관',2,'End of Cluster 1','BROKEN','SHARE',3,0,NULL,NULL,NULL),(7,7,'새롬관',4,'Cluster 3 - OA','BANNED','SHARE',3,0,NULL,NULL,NULL),(8,8,'새롬관',4,'End of Cluster 3','SET_EXPIRE_FULL','SHARE',3,0,NULL,NULL,NULL),(9,9,'새롬관',5,'Oasis','SET_EXPIRE_AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(10,10,'새롬관',2,'Cluster 1 - OA','AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(11,11,'새롬관',5,'Cluster 5 - OA','SET_EXPIRE_AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(12,12,'새롬관',2,'Cluster 1 - OA','SET_EXPIRE_FULL','CLUB',3,0,NULL,'CABI',NULL),(13,13,'새롬관',5,'End of Cluster 5','EXPIRED','PRIVATE',3,0,NULL,NULL,NULL),(14,14,'새롬관',4,'Cluster 3 - OA','EXPIRED','SHARE',3,0,NULL,NULL,NULL);
+INSERT INTO `cabinet` VALUES (1,1,'새롬관',2,'Oasis','AVAILABLE','PRIVATE',1,0,NULL,NULL,NULL),(2,2,'새롬관',2,'End of Cluster 2','BROKEN','PRIVATE',1,0,NULL,NULL,NULL),(3,3,'새롬관',4,'Oasis','BANNED','PRIVATE',1,0,NULL,NULL,NULL),(4,4,'새롬관',4,'End of Cluster 4','SET_EXPIRE_FULL','PRIVATE',1,0,NULL,NULL,NULL),(5,5,'새롬관',2,'Cluster 1 - OA','AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(6,6,'새롬관',2,'End of Cluster 1','BROKEN','SHARE',3,0,NULL,NULL,NULL),(7,7,'새롬관',4,'Cluster 3 - OA','BANNED','SHARE',3,0,NULL,NULL,NULL),(8,8,'새롬관',4,'End of Cluster 3','SET_EXPIRE_FULL','SHARE',3,0,NULL,NULL,NULL),(9,9,'새롬관',5,'Oasis','SET_EXPIRE_AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(10,10,'새롬관',2,'Cluster 1 - OA','AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(11,11,'새롬관',5,'Cluster 5 - OA','SET_EXPIRE_AVAILABLE','SHARE',3,0,NULL,NULL,NULL),(12,12,'새롬관',2,'Cluster 1 - OA','SET_EXPIRE_FULL','CLUB',3,0,NULL,'CABI',NULL),(13,13,'새롬관',5,'End of Cluster 5','EXPIRED','PRIVATE',1,0,NULL,NULL,NULL),(14,14,'새롬관',4,'Cluster 3 - OA','EXPIRED','SHARE',3,0,NULL,NULL,NULL),(15,15,'새롬관',2,'Cluster 1 - OA','AVAILABLE','CLUB',3,0,NULL,NULL,NULL);
 /*!40000 ALTER TABLE `cabinet` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -208,4 +208,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-02-05 18:49:28
+-- Dump completed on 2023-02-05 21:01:10


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/7

main: lent
admin: lent, return
E2E 테스트 코드 작성을 완료했습니다.
작성 결과 소스코드 수정이 필요한 부분이 확인되어 따로 FIXME로 주석처리 해두었습니다.
또한 대여 반납 후 반납이 잘 되었는지 확인(`cabinet_status` 확인 + `lent` 삭제 확인 + `lent_log` 추가 확인 + `ban_log` 추가 확인)해야 하는데
직접 DB에 접근해서 할 지, 다른 모듈의 API를 이용해서 할 지, 애매한 것 같아 일단 `TODO`로 표시했습니다.

### 수정이 필요한 부분들
1. Admin Return
-  `/cabinet/:cabinetId`, `/user/:userId`, `/bundle/cabinet`에서 실패 시 400을 응답하고 있으나 400은 문법 오류와 관련된 에러 코드이므로 409로 수정하는 것이 좋을 것 같습니다.
- 또한 성공 시, 204가 응답되어야 하는데 200이 응답되고 있습니다.
2. Admin Lent
- `lentService`에서 `intraId` 사용이 필요가 없으므로 param으로 cabinetId, userId만 받아도 될 것 같습니다.
- user와 cabinet이 존재하는지 확인하는 로직이 없어 500이 발생합니다. 
- user와 cabinet이 존재하지 않는다면 지금은 400을 반환 하도록 정의했습니다. 하지만 400은 클라이언트의 요청 문법이 잘못되었을 때 사용하는 것이므로 409를 응답하도록 수정하는게 좋을 것 같습니다.
- Return type이 any가 아닌 void로 수정해야 합니다.
3. Main Lent
- `lentService.lentCabinet`에서 `intraId`가 필요 없어졌으므로 `userId`와 `cabinetId`만 인자로 받도록 수정하는 것이 좋을 것 같습니다.
- 이미 대여중인 사물함이 있는 경우, 400 Bad_Request를 응답하고 있는데 마찬가지로 409를 응답하도록 하는 것이 좋을 것 같습니다.


https://github.com/innovationacademy-kr/42cabi/issues/#793
