### PR TITLE
[FE] admin 사물함 상태 관리 모달 추가

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -1,3 +1,5 @@
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import CabinetType from "@/types/enum/cabinet.type.enum";
 import instance from "./axios.instance";
 
 const axiosLogoutUrl = "/auth/logout";
@@ -170,6 +172,36 @@ const axiosReturnByUserIdURL = "/api/admin/return/user/";
 export const axiosReturnByUserId = async (userId: number): Promise<any> => {
   try {
     const response = await instance.delete(axiosReturnByUserIdURL + userId);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosChangeCabinetTypeURL = "/api/admin/cabinet/lentType/";
+export const axiosChangeCabinetType = async (
+  cabinetId: number,
+  lentType: CabinetType
+) => {
+  try {
+    const response = await instance.patch(
+      `${axiosChangeCabinetTypeURL}${cabinetId}/${lentType}`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosChangeCabinetStatusURL = "/api/admin/cabinet/status/";
+export const axiosChangeCabinetStatus = async (
+  cabinetId: number,
+  status: CabinetStatus
+) => {
+  try {
+    const response = await instance.patch(
+      `${axiosChangeCabinetStatusURL}${cabinetId}/${status}`
+    );
     return response;
   } catch (error) {
     throw error;

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -178,14 +178,14 @@ export const axiosReturnByUserId = async (userId: number): Promise<any> => {
   }
 };
 
-const axiosChangeCabinetTypeURL = "/api/admin/cabinet/lentType/";
-export const axiosChangeCabinetType = async (
+const axiosUpdateCabinetTypeURL = "/api/admin/cabinet/lentType/";
+export const axiosUpdateCabinetType = async (
   cabinetId: number,
   lentType: CabinetType
 ) => {
   try {
     const response = await instance.patch(
-      `${axiosChangeCabinetTypeURL}${cabinetId}/${lentType}`
+      `${axiosUpdateCabinetTypeURL}${cabinetId}/${lentType}`
     );
     return response;
   } catch (error) {
@@ -193,14 +193,14 @@ export const axiosChangeCabinetType = async (
   }
 };
 
-const axiosChangeCabinetStatusURL = "/api/admin/cabinet/status/";
-export const axiosChangeCabinetStatus = async (
+const axiosUpdateCabinetStatusURL = "/api/admin/cabinet/status/";
+export const axiosUpdateCabinetStatus = async (
   cabinetId: number,
   status: CabinetStatus
 ) => {
   try {
     const response = await instance.patch(
-      `${axiosChangeCabinetStatusURL}${cabinetId}/${status}`
+      `${axiosUpdateCabinetStatusURL}${cabinetId}/${status}`
     );
     return response;
   } catch (error) {

--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -89,3 +89,18 @@ export const cabinetFilterMap = {
   [CabinetStatus.BROKEN]: "brightness(100)",
   [CabinetStatus.BANNED]: "brightness(100)",
 };
+
+export const cabinetStatusLabelMap = {
+  [CabinetStatus.AVAILABLE]: "사용 가능",
+  [CabinetStatus.SET_EXPIRE_AVAILABLE]: "사용 가능",
+  [CabinetStatus.SET_EXPIRE_FULL]: "사용 가능",
+  [CabinetStatus.EXPIRED]: "사용 가능",
+  [CabinetStatus.BANNED]: "사용 불가",
+  [CabinetStatus.BROKEN]: "사용 불가",
+};
+
+export const cabinetTypeLabelMap = {
+  [CabinetType.CLUB]: "동아리 사물함",
+  [CabinetType.PRIVATE]: "개인 사물함",
+  [CabinetType.SHARE]: "공유 사물함",
+};

--- a/frontend/src/assets/images/dropdownChevron.svg
+++ b/frontend/src/assets/images/dropdownChevron.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L7 7L13 0.999999" stroke="#BCBCBC"/>
+</svg>

--- a/frontend/src/assets/images/warningTriangleIcon.svg
+++ b/frontend/src/assets/images/warningTriangleIcon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 9V14" stroke="#ff4e4e" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.0004 21.41H5.94042C2.47042 21.41 1.02042 18.93 2.70042 15.9L5.82042 10.28L8.76042 5C10.5404 1.79 13.4604 1.79 15.2404 5L18.1804 10.29L21.3004 15.91C22.9804 18.94 21.5204 21.42 18.0604 21.42H12.0004V21.41Z" stroke="#ff4e4e" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.9941 17H12.0031" stroke="#ff4e4e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -17,6 +17,7 @@ import {
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import useMultiSelect from "@/hooks/useMultiSelect";
 import AdminReturnModal from "../Modals/ReturnModal/AdminReturnModal";
+import StatusModalContainer from "@/components/Modals/StatusModal/StatusModal.container";
 export interface ISelectedCabinetInfo {
   floor: number;
   section: string;
@@ -67,6 +68,7 @@ const CabinetInfoArea: React.FC<{
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
   const [showAdminReturnModal, setShowAdminReturnModal] =
     useState<boolean>(false);
+  const [showStatusModal, setShowStatusModal] = useState<boolean>(false);
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
@@ -102,6 +104,12 @@ const CabinetInfoArea: React.FC<{
   };
   const handleCloseAdminReturnModal = () => {
     setShowAdminReturnModal(false);
+  };
+  const handleOpenStatusModal = () => {
+    setShowStatusModal(true);
+  };
+  const handleCloseStatusModal = () => {
+    setShowStatusModal(false);
   };
 
   if (
@@ -148,7 +156,7 @@ const CabinetInfoArea: React.FC<{
             theme="fill"
           />
           <ButtonContainer
-            onClick={() => {}} //todo: admin 일괄 상태관리 모달 만들기
+            onClick={handleOpenStatusModal} //todo: admin 일괄 상태관리 모달 만들기
             text="상태관리"
             theme="line"
           />
@@ -211,7 +219,7 @@ const CabinetInfoArea: React.FC<{
                   theme="fill"
                 />
                 <ButtonContainer
-                  onClick={() => {}} //todo: admin 단일 상태관리 모달 만들기
+                  onClick={handleOpenStatusModal} //todo: admin 단일 상태관리 모달 만들기
                   text="상태 관리"
                   theme="line"
                 />
@@ -261,6 +269,9 @@ const CabinetInfoArea: React.FC<{
           lentType={selectedCabinetInfo!.lentType}
           closeModal={handleCloseAdminReturnModal}
         />
+      )}
+      {showStatusModal && (
+        <StatusModalContainer onClose={handleCloseStatusModal} />
       )}
     </CabinetDetailAreaStyled>
   );

--- a/frontend/src/components/Common/Dropdown.tsx
+++ b/frontend/src/components/Common/Dropdown.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styled, { css } from "styled-components";
 
 interface IDropdown {
   options: { name: string; value: any }[];
   defaultValue: string;
-  onChange: React.MouseEventHandler<HTMLOptionElement>;
+  onChangeValue?: (param: any) => any;
 }
 
-const Dropdown = ({ options, defaultValue, onChange }: IDropdown) => {
+const Dropdown = ({ options, defaultValue, onChangeValue }: IDropdown) => {
   const [currentName, setCurrentName] = useState(defaultValue);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   return (
@@ -16,8 +16,10 @@ const Dropdown = ({ options, defaultValue, onChange }: IDropdown) => {
         onClick={() => {
           setIsOpen(!isOpen);
         }}
+        isOpen={isOpen}
       >
         <p>{currentName}</p>
+        <img src="/src/assets/images/dropdownChevron.svg" />
       </DropdownSelectionBoxStyled>
       <DropdownItemContainerStyled isVisible={isOpen}>
         {options?.map((option) => {
@@ -27,6 +29,9 @@ const Dropdown = ({ options, defaultValue, onChange }: IDropdown) => {
               onClick={() => {
                 setCurrentName(option.name);
                 setIsOpen(false);
+                if (onChangeValue) {
+                  onChangeValue(option.value);
+                }
               }}
               isSelected={option.name === currentName}
             >
@@ -46,7 +51,7 @@ const DropdownContainerStyled = styled.div`
   position: relative;
 `;
 
-const DropdownSelectionBoxStyled = styled.div`
+const DropdownSelectionBoxStyled = styled.div<{ isOpen: boolean }>`
   position: relative;
   border: 1px solid var(--line-color);
   width: 100%;
@@ -58,7 +63,20 @@ const DropdownSelectionBoxStyled = styled.div`
   color: var(--main-color);
   & p {
     position: absolute;
-    top: 30%;
+    top: 32%;
+  }
+  & img {
+    filter: contrast(0.6);
+    width: 14px;
+    height: 8px;
+    position: relative;
+    top: 45%;
+    left: 80%;
+    ${({ isOpen }) =>
+      isOpen === true &&
+      css`
+        transform: scaleY(-1);
+      `}
   }
 `;
 
@@ -69,7 +87,11 @@ const DropdownItemContainerStyled = styled.div<{ isVisible: boolean }>`
   position: absolute;
   top: 110%;
   z-index: 99;
-  visibility: ${({ isVisible }) => (isVisible ? "" : "hidden")};
+  ${({ isVisible }) =>
+    isVisible !== true &&
+    css`
+      visibility: hidden;
+    `}
   div {
     &: first-child {
 
@@ -88,6 +110,7 @@ const DropdownItemStyled = styled.div<{ isSelected: boolean }>`
   text-indent: 20px;
   font-size: 18px;
   color: ${({ isSelected }) => (isSelected ? "var(--main-color)" : "black")};
+  cursor: pointer;
   & p {
     position: absolute;
     top: 30%;

--- a/frontend/src/components/Common/Dropdown.tsx
+++ b/frontend/src/components/Common/Dropdown.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import styled, { css } from "styled-components";
+
+interface IDropdown {
+  options: { name: string; value: any }[];
+  defaultValue: string;
+  onChange: React.MouseEventHandler<HTMLOptionElement>;
+}
+
+const Dropdown = ({ options, defaultValue, onChange }: IDropdown) => {
+  const [currentName, setCurrentName] = useState(defaultValue);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <DropdownContainerStyled>
+      <DropdownSelectionBoxStyled
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <p>{currentName}</p>
+      </DropdownSelectionBoxStyled>
+      <DropdownItemContainerStyled isVisible={isOpen}>
+        {options?.map((option) => {
+          return (
+            <DropdownItemStyled
+              key={option.value}
+              onClick={() => {
+                setCurrentName(option.name);
+                setIsOpen(false);
+              }}
+              isSelected={option.name === currentName}
+            >
+              <p>{option.name}</p>
+            </DropdownItemStyled>
+          );
+        })}
+      </DropdownItemContainerStyled>
+    </DropdownContainerStyled>
+  );
+};
+
+const DropdownContainerStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  position: relative;
+`;
+
+const DropdownSelectionBoxStyled = styled.div`
+  position: relative;
+  border: 1px solid var(--line-color);
+  width: 100%;
+  height: 60px;
+  border-radius: 10px;
+  text-align: start;
+  text-indent: 20px;
+  font-size: 18px;
+  color: var(--main-color);
+  & p {
+    position: absolute;
+    top: 30%;
+  }
+`;
+
+const DropdownItemContainerStyled = styled.div<{ isVisible: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 110%;
+  z-index: 99;
+  visibility: ${({ isVisible }) => (isVisible ? "" : "hidden")};
+  div {
+    &: first-child {
+
+    }
+  }
+`;
+
+const DropdownItemStyled = styled.div<{ isSelected: boolean }>`
+  position: relative;
+  background-color: ${({ isSelected }) => (isSelected ? "#f1f1f1" : "white")};
+  border: 1px solid var(--line-color);
+  border-width: 0px 1px 1px 1px;
+  width: 100%;
+  height: 60px;
+  text-align: start;
+  text-indent: 20px;
+  font-size: 18px;
+  color: ${({ isSelected }) => (isSelected ? "var(--main-color)" : "black")};
+  & p {
+    position: absolute;
+    top: 30%;
+  }
+  &:first-child {
+    border-radius: 10px 10px 0px 0px;
+    border-width: 1px 1px 1px 1px;
+  }
+  &:last-child {
+    border-radius: 0px 0px 10px 10px;
+  }
+  &:hover {
+    background-color: #f1f1f1;
+  }
+`;
+
+export default Dropdown;

--- a/frontend/src/components/Common/WarningNotification.tsx
+++ b/frontend/src/components/Common/WarningNotification.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import styled from "styled-components";
+
+export interface WarningNotificationProps {
+  isVisible: boolean;
+  message: string;
+}
+
+const WarningNotification: React.FC<WarningNotificationProps> = ({
+  isVisible,
+  message,
+}: WarningNotificationProps) => {
+  return (
+    <WarningWrapper isVisible={isVisible}>
+      <WarningIcon isVisible={isVisible} />
+      <WarningBox>{message}</WarningBox>
+    </WarningWrapper>
+  );
+};
+
+export default WarningNotification;
+
+const WarningIcon = styled.div<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? "block" : "none")};
+  background-image: url("/src/assets/images/warningTriangleIcon.svg");
+  width: 24px;
+  height: 24px;
+  margin: 0px auto;
+  opacity: 0.6;
+  cursor: pointer;
+  &:hover {
+    opacity: 1;
+  }
+`;
+const WarningBox = styled.div`
+  position: relative;
+  margin: 10px auto;
+  visibility: hidden;
+  color: transparent;
+  background-color: transparent;
+  width: 280px;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  text-align: center;
+  line-height: 1.25rem;
+  letter-spacing: -0.02rem;
+  white-space: pre-line;
+  z-index: 100;
+  transition: visibility 0.5s, color 0.5s, background-color 0.5s, width 0.5s,
+    padding 0.5s ease-in-out;
+`;
+const WarningWrapper = styled.div<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? "block" : "none")};
+  position: relative;
+  width: 100%;
+  height: 24px;
+  justify-content: center;
+  & ${WarningIcon}:hover + ${WarningBox} {
+    visibility: visible;
+    color: #fff;
+    background-color: rgba(0, 0, 0, 0.8);
+    &:before {
+      border-color: transparent transparent rgba(0, 0, 0, 0.8)
+        rgba(0, 0, 0, 0.8);
+    }
+  }
+`;

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -3,18 +3,15 @@ import {
   axiosUpdateCabinetTitle,
 } from "@/api/axios/axios.custom";
 import {
-  myCabinetInfoState,
   currentFloorCabinetState,
   targetCabinetInfoState,
 } from "@/recoil/atoms";
-import {
-  CabinetInfo,
-  CabinetInfoByLocationFloorDto,
-  MyCabinetInfoResponseDto,
-} from "@/types/dto/cabinet.dto";
+import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import React from "react";
 import { useRecoilState } from "recoil";
 import StatusModal from "@/components/Modals/StatusModal/StatusModal";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
 
 const StatusModalContainer = (props: {
   onClose: React.MouseEventHandler<Element>;
@@ -45,7 +42,23 @@ const StatusModalContainer = (props: {
   //     targetCabinet!.cabinet_title = newTitle;
   //     setCurrentFloorCabinet(updatedCabinetList);
   //   };
-
+  const onSaveEditStatus = (
+    newCabinetType: CabinetType,
+    newCabinetStatus: CabinetStatus
+  ) => {
+    //type 수정 사항이 있으면 type변경 api 호출
+    if (newCabinetType !== targetCabinetInfo.lent_type) {
+      console.log(
+        `changed from ${targetCabinetInfo.lent_type} to ${newCabinetType}`
+      );
+    }
+    // status 수정 사항이 있으면 status변경 api호출
+    if (newCabinetStatus !== targetCabinetInfo.status) {
+      console.log(
+        `changed from ${targetCabinetInfo.status} to ${newCabinetStatus}`
+      );
+    }
+  };
   //   const onSaveEditMemo = (newTitle: string | null, newMemo: string) => {
   //     if (newTitle !== myCabinetInfo.cabinet_title) {
   //       //수정사항이 있으면
@@ -81,7 +94,7 @@ const StatusModalContainer = (props: {
     <StatusModal
       statusModalObj={statusModalProps}
       onClose={props.onClose}
-      onSave={() => {}}
+      onSave={onSaveEditStatus}
     />
   );
 };

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -11,7 +11,7 @@ import {
   targetCabinetInfoState,
 } from "@/recoil/atoms";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
-import React, { useState } from "react";
+import React from "react";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import StatusModal from "@/components/Modals/StatusModal/StatusModal";
 import CabinetType from "@/types/enum/cabinet.type.enum";
@@ -34,6 +34,11 @@ const StatusModalContainer = (props: {
   const statusModalProps = {
     cabinetType: targetCabinetInfo.lent_type,
     cabinetStatus: targetCabinetInfo.status,
+    warningNotificationObj: {
+      isVisible: targetCabinetInfo.lent_info.length > 0,
+      message: `사물함의 상태 또는 타입을 변경하려면
+		먼저 해당 사물함을 반납해야 합니다.`,
+    },
   };
 
   const onSaveEditStatus = (
@@ -43,10 +48,8 @@ const StatusModalContainer = (props: {
     const cabinetId = targetCabinetInfo.cabinet_id;
     const cabinetStatus = targetCabinetInfo.status;
     const cabinetType = targetCabinetInfo.lent_type;
-    const isLent = targetCabinetInfo.lent_info.length > 0;
     //type 수정 사항이 있으면 type변경 api 호출
     if (newCabinetType !== cabinetType) {
-      console.log(`changed from ${cabinetType} to ${newCabinetType}`);
       axiosUpdateCabinetType(cabinetId, newCabinetType)
         .then(async () => {
           setIsCurrentSectionRender(true);
@@ -64,9 +67,6 @@ const StatusModalContainer = (props: {
     }
     // status 수정 사항이 있으면 status변경 api호출
     if (newCabinetStatus !== cabinetStatus) {
-      console.log(
-        `changed from ${targetCabinetInfo.status} to ${newCabinetStatus}`
-      );
       axiosUpdateCabinetStatus(cabinetId, newCabinetStatus)
         .then(async () => {
           setIsCurrentSectionRender(true);

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -1,0 +1,89 @@
+import {
+  axiosUpdateCabinetMemo,
+  axiosUpdateCabinetTitle,
+} from "@/api/axios/axios.custom";
+import {
+  myCabinetInfoState,
+  currentFloorCabinetState,
+  targetCabinetInfoState,
+} from "@/recoil/atoms";
+import {
+  CabinetInfo,
+  CabinetInfoByLocationFloorDto,
+  MyCabinetInfoResponseDto,
+} from "@/types/dto/cabinet.dto";
+import React from "react";
+import { useRecoilState } from "recoil";
+import StatusModal from "@/components/Modals/StatusModal/StatusModal";
+
+const StatusModalContainer = (props: {
+  onClose: React.MouseEventHandler<Element>;
+}) => {
+  const [targetCabinetInfo, setTargetCabinetInfo] = useRecoilState<CabinetInfo>(
+    targetCabinetInfoState
+  );
+  const [currentFloorCabinet, setCurrentFloorCabinet] = useRecoilState(
+    currentFloorCabinetState
+  );
+  const statusModalProps = {
+    cabinetType: targetCabinetInfo.lent_type,
+    cabinetStatus: targetCabinetInfo.status,
+  };
+  //   const updateCabinetTitleInList = (newTitle: string | null) => {
+  //     const updatedCabinetList: CabinetInfoByLocationFloorDto[] = JSON.parse(
+  //       JSON.stringify(currentFloorCabinet)
+  //     );
+  //     const targetSectionCabinetList = updatedCabinetList.find(
+  //       (floor) => floor.section === myCabinetInfo.section
+  //     )?.cabinets;
+  //     if (targetSectionCabinetList === undefined) return;
+
+  //     let targetCabinet = targetSectionCabinetList.find(
+  //       (section) => section.cabinet_id === myCabinetInfo.cabinet_id
+  //     );
+
+  //     targetCabinet!.cabinet_title = newTitle;
+  //     setCurrentFloorCabinet(updatedCabinetList);
+  //   };
+
+  //   const onSaveEditMemo = (newTitle: string | null, newMemo: string) => {
+  //     if (newTitle !== myCabinetInfo.cabinet_title) {
+  //       //수정사항이 있으면
+  //       axiosUpdateCabinetTitle({ cabinet_title: newTitle ?? "" })
+  //         .then(() => {
+  //           setMyCabinetInfo({
+  //             ...myCabinetInfo,
+  //             cabinet_title: newTitle,
+  //             cabinet_memo: newMemo,
+  //           });
+  //           // list에서 제목 업데이트
+  //           updateCabinetTitleInList(newTitle);
+  //         })
+  //         .catch((error) => {
+  //           console.log(error);
+  //         });
+  //     }
+  //     if (newMemo !== myCabinetInfo.cabinet_memo) {
+  //       axiosUpdateCabinetMemo({ cabinet_memo: newMemo })
+  //         .then(() => {
+  //           setMyCabinetInfo({
+  //             ...myCabinetInfo,
+  //             cabinet_title: newTitle,
+  //             cabinet_memo: newMemo,
+  //           });
+  //         })
+  //         .catch((error) => {
+  //           console.log(error);
+  //         });
+  //     }
+  //   };
+  return (
+    <StatusModal
+      statusModalObj={statusModalProps}
+      onClose={props.onClose}
+      onSave={() => {}}
+    />
+  );
+};
+
+export default StatusModalContainer;

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -1,14 +1,18 @@
 import {
-  axiosUpdateCabinetMemo,
-  axiosUpdateCabinetTitle,
+  axiosCabinetById,
+  axiosUpdateCabinetStatus,
+  axiosUpdateCabinetType,
 } from "@/api/axios/axios.custom";
 import {
+  currentCabinetIdState,
   currentFloorCabinetState,
+  isCurrentSectionRenderState,
+  numberOfAdminWorkState,
   targetCabinetInfoState,
 } from "@/recoil/atoms";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
-import React from "react";
-import { useRecoilState } from "recoil";
+import React, { useState } from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import StatusModal from "@/components/Modals/StatusModal/StatusModal";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
@@ -22,6 +26,13 @@ const StatusModalContainer = (props: {
   const [currentFloorCabinet, setCurrentFloorCabinet] = useRecoilState(
     currentFloorCabinetState
   );
+  const setNumberOfAdminWork = useSetRecoilState(numberOfAdminWorkState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
+  const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
   const statusModalProps = {
     cabinetType: targetCabinetInfo.lent_type,
     cabinetStatus: targetCabinetInfo.status,
@@ -46,17 +57,48 @@ const StatusModalContainer = (props: {
     newCabinetType: CabinetType,
     newCabinetStatus: CabinetStatus
   ) => {
+    const cabinetId = targetCabinetInfo.cabinet_id;
+    const cabinetStatus = targetCabinetInfo.status;
+    const cabinetType = targetCabinetInfo.lent_type;
     //type 수정 사항이 있으면 type변경 api 호출
-    if (newCabinetType !== targetCabinetInfo.lent_type) {
-      console.log(
-        `changed from ${targetCabinetInfo.lent_type} to ${newCabinetType}`
-      );
+    if (newCabinetType !== cabinetType) {
+      console.log(`changed from ${cabinetType} to ${newCabinetType}`);
+      axiosUpdateCabinetType(cabinetId, newCabinetType)
+        .then(async () => {
+          setIsCurrentSectionRender(true);
+
+          setNumberOfAdminWork((prev) => prev + 1);
+          try {
+            const { data } = await axiosCabinetById(currentCabinetId);
+            setTargetCabinetInfo(data);
+          } catch (error) {
+            throw error;
+          }
+        })
+        .catch((error) => {
+          console.log(error.message);
+        });
     }
     // status 수정 사항이 있으면 status변경 api호출
-    if (newCabinetStatus !== targetCabinetInfo.status) {
+    if (newCabinetStatus !== cabinetStatus) {
       console.log(
         `changed from ${targetCabinetInfo.status} to ${newCabinetStatus}`
       );
+      axiosUpdateCabinetStatus(cabinetId, newCabinetStatus)
+        .then(async () => {
+          setIsCurrentSectionRender(true);
+
+          setNumberOfAdminWork((prev) => prev + 1);
+          try {
+            const { data } = await axiosCabinetById(currentCabinetId);
+            setTargetCabinetInfo(data);
+          } catch (error) {
+            throw error;
+          }
+        })
+        .catch((error) => {
+          console.log(error.message);
+        });
     }
   };
   //   const onSaveEditMemo = (newTitle: string | null, newMemo: string) => {

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -31,28 +31,11 @@ const StatusModalContainer = (props: {
     isCurrentSectionRenderState
   );
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
-  const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
-  const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
   const statusModalProps = {
     cabinetType: targetCabinetInfo.lent_type,
     cabinetStatus: targetCabinetInfo.status,
   };
-  //   const updateCabinetTitleInList = (newTitle: string | null) => {
-  //     const updatedCabinetList: CabinetInfoByLocationFloorDto[] = JSON.parse(
-  //       JSON.stringify(currentFloorCabinet)
-  //     );
-  //     const targetSectionCabinetList = updatedCabinetList.find(
-  //       (floor) => floor.section === myCabinetInfo.section
-  //     )?.cabinets;
-  //     if (targetSectionCabinetList === undefined) return;
 
-  //     let targetCabinet = targetSectionCabinetList.find(
-  //       (section) => section.cabinet_id === myCabinetInfo.cabinet_id
-  //     );
-
-  //     targetCabinet!.cabinet_title = newTitle;
-  //     setCurrentFloorCabinet(updatedCabinetList);
-  //   };
   const onSaveEditStatus = (
     newCabinetType: CabinetType,
     newCabinetStatus: CabinetStatus
@@ -60,13 +43,13 @@ const StatusModalContainer = (props: {
     const cabinetId = targetCabinetInfo.cabinet_id;
     const cabinetStatus = targetCabinetInfo.status;
     const cabinetType = targetCabinetInfo.lent_type;
+    const isLent = targetCabinetInfo.lent_info.length > 0;
     //type 수정 사항이 있으면 type변경 api 호출
     if (newCabinetType !== cabinetType) {
       console.log(`changed from ${cabinetType} to ${newCabinetType}`);
       axiosUpdateCabinetType(cabinetId, newCabinetType)
         .then(async () => {
           setIsCurrentSectionRender(true);
-
           setNumberOfAdminWork((prev) => prev + 1);
           try {
             const { data } = await axiosCabinetById(currentCabinetId);
@@ -87,7 +70,6 @@ const StatusModalContainer = (props: {
       axiosUpdateCabinetStatus(cabinetId, newCabinetStatus)
         .then(async () => {
           setIsCurrentSectionRender(true);
-
           setNumberOfAdminWork((prev) => prev + 1);
           try {
             const { data } = await axiosCabinetById(currentCabinetId);
@@ -101,37 +83,6 @@ const StatusModalContainer = (props: {
         });
     }
   };
-  //   const onSaveEditMemo = (newTitle: string | null, newMemo: string) => {
-  //     if (newTitle !== myCabinetInfo.cabinet_title) {
-  //       //수정사항이 있으면
-  //       axiosUpdateCabinetTitle({ cabinet_title: newTitle ?? "" })
-  //         .then(() => {
-  //           setMyCabinetInfo({
-  //             ...myCabinetInfo,
-  //             cabinet_title: newTitle,
-  //             cabinet_memo: newMemo,
-  //           });
-  //           // list에서 제목 업데이트
-  //           updateCabinetTitleInList(newTitle);
-  //         })
-  //         .catch((error) => {
-  //           console.log(error);
-  //         });
-  //     }
-  //     if (newMemo !== myCabinetInfo.cabinet_memo) {
-  //       axiosUpdateCabinetMemo({ cabinet_memo: newMemo })
-  //         .then(() => {
-  //           setMyCabinetInfo({
-  //             ...myCabinetInfo,
-  //             cabinet_title: newTitle,
-  //             cabinet_memo: newMemo,
-  //           });
-  //         })
-  //         .catch((error) => {
-  //           console.log(error);
-  //         });
-  //     }
-  //   };
   return (
     <StatusModal
       statusModalObj={statusModalProps}

--- a/frontend/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.tsx
@@ -83,7 +83,7 @@ const StatusModal = ({
         <H2Styled>상태 관리</H2Styled>
         <ContentSectionStyled>
           <ContentItemSectionStyled>
-            <ContentItemWrapperStyled isVisible={true} mode={mode}>
+            <ContentItemWrapperStyled isVisible={true}>
               <ContentItemTitleStyled>사물함 타입</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
@@ -93,7 +93,14 @@ const StatusModal = ({
                 <Dropdown {...TYPE_DROP_DOWN_PROPS} />
               )}
             </ContentItemWrapperStyled>
-            <ContentItemWrapperStyled isVisible={true} mode={mode}>
+            <ContentItemWrapperStyled
+              isVisible={true}
+              style={
+                warningNotificationObj.isVisible && mode === "write"
+                  ? { marginBottom: "1px" }
+                  : { marginBottom: "25px" }
+              }
+            >
               <ContentItemTitleStyled>사물함 상태</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
@@ -181,19 +188,11 @@ const ContentItemSectionStyled = styled.div`
 
 const ContentItemWrapperStyled = styled.div<{
   isVisible: boolean;
-  mode: string;
 }>`
   display: ${({ isVisible }) => (isVisible ? "flex" : "none")};
   flex-direction: column;
   align-items: flex-start;
   margin-bottom: 25px;
-  &:last-child {
-    ${({ mode }) =>
-      mode === "write" &&
-      css`
-        margin-bottom: 1px;
-      `}
-  }
 `;
 
 const ContentItemTitleStyled = styled.h3`

--- a/frontend/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import Button from "@/components/Common/Button";
 import React, { useRef, useState } from "react";
 import CabinetType from "@/types/enum/cabinet.type.enum";
@@ -6,10 +6,14 @@ import ModalPortal from "../ModalPortal";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import Dropdown from "@/components/Common/Dropdown";
 import { cabinetStatusLabelMap, cabinetTypeLabelMap } from "@/assets/data/maps";
+import WarningNotification, {
+  WarningNotificationProps,
+} from "@/components/Common/WarningNotification";
 
 export interface StatusModalInterface {
   cabinetType: CabinetType;
   cabinetStatus: CabinetStatus;
+  warningNotificationObj: WarningNotificationProps;
 }
 
 interface StatusModalContainerInterface {
@@ -34,7 +38,7 @@ const StatusModal = ({
   onClose,
   onSave,
 }: StatusModalContainerInterface) => {
-  const { cabinetType, cabinetStatus } = statusModalObj;
+  const { cabinetType, cabinetStatus, warningNotificationObj } = statusModalObj;
   const [mode, setMode] = useState<string>("read");
   const [newCabinetType, setNewCabinetType] =
     useState<CabinetType>(cabinetType);
@@ -79,7 +83,7 @@ const StatusModal = ({
         <H2Styled>상태 관리</H2Styled>
         <ContentSectionStyled>
           <ContentItemSectionStyled>
-            <ContentItemWrapperStyled isVisible={true}>
+            <ContentItemWrapperStyled isVisible={true} mode={mode}>
               <ContentItemTitleStyled>사물함 타입</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
@@ -89,7 +93,7 @@ const StatusModal = ({
                 <Dropdown {...TYPE_DROP_DOWN_PROPS} />
               )}
             </ContentItemWrapperStyled>
-            <ContentItemWrapperStyled isVisible={true}>
+            <ContentItemWrapperStyled isVisible={true} mode={mode}>
               <ContentItemTitleStyled>사물함 상태</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
@@ -101,10 +105,17 @@ const StatusModal = ({
             </ContentItemWrapperStyled>
           </ContentItemSectionStyled>
         </ContentSectionStyled>
-        <input id="unselect-input" readOnly style={{ height: 0, width: 0 }} />
+        {mode === "write" && (
+          <WarningNotification {...warningNotificationObj} />
+        )}
         <ButtonWrapperStyled mode={mode}>
           {mode === "write" && (
-            <Button onClick={handleClickSave} text="저장" theme="fill" />
+            <Button
+              onClick={handleClickSave}
+              text="저장"
+              theme="fill"
+              disabled={warningNotificationObj.isVisible}
+            />
           )}
           <Button
             onClick={
@@ -112,6 +123,8 @@ const StatusModal = ({
                 ? onClose
                 : () => {
                     setMode("read");
+                    setNewCabinetStatus(cabinetStatus);
+                    setNewCabinetType(cabinetType);
                   }
             }
             text={mode === "read" ? "닫기" : "취소"}
@@ -166,11 +179,21 @@ const ContentItemSectionStyled = styled.div`
   width: 100%;
 `;
 
-const ContentItemWrapperStyled = styled.div<{ isVisible: boolean }>`
+const ContentItemWrapperStyled = styled.div<{
+  isVisible: boolean;
+  mode: string;
+}>`
   display: ${({ isVisible }) => (isVisible ? "flex" : "none")};
   flex-direction: column;
   align-items: flex-start;
   margin-bottom: 25px;
+  &:last-child {
+    ${({ mode }) =>
+      mode === "write" &&
+      css`
+        margin-bottom: 1px;
+      `}
+  }
 `;
 
 const ContentItemTitleStyled = styled.h3`

--- a/frontend/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.tsx
@@ -1,0 +1,255 @@
+import styled from "styled-components";
+import Button from "@/components/Common/Button";
+import React, { useRef, useState } from "react";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+import ModalPortal from "../ModalPortal";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import Dropdown from "@/components/Common/Dropdown";
+
+export interface StatusModalInterface {
+  cabinetType: CabinetType;
+  cabinetStatus: CabinetStatus;
+}
+
+interface StatusModalContainerInterface {
+  statusModalObj: StatusModalInterface;
+  onClose: React.MouseEventHandler;
+  onSave: any;
+}
+
+const MAX_INPUT_LENGTH = 14;
+
+const TYPE_OPTIONS = [
+  { name: "동아리", value: CabinetType.CLUB },
+  { name: "개인", value: CabinetType.PRIVATE },
+  { name: "공유", value: CabinetType.SHARE },
+];
+
+const STATUS_OPTIONS = [
+  { name: "사뇽 가능", value: CabinetStatus.AVAILABLE },
+  { name: "사용 불가", value: CabinetStatus.BROKEN },
+];
+
+const TYPE_DROP_DOWN_PROPS = {
+  options: TYPE_OPTIONS,
+  defaultValue: "공유",
+  onChange: () => {},
+};
+
+const STATUS_DROP_DOWN_PROPS = {
+  options: STATUS_OPTIONS,
+  defaultValue: "사용 가능",
+  onChange: () => {},
+};
+
+const StatusModal = ({
+  statusModalObj,
+  onClose,
+  onSave,
+}: StatusModalContainerInterface) => {
+  const { cabinetType, cabinetStatus } = statusModalObj;
+  const [mode, setMode] = useState<string>("read");
+  const newTitle = useRef<HTMLInputElement>(null);
+  const newMemo = useRef<HTMLInputElement>(null);
+  const newTypeRef = useRef(null);
+  const newStatusRef = useRef(null);
+  const handleClickWriteMode = (e: any) => {
+    setMode("write");
+    if (cabinetType === "PRIVATE" && newMemo.current) {
+      newMemo.current.select();
+    } else if (newTitle.current) {
+      newTitle.current.select();
+    }
+  };
+
+  const handleClickSave = (e: React.MouseEvent) => {
+    //사물함 제목, 사물함 비밀메모 update api 호출
+    // onClose(e);
+    document.getElementById("unselect-input")?.focus();
+    if (cabinetType === "SHARE" && newTitle.current!.value) {
+      onSave(newTitle.current!.value, newMemo.current!.value);
+    } else {
+      onSave(null, newMemo.current!.value);
+    }
+    setMode("read");
+  };
+  return (
+    <ModalPortal>
+      <BackgroundStyled onClick={onClose} />
+      <ModalContainerStyled type={"confirm"}>
+        <WriteModeButtonStyled mode={mode} onClick={handleClickWriteMode}>
+          수정하기
+        </WriteModeButtonStyled>
+        <H2Styled>상태 관리</H2Styled>
+        <ContentSectionStyled>
+          <ContentItemSectionStyled>
+            <ContentItemWrapperStyled isVisible={true}>
+              <ContentItemTitleStyled>사물함 타입</ContentItemTitleStyled>
+              {/* <ContentItemInputStyled
+                onKeyUp={(e: any) => {
+                  if (e.key === "Enter") {
+                    handleClickSave(e);
+                  }
+                }}
+                placeholder={cabinetType}
+                mode={mode}
+                defaultValue={cabinetType}
+                ref={newTypeRef}
+              /> */}
+              <Dropdown {...TYPE_DROP_DOWN_PROPS} />
+            </ContentItemWrapperStyled>
+            <ContentItemWrapperStyled isVisible={true}>
+              <ContentItemTitleStyled>사물함 상태</ContentItemTitleStyled>
+              <ContentItemInputStyled
+                onKeyUp={(e: any) => {
+                  if (e.key === "Enter") {
+                    handleClickSave(e);
+                  }
+                }}
+                placeholder={cabinetStatus}
+                mode={mode}
+                defaultValue={cabinetStatus}
+                ref={newStatusRef}
+              />
+            </ContentItemWrapperStyled>
+          </ContentItemSectionStyled>
+        </ContentSectionStyled>
+        <input id="unselect-input" readOnly style={{ height: 0, width: 0 }} />
+        <ButtonWrapperStyled mode={mode}>
+          {mode === "write" && (
+            <Button onClick={handleClickSave} text="저장" theme="fill" />
+          )}
+          <Button
+            onClick={
+              mode === "read"
+                ? onClose
+                : () => {
+                    setMode("read");
+                    if (cabinetType) newTitle.current!.value = cabinetType;
+                    newMemo.current!.value = cabinetStatus;
+                  }
+            }
+            text={mode === "read" ? "닫기" : "취소"}
+            theme={mode === "read" ? "lightGrayLine" : "line"}
+          />
+        </ButtonWrapperStyled>
+      </ModalContainerStyled>
+    </ModalPortal>
+  );
+};
+
+const ModalContainerStyled = styled.div<{ type: string }>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 360px;
+  background: white;
+  z-index: 1000;
+  border-radius: 10px;
+  transform: translate(-50%, -50%);
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  text-align: center;
+  padding: 40px;
+`;
+
+export const DetailStyled = styled.p`
+  margin: 0 30px 30px 30px;
+  line-height: 1.2em;
+  white-space: break-spaces;
+`;
+
+const H2Styled = styled.h2`
+  font-weight: 600;
+  font-size: 1.5rem;
+  margin: 0 30px 25px 0px;
+  white-space: break-spaces;
+  text-align: start;
+`;
+
+const ContentSectionStyled = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+`;
+
+const ContentItemSectionStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const ContentItemWrapperStyled = styled.div<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? "flex" : "none")};
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 25px;
+`;
+
+const ContentItemTitleStyled = styled.h3`
+  font-size: 18px;
+  margin-bottom: 8px;
+`;
+const ContentItemInputStyled = styled.input<{
+  mode: string;
+}>`
+  border: 1px solid var(--line-color);
+  width: 100%;
+  height: 60px;
+  border-radius: 10px;
+  text-align: start;
+  text-indent: 20px;
+  font-size: 18px;
+  cursor: ${({ mode }) => (mode === "read" ? "default" : "input")};
+  color: ${({ mode }) => (mode === "read" ? "var(--main-color)" : "black")};
+  &::placeholder {
+    color: ${({ mode }) =>
+      mode === "read" ? "var(--main-color)" : "var(--line-color)"};
+  }
+`;
+
+const BackgroundStyled = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+`;
+
+const WriteModeButtonStyled = styled.button<{ mode: string }>`
+  display: ${({ mode }) => (mode === "read" ? "block" : "none")};
+  position: absolute;
+  right: 40px;
+  padding: 0;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 17px;
+  width: max-content;
+  height: auto;
+  border: none;
+  outline: none;
+  background: none;
+  cursor: pointer;
+  text-decoration: underline;
+  color: var(--main-color);
+  &: hover {
+    opacity: 0.8;
+  }
+`;
+
+const ButtonWrapperStyled = styled.div<{ mode: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: ${({ mode }) => (mode === "read" ? "75px" : "0")};
+  @media (max-height: 745px) {
+    margin-top: ${({ mode }) => (mode === "read" ? "68px" : "0")};
+  }
+`;
+
+export default StatusModal;

--- a/frontend/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.tsx
@@ -18,8 +18,6 @@ interface StatusModalContainerInterface {
   onSave: any;
 }
 
-const MAX_INPUT_LENGTH = 14;
-
 const TYPE_OPTIONS = [
   { name: "동아리 사물함", value: CabinetType.CLUB },
   { name: "개인 사물함", value: CabinetType.PRIVATE },
@@ -56,13 +54,13 @@ const StatusModal = ({
 
   const TYPE_DROP_DOWN_PROPS = {
     options: TYPE_OPTIONS,
-    defaultValue: cabinetTypeLabelMap[cabinetType],
+    defaultValue: cabinetTypeLabelMap[newCabinetType],
     onChangeValue: handleDropdownChangeValue,
   };
 
   const STATUS_DROP_DOWN_PROPS = {
     options: STATUS_OPTIONS,
-    defaultValue: cabinetStatusLabelMap[cabinetStatus],
+    defaultValue: cabinetStatusLabelMap[newCabinetStatus],
     onChangeValue: handleDropdownChangeValue,
   };
 
@@ -85,7 +83,7 @@ const StatusModal = ({
               <ContentItemTitleStyled>사물함 타입</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
-                  <p>{cabinetTypeLabelMap[cabinetType]}</p>
+                  <p>{cabinetTypeLabelMap[newCabinetType]}</p>
                 </ContentItemContainerStyled>
               ) : (
                 <Dropdown {...TYPE_DROP_DOWN_PROPS} />
@@ -95,7 +93,7 @@ const StatusModal = ({
               <ContentItemTitleStyled>사물함 상태</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
-                  <p>{cabinetStatusLabelMap[cabinetStatus]}</p>
+                  <p>{cabinetStatusLabelMap[newCabinetStatus]}</p>
                 </ContentItemContainerStyled>
               ) : (
                 <Dropdown {...STATUS_DROP_DOWN_PROPS} />


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

#976 
<img width="384" alt="image" src="https://user-images.githubusercontent.com/45449387/222128085-5c36f5c5-ef92-4869-9727-2a391cfc513f.png">
위와 같이 사물함의 타입과 상태를 조회할 수 있습니다. 
<img width="376" alt="image" src="https://user-images.githubusercontent.com/45449387/222129762-0194242d-5b5a-4248-8911-bba299e5f41b.png">
위와 같이 사물함 상태, 타입을 드롭다운 메뉴 형식으로 수정할 수 있습니다. 
<img width="371" alt="image" src="https://user-images.githubusercontent.com/45449387/222129924-adaa8fa8-ccfc-42c3-9bf8-54ee8f8454d2.png">
빌린 사람이 있는 사물함의 경우 위와 같이 경고가 뜨고 저장 버튼이 비활성화 됩니다. RealViewNotification 컴포넌트의 코드를 활용하여 새로 만들었습니다. 
Closes #976 