### PR TITLE
[FE] admin이 단일 선택모드에서 개인 캐비닛 반납 클릭 시 반납 모달 렌더링 및 api연동  

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -156,6 +156,16 @@ export const axiosGetCabinetState = async (): Promise<any> => {
   }
 };
 
+const axiosAdminReturnURL = "/api/admin/return/cabinet/";
+export const axiosAdminReturn = async (cabinetId: number): Promise<any> => {
+  try {
+    const response = await instance.delete(axiosAdminReturnURL + cabinetId);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const axiosSearchByIntraIdURL = "/api/admin/search/intraId/";
 export const axiosSearchByIntraId = async (intraId: string) => {
   try {

--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -4,6 +4,7 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 export enum additionalModalType {
   MODAL_RETURN = "MODAL_RETURN",
   MODAL_UNAVAILABLE_ALREADY_LENT = "MODAL_UNAVAILABLE_ALREADY_LENT",
+  MODAL_ADMIN_RETURN = "MODAL_ADMIN_RETURN",
 }
 
 export const cabinetIconSrcMap = {
@@ -72,6 +73,11 @@ export const modalPropsMap = {
     type: "error",
     title: "이미 대여 중인 사물함이 있습니다",
     confirmMessage: "",
+  },
+  MODAL_ADMIN_RETURN: {
+    type: "confirm",
+    title: "반납 처리",
+    confirmMessage: "네, 반납할게요",
   },
 };
 

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -15,8 +15,8 @@ import {
   cabinetStatusColorMap,
 } from "@/assets/data/maps";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
-import { targetCabinetInfoListState } from "@/recoil/atoms";
 import useMultiSelect from "@/hooks/useMultiSelect";
+import AdminReturnModal from "../Modals/ReturnModal/AdminReturnModal";
 export interface ISelectedCabinetInfo {
   floor: number;
   section: string;
@@ -65,6 +65,8 @@ const CabinetInfoArea: React.FC<{
   const [showLentModal, setShowLentModal] = useState<boolean>(false);
   const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
+  const [showAdminReturnModal, setShowAdminReturnModal] =
+    useState<boolean>(false);
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
@@ -94,6 +96,12 @@ const CabinetInfoArea: React.FC<{
   };
   const handleCloseUnavailableModal = () => {
     setShowUnavailableModal(false);
+  };
+  const handleOpenAdminReturnModal = () => {
+    setShowAdminReturnModal(true);
+  };
+  const handleCloseAdminReturnModal = () => {
+    setShowAdminReturnModal(false);
   };
 
   if (
@@ -135,12 +143,12 @@ const CabinetInfoArea: React.FC<{
         </MultiCabinetIconWrapperStyled>
         <CabinetInfoButtonsContainerStyled>
           <ButtonContainer
-            onClick={() => {}} //todo: admin 반납 모달 만들기
+            onClick={() => {}} //todo: admin 일괄 반납 모달 만들기
             text="일괄 반납"
             theme="fill"
           />
           <ButtonContainer
-            onClick={() => {}} //todo: 상태관리 모달 만들기
+            onClick={() => {}} //todo: admin 일괄 상태관리 모달 만들기
             text="상태관리"
             theme="line"
           />
@@ -198,12 +206,12 @@ const CabinetInfoArea: React.FC<{
             {selectedCabinetInfo!.isAdmin ? (
               <>
                 <ButtonContainer
-                  onClick={() => {}} //todo: admin 반납 모달 만들기
+                  onClick={handleOpenAdminReturnModal} //todo: admin 단일 반납 모달 만들기
                   text="반납"
                   theme="fill"
                 />
                 <ButtonContainer
-                  onClick={() => {}} //todo: 상태관리 모달 만들기
+                  onClick={() => {}} //todo: admin 단일 상태관리 모달 만들기
                   text="상태 관리"
                   theme="line"
                 />
@@ -248,6 +256,12 @@ const CabinetInfoArea: React.FC<{
         />
       )}
       {showMemoModal && <MemoModalContainer onClose={handleCloseMemoModal} />}
+      {showAdminReturnModal && (
+        <AdminReturnModal
+          lentType={selectedCabinetInfo!.lentType}
+          closeModal={handleCloseAdminReturnModal}
+        />
+      )}
     </CabinetDetailAreaStyled>
   );
 };

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
@@ -7,6 +7,7 @@ import {
   currentLocationNameState,
   currentSectionNameState,
   isCurrentSectionRenderState,
+  numberOfAdminWorkState,
   userState,
 } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
@@ -37,6 +38,7 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
     CabinetInfoByLocationFloorDto[]
   >(currentFloorCabinetState);
   const setCurrentSection = useSetRecoilState<string>(currentSectionNameState);
+  const numberOfAdminWork = useRecoilValue<number>(numberOfAdminWorkState);
   const navigator = useNavigate();
   const { pathname } = useLocation();
   const isMount = useIsMount();
@@ -66,7 +68,7 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
       .catch((error) => {
         console.error(error);
       });
-  }, [currentLocation, currentFloor, myInfo.cabinet_id]);
+  }, [currentLocation, currentFloor, myInfo.cabinet_id, numberOfAdminWork]);
 
   const onClickFloorButton = (floor: number) => {
     setCurrentFloor(floor);

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -5,7 +5,7 @@ import {
   isCurrentSectionRenderState,
   targetCabinetInfoState,
 } from "@/recoil/atoms";
-import { axiosCabinetById, axiosReturn } from "@/api/axios/axios.custom";
+import { axiosAdminReturn, axiosCabinetById } from "@/api/axios/axios.custom";
 import Modal, { IModalContents } from "@/components/Modals/Modal";
 import {
   SuccessResponseModal,
@@ -30,7 +30,7 @@ const AdminReturnModal: React.FC<{
   const returnDetail = "지금 반납 하시겠습니까?";
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
-      await axiosReturn();
+      await axiosAdminReturn(currentCabinetId);
       //userCabinetId 세팅
       setIsCurrentSectionRender(true);
       setModalTitle("반납되었습니다");

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -15,6 +15,7 @@ import {
 import ModalPortal from "@/components/Modals/ModalPortal";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
+import { CabinetInfo } from "@/types/dto/cabinet.dto";
 
 const AdminReturnModal: React.FC<{
   lentType: string;
@@ -31,7 +32,9 @@ const AdminReturnModal: React.FC<{
   const setNumberOfAdminWork = useSetRecoilState<number>(
     numberOfAdminWorkState
   );
-  const returnDetail = "지금 반납 하시겠습니까?";
+  const targetCabinetInfo = useRecoilValue<CabinetInfo>(targetCabinetInfoState);
+  const returnDetail = `<strong>${targetCabinetInfo.floor}층 ${targetCabinetInfo.section} ${targetCabinetInfo.cabinet_num}번 사물함</strong>
+  해당 사물함을 정말 반납하시겠습니까?`;
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
       await axiosAdminReturn(currentCabinetId);
@@ -57,7 +60,7 @@ const AdminReturnModal: React.FC<{
   const returnModalContents: IModalContents = {
     type: "hasProceedBtn",
     icon: checkIcon,
-    title: modalPropsMap[additionalModalType.MODAL_RETURN].title,
+    title: modalPropsMap[additionalModalType.MODAL_ADMIN_RETURN].title,
     detail: returnDetail,
     proceedBtnText:
       modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  currentCabinetIdState,
+  isCurrentSectionRenderState,
+  targetCabinetInfoState,
+} from "@/recoil/atoms";
+import { axiosCabinetById, axiosReturn } from "@/api/axios/axios.custom";
+import Modal, { IModalContents } from "@/components/Modals/Modal";
+import {
+  SuccessResponseModal,
+  FailResponseModal,
+} from "@/components/Modals/ResponseModal/ResponseModal";
+import ModalPortal from "@/components/Modals/ModalPortal";
+import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
+import checkIcon from "@/assets/images/checkIcon.svg";
+
+const AdminReturnModal: React.FC<{
+  lentType: string;
+  closeModal: React.MouseEventHandler;
+}> = (props) => {
+  const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
+  const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
+  const [modalTitle, setModalTitle] = useState<string>("");
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+  const returnDetail = "지금 반납 하시겠습니까?";
+  const tryReturnRequest = async (e: React.MouseEvent) => {
+    try {
+      await axiosReturn();
+      //userCabinetId 세팅
+      setIsCurrentSectionRender(true);
+      setModalTitle("반납되었습니다");
+      // 캐비닛 상세정보 바꾸는 곳
+      try {
+        const { data } = await axiosCabinetById(currentCabinetId);
+        setTargetCabinetInfo(data);
+      } catch (error) {
+        throw error;
+      }
+    } catch (error: any) {
+      setHasErrorOnResponse(true);
+      setModalTitle(error.response.data.message);
+    } finally {
+      setShowResponseModal(true);
+    }
+  };
+
+  const returnModalContents: IModalContents = {
+    type: "hasProceedBtn",
+    icon: checkIcon,
+    title: modalPropsMap[additionalModalType.MODAL_RETURN].title,
+    detail: returnDetail,
+    proceedBtnText:
+      modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
+    onClickProceed: tryReturnRequest,
+    closeModal: props.closeModal,
+  };
+
+  return (
+    <ModalPortal>
+      {!showResponseModal && <Modal modalContents={returnModalContents} />}
+      {showResponseModal &&
+        (hasErrorOnResponse ? (
+          <FailResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.closeModal}
+          />
+        ) : (
+          <SuccessResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.closeModal}
+          />
+        ))}
+    </ModalPortal>
+  );
+};
+
+export default AdminReturnModal;

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import {
   currentCabinetIdState,
   isCurrentSectionRenderState,
+  numberOfAdminWorkState,
   targetCabinetInfoState,
 } from "@/recoil/atoms";
 import { axiosAdminReturn, axiosCabinetById } from "@/api/axios/axios.custom";
@@ -27,12 +28,16 @@ const AdminReturnModal: React.FC<{
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
   );
+  const setNumberOfAdminWork = useSetRecoilState<number>(
+    numberOfAdminWorkState
+  );
   const returnDetail = "지금 반납 하시겠습니까?";
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
       await axiosAdminReturn(currentCabinetId);
       //userCabinetId 세팅
       setIsCurrentSectionRender(true);
+      setNumberOfAdminWork((prev) => prev + 1);
       setModalTitle("반납되었습니다");
       // 캐비닛 상세정보 바꾸는 곳
       try {

--- a/frontend/src/recoil/atoms.ts
+++ b/frontend/src/recoil/atoms.ts
@@ -104,3 +104,8 @@ export const currentIntraIdState = atom<string>({
   key: "CurrentIntraId",
   default: undefined,
 });
+
+export const numberOfAdminWorkState = atom<number>({
+  key: "NumberOfAdminWork",
+  default: 0,
+});


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>
#959 
Closes #959 
admin이 단일 선택으로 개인 사물함을 반납시킬 수 있는 기능을 구현하였습니다. api도 연동하여 실제 동작을 확인하였습니다. 
recoil상태를 추가하였습니다. numberOfAdminWorkState라는 상태입니다. 관리자가 반납, 상태변경 등의 관리자 일을 api호출을 통해 하고 완료할 때 해당 상태값이 1 증가합니다. leftMainNav컴포넌트에서 이 상태를 useEffect Dependency로 가지며, admin 작업으로 인한 mainPage 캐비닛 아이템들의 변경 상태를 새로고침 없이 바로 반영되도록 하기 위해 만든 recoil 상태입니다. 