### PR TITLE
[BE] 사물함 번호로 검색 API에서 층 정보를 받도록 수정

### DIFF
--- a/backend/src/admin/search/repository/search.repository.interface.ts
+++ b/backend/src/admin/search/repository/search.repository.interface.ts
@@ -50,11 +50,15 @@ export interface IAdminSearchRepository {
 
   /**
    * 해당 사물함 번호를 가진 사물함 리스트를 반환합니다.
-   *
+   * 선택적으로 특정 층을 지정할 수 있습니다.
    * @param visibleNum 사물함 번호
+   * @param floor 층
    * @returns CabinetInfoPagenationDto
    */
-  searchByCabinetNumber(visibleNum: number): Promise<CabinetInfoPagenationDto>;
+  searchByCabinetNumber(
+    visibleNum: number,
+    floor?: number,
+  ): Promise<CabinetInfoPagenationDto>;
 
   /**
    * 정지당한 사물함 리스트를 반환합니다.

--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -154,11 +154,13 @@ export class AdminSearchRepository implements IAdminSearchRepository {
 
   async searchByCabinetNumber(
     visibleNum: number,
+    floor?: number,
   ): Promise<CabinetInfoPagenationDto> {
     const result = await this.cabinetRepository.find({
       relations: ['lent', 'lent.user'],
       where: {
         cabinet_num: visibleNum,
+        floor: floor,
       },
       order: { cabinet_id: 'ASC' },
     });

--- a/backend/src/admin/search/search.controller.ts
+++ b/backend/src/admin/search/search.controller.ts
@@ -153,7 +153,8 @@ export class SearchController {
 
   @ApiOperation({
     summary: '해당 사물함 번호를 가진 사물함 리스트',
-    description: '해당 사물함 번호를 가진 사물함 리스트를 반환합니다.',
+    description:
+      '해당 사물함 번호를 가진 사물함 리스트를 반환합니다. 선택적으로 특정 층을 지정할 수 있습니다.',
   })
   @ApiParam({
     name: 'visibleNum',
@@ -166,10 +167,14 @@ export class SearchController {
   @Get('/cabinet/visibleNum/:visibleNum')
   async getCabinetListByVisibleNum(
     @Param('visibleNum', ParseIntPipe) visibleNum: number,
+    @Query('floor') floor?: number,
   ): Promise<CabinetInfoPagenationDto> {
     this.logger.debug(`Called ${this.getCabinetListByVisibleNum.name}`);
     try {
-      return await this.adminSearchService.searchByCabinetNumber(visibleNum);
+      return await this.adminSearchService.searchByCabinetNumber(
+        visibleNum,
+        floor,
+      );
     } catch (err) {
       this.logger.error(err);
       throw err;

--- a/backend/src/admin/search/search.service.ts
+++ b/backend/src/admin/search/search.service.ts
@@ -89,17 +89,23 @@ export class AdminSearchService {
 
   /**
    * 해당 사물함 번호를 가진 사물함 리스트를 반환합니다.
+   * 선택적으로 특정 층을 지정할 수 있습니다.
    * @param visibleNum 사물함 번호
+   * @param floor 층
    * @returns CabinetInfoPagenationDto
    * @throw HTTPError
    */
   async searchByCabinetNumber(
     visibleNum: number,
+    floor?: number,
   ): Promise<CabinetInfoPagenationDto> {
     this.logger.debug(
       `Called ${AdminSearchService.name} ${this.searchByCabinetNumber.name}`,
     );
-    return await this.adminSearchRepository.searchByCabinetNumber(visibleNum);
+    return await this.adminSearchRepository.searchByCabinetNumber(
+      visibleNum,
+      floor,
+    );
   }
 
   /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

사물함 번호로 검색 API에서 선택적으로 층 정보를 받아, 해당 층에 있는 사물함 정보만 가져올 수도 있도록 수정했습니다.
**사용 예시**
`localhost:2424/api/admin/search/cabinet/visibleNum/42`
-> 2, 4, 5층의 42번 사물함 정보 반환

`localhost:2424/api/admin/search/cabinet/visibleNum/42/?floor=2`
-> 2층의 42번 사물함 정보 반환

https://github.com/innovationacademy-kr/42cabi/issues/952

