### PR TITLE
[BE] fix: returnCabinetBundle 수정 #991

### DIFF
--- a/backend/src/admin/return/return.controller.ts
+++ b/backend/src/admin/return/return.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Logger, Param, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Logger, Param, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AdminJwtAuthGuard } from 'src/admin/auth/jwt/guard/jwtauth.guard';
 import { AdminReturnService } from 'src/admin/return/return.service';
@@ -29,10 +29,9 @@ export class AdminReturnController {
   @Delete('/bundle/cabinet')
   @ApiOperation({})
   async returnCabinetBundle(
-    users: number[],
-    cabinets: number[],
+    @Body() bundle: number[],
   ): Promise<void> {
     this.logger.debug(`Called ${this.returnCabinetBundle.name}`);
-    return await this.adminReturnService.returnCabinetBundle(users, cabinets);
+    return await this.adminReturnService.returnCabinetBundle(bundle);
   }
 }

--- a/backend/src/admin/return/return.service.ts
+++ b/backend/src/admin/return/return.service.ts
@@ -116,32 +116,22 @@ export class AdminReturnService {
   }
 
   async returnCabinetBundle(
-    users: number[],
-    cabinets: number[],
+    bundle: number[],
   ): Promise<void> {
     this.logger.debug(
       `Called ${AdminReturnService.name} ${this.returnCabinetBundle.name}`,
     );
-    const userFailures = [];
     const cabinetsFailures = [];
-    if (users) {
-      for await (const userId of users) {
-        await this.returnUserCabinetByUserId(userId).catch(() => {
-          userFailures.push(userId);
-        });
-      }
-    }
-    if (cabinets) {
-      for await (const cabinetId of cabinets) {
+    if (bundle) {
+      for await (const cabinetId of bundle) {
         await this.returnCabinetByCabinetId(cabinetId).catch(() => {
           cabinetsFailures.push(cabinetId);
         });
       }
     }
-    if (!(userFailures.length === 0 && cabinetsFailures.length === 0)) {
+    if (!(cabinetsFailures.length === 0)) {
       throw new HttpException(
         {
-          user_failures: userFailures,
           cabinet_failures: cabinetsFailures,
         },
         HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/991

사물함 여러개를 반납하는 returnCabinetBundle 메소드를 body에 cabinetId를 배열로 받을 수 있도록 수정했습니다.