### PR TITLE
[BE] 사물함 상태 변경 메서드 수정 #988

### DIFF
--- a/backend/src/admin/cabinet/cabinet.service.ts
+++ b/backend/src/admin/cabinet/cabinet.service.ts
@@ -140,7 +140,8 @@ export class AdminCabinetService {
       `Called ${AdminCabinetService.name} ${this.updateCabinetStatus.name}`,
     );
     await this.throwIfNotExistedCabinet(cabinetId);
-    await this.throwIfHasBorrower(cabinetId);
+    if (status == CabinetStatusType.BROKEN)
+      await this.throwIfHasBorrower(cabinetId);
     await this.adminCabinetRepository.updateCabinetStatus(cabinetId, status);
   }
 

--- a/backend/src/admin/cabinet/cabinet.service.ts
+++ b/backend/src/admin/cabinet/cabinet.service.ts
@@ -140,7 +140,7 @@ export class AdminCabinetService {
       `Called ${AdminCabinetService.name} ${this.updateCabinetStatus.name}`,
     );
     await this.throwIfNotExistedCabinet(cabinetId);
-    if (status == CabinetStatusType.BROKEN)
+    if (status === CabinetStatusType.BROKEN)
       await this.throwIfHasBorrower(cabinetId);
     await this.adminCabinetRepository.updateCabinetStatus(cabinetId, status);
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/988

이전 코드는 대여자가 있으면 사물함 상태 변경이 불가능하게 되어있었지만,
[이전 상태] -> BROKEN인 경우에만 대여자가 있는 경우 상태 변경이 불가능하도록 수정했습니다.
