### PR TITLE
[BE] FIX: 고장난 사물함 리스트 API에 location, floor 정보 추가 #972

### DIFF
--- a/backend/src/admin/dto/broken.cabinet.info.dto.ts
+++ b/backend/src/admin/dto/broken.cabinet.info.dto.ts
@@ -38,4 +38,16 @@ export class BrokenCabinetInfoDto {
     example: 'Oasis',
   })
   section: string; // 사물함의 섹션 종류 (오아시스 등)
+
+  @ApiProperty({
+    description: '사물함의 건물',
+    example: '새롬관',
+  })
+  location: string; // 사물함의 건물
+
+  @ApiProperty({
+    description: '사물함의 층',
+    example: 2,
+  })
+  floor: number; // 사물함의 층
 }

--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -266,6 +266,8 @@ export class AdminSearchRepository implements IAdminSearchRepository {
         note: cabinet.title,
         max_user: cabinet.max_user,
         section: cabinet.section,
+        location: cabinet.location,
+        floor: cabinet.floor,
       })),
       total_length: result[1],
     };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

<img width="268" alt="스크린샷 2023-02-22 오후 5 18 54" src="https://user-images.githubusercontent.com/83565255/220562425-e09a8e57-5f68-46e8-ab06-1768878102bd.png">
응답 리스트에 location과 floor 정보를 추가했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/
