### PR TITLE
[FE] admin 공유 사물함 반납 기능 추가 

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -166,6 +166,16 @@ export const axiosAdminReturn = async (cabinetId: number): Promise<any> => {
   }
 };
 
+const axiosReturnByUserIdURL = "/api/admin/return/user/";
+export const axiosReturnByUserId = async (userId: number): Promise<any> => {
+  try {
+    const response = await instance.delete(axiosReturnByUserIdURL + userId);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const axiosSearchByIntraIdURL = "/api/admin/search/intraId/";
 export const axiosSearchByIntraId = async (intraId: string) => {
   try {

--- a/frontend/src/components/Common/PillButton.tsx
+++ b/frontend/src/components/Common/PillButton.tsx
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+
+interface IPillButtonProps {
+  text: string;
+  theme: string;
+  onClick(event: React.MouseEvent<HTMLButtonElement>): void;
+}
+
+const PillButton = ({ text, theme, onClick }: IPillButtonProps) => {
+  return (
+    <PillButtonContainerStyled theme={theme} onClick={onClick}>
+      {text}
+    </PillButtonContainerStyled>
+  );
+};
+
+const PillButtonContainerStyled = styled.button<{
+  theme: string;
+}>`
+  background-color: ${({ theme }) =>
+    theme === "fill" ? "var(--main-color)" : "transparent"};
+  border: ${({ theme }) =>
+    theme === "fill" ? "none" : "1px solid var(--line-color)"};
+  color: ${({ theme }) => (theme === "fill" ? "var(--white)" : "var(--black)")};
+  padding: 2px 10px 4px 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  margin: 4px 2px;
+  width: auto;
+  height: auto;
+  cursor: pointer;
+  border-radius: 20px;
+  transition: all 0.3s ease-in-out;
+  &:hover {
+    background-color: var(--main-color);
+    color: var(--white);
+  }
+`;
+
+export default PillButton;

--- a/frontend/src/components/Common/PillButton.tsx
+++ b/frontend/src/components/Common/PillButton.tsx
@@ -1,27 +1,38 @@
+import { useState } from "react";
 import styled from "styled-components";
 
 interface IPillButtonProps {
   text: string;
   theme: string;
-  onClick(event: React.MouseEvent<HTMLButtonElement>): void;
+  onClickButton(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 
-const PillButton = ({ text, theme, onClick }: IPillButtonProps) => {
+const PillButton = ({ text, theme, onClickButton }: IPillButtonProps) => {
+  const [isSelected, setIsSelected] = useState(theme === "line" ? false : true);
+  const toggleSelect = () => {
+    setIsSelected(!isSelected);
+  };
   return (
-    <PillButtonContainerStyled theme={theme} onClick={onClick}>
+    <PillButtonContainerStyled
+      isSelected={isSelected}
+      onClick={(e) => {
+        onClickButton(e);
+        toggleSelect();
+      }}
+    >
       {text}
     </PillButtonContainerStyled>
   );
 };
 
 const PillButtonContainerStyled = styled.button<{
-  theme: string;
+  isSelected: boolean;
 }>`
-  background-color: ${({ theme }) =>
-    theme === "fill" ? "var(--main-color)" : "transparent"};
-  border: ${({ theme }) =>
-    theme === "fill" ? "none" : "1px solid var(--line-color)"};
-  color: ${({ theme }) => (theme === "fill" ? "var(--white)" : "var(--black)")};
+  background-color: ${({ isSelected }) =>
+    isSelected ? "var(--main-color)" : "transparent"};
+  border: ${({ isSelected }) =>
+    isSelected ? "1px solid var(--main-color)" : "1px solid var(--line-color)"};
+  color: ${({ isSelected }) => (isSelected ? "var(--white)" : "var(--black)")};
   padding: 2px 10px 4px 10px;
   text-align: center;
   text-decoration: none;
@@ -31,7 +42,7 @@ const PillButtonContainerStyled = styled.button<{
   height: auto;
   cursor: pointer;
   border-radius: 20px;
-  transition: all 0.3s ease-in-out;
+  transition: background-color 0.3s ease-in-out;
   &:hover {
     background-color: var(--main-color);
     color: var(--white);

--- a/frontend/src/components/Common/PillButton.tsx
+++ b/frontend/src/components/Common/PillButton.tsx
@@ -33,7 +33,7 @@ const PillButtonContainerStyled = styled.button<{
   border: ${({ isSelected }) =>
     isSelected ? "1px solid var(--main-color)" : "1px solid var(--line-color)"};
   color: ${({ isSelected }) => (isSelected ? "var(--white)" : "var(--black)")};
-  padding: 2px 10px 4px 10px;
+  padding: 2px 16px 4px 16px;
   text-align: center;
   text-decoration: none;
   display: inline-block;

--- a/frontend/src/components/Common/Selector.tsx
+++ b/frontend/src/components/Common/Selector.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import styled from "styled-components";
 import PillButton from "./PillButton";
 
 interface ISelectorProps {
   iconSrc?: string;
-  selectList: string[];
+  selectList: { key: number; value: string }[];
   onClickSelect: any;
 }
 
@@ -17,7 +16,14 @@ const Selector = ({ iconSrc, selectList, onClickSelect }: ISelectorProps) => {
       {selectList &&
         selectList.map((elem) => {
           return (
-            <PillButton theme="line" text={elem} onClick={onClickSelect} />
+            <PillButton
+              key={elem.key}
+              theme="line"
+              text={elem.value}
+              onClickButton={() => {
+                onClickSelect(elem.key);
+              }}
+            />
           );
         })}
     </SelectorWrapperStyled>

--- a/frontend/src/components/Common/Selector.tsx
+++ b/frontend/src/components/Common/Selector.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import styled from "styled-components";
+import PillButton from "./PillButton";
+
+interface ISelectorProps {
+  iconSrc?: string;
+  selectList: string[];
+  onClickSelect: any;
+}
+
+const Selector = ({ iconSrc, selectList, onClickSelect }: ISelectorProps) => {
+  return (
+    <SelectorWrapperStyled>
+      <IconWrapperStyled>
+        <img src={iconSrc} />
+      </IconWrapperStyled>
+      {selectList &&
+        selectList.map((elem) => {
+          return (
+            <PillButton theme="line" text={elem} onClick={onClickSelect} />
+          );
+        })}
+    </SelectorWrapperStyled>
+  );
+};
+
+const SelectorWrapperStyled = styled.div`
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const IconWrapperStyled = styled.div`
+  width: 24px;
+  height: 24px;
+`;
+
+export default Selector;

--- a/frontend/src/components/Common/Selector.tsx
+++ b/frontend/src/components/Common/Selector.tsx
@@ -41,6 +41,7 @@ const SelectorWrapperStyled = styled.div`
 const IconWrapperStyled = styled.div`
   width: 24px;
   height: 24px;
+  margin-bottom: 12px;
 `;
 
 export default Selector;

--- a/frontend/src/components/Modals/Modal.tsx
+++ b/frontend/src/components/Modals/Modal.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 import Button from "@/components/Common/Button";
-import React from "react";
+import React, { ReactElement } from "react";
 
 export interface IModalContents {
   type: string; // hasProceedBtn(모달 외부 클릭이나 취소 버튼으로 끔), noBtn(모달 내/외부 클릭으로 끔)
@@ -8,6 +8,7 @@ export interface IModalContents {
   iconScaleEffect?: boolean; // iconEffect 적용 여부
   title?: string; // 모달 제목
   detail?: string; // 모달 본문
+  renderAdditionalComponent?: () => ReactElement; // 모달에 추가로 띄울 UI를 렌더해주는 함수
   proceedBtnText?: string; // 확인 버튼의 텍스트(기본값: 확인)
   onClickProceed?: ((e: React.MouseEvent) => Promise<void>) | null; // 확인 버튼의 동작함수
   cancleBtnText?: string; // 취소 버튼의 텍스트(기본값: 취소)
@@ -21,6 +22,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
     iconScaleEffect,
     title,
     detail,
+    renderAdditionalComponent,
     proceedBtnText,
     onClickProceed,
     cancleBtnText,
@@ -40,6 +42,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
         {detail && (
           <DetailStyled dangerouslySetInnerHTML={{ __html: detail }} />
         )}
+        {renderAdditionalComponent && renderAdditionalComponent()}
         {type === "hasProceedBtn" && (
           <ButtonWrapperStyled>
             <Button

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -16,9 +16,11 @@ import ModalPortal from "@/components/Modals/ModalPortal";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+import Selector from "@/components/Common/Selector";
 
 const AdminReturnModal: React.FC<{
-  lentType: string;
+  lentType: CabinetType;
   closeModal: React.MouseEventHandler;
 }> = (props) => {
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
@@ -33,8 +35,24 @@ const AdminReturnModal: React.FC<{
     numberOfAdminWorkState
   );
   const targetCabinetInfo = useRecoilValue<CabinetInfo>(targetCabinetInfoState);
-  const returnDetail = `<strong>${targetCabinetInfo.floor}층 ${targetCabinetInfo.section} ${targetCabinetInfo.cabinet_num}번 사물함</strong>
-  해당 사물함을 정말 반납하시겠습니까?`;
+
+  const getReturnDetail = (lentType: CabinetType) => {
+    const detail = `<strong>${targetCabinetInfo.floor}층 ${targetCabinetInfo.section} ${targetCabinetInfo.cabinet_num}번 사물함</strong>`;
+    if (lentType === CabinetType.PRIVATE) {
+      return detail + `<br>해당 사물함을 정말 반납하시겠습니까?`;
+    }
+    return detail + `<br>선택한 유저를 반납 처리 하시겠습니까?`;
+  };
+
+  const renderSelector = () => (
+    <Selector
+      iconSrc="/src/assets/images/shareIcon.svg"
+      selectList={targetCabinetInfo.lent_info.map((info) => {
+        return info.intra_id;
+      })}
+      onClickSelect={() => {}}
+    />
+  );
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
       await axiosAdminReturn(currentCabinetId);
@@ -61,9 +79,11 @@ const AdminReturnModal: React.FC<{
     type: "hasProceedBtn",
     icon: checkIcon,
     title: modalPropsMap[additionalModalType.MODAL_ADMIN_RETURN].title,
-    detail: returnDetail,
+    detail: getReturnDetail(props.lentType),
     proceedBtnText:
       modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
+    renderAdditionalComponent:
+      props.lentType === CabinetType.SHARE ? renderSelector : undefined,
     onClickProceed: tryReturnRequest,
     closeModal: props.closeModal,
   };

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -46,7 +46,7 @@ const AdminReturnModal: React.FC<{
     if (lentType === CabinetType.PRIVATE) {
       return detail + `<br>해당 사물함을 정말 반납하시겠습니까?`;
     }
-    return detail + `<br>선택한 유저를 반납 처리 하시겠습니까?`;
+    return detail + `<br>반납할 유저를 선택해 주세요.`;
   };
 
   const handleSelectUser = (userId: number) => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

#969 
admin이 공유 사물함 선택 후 반납하기를 누르면 아래와 같은 전용 UI가 렌더링 됩니다. 선택한 공유 사물함을 사용중인 유저들을 선택하여 반납할 수 있으며, 유저를 모두 선택하여 반납할 경우 사물함이 전체 반납됩니다. 
<img width="413" alt="image" src="https://user-images.githubusercontent.com/45449387/220859712-78aa6a30-7e8f-4042-b315-6ca358047fe8.png">
Closes #969 