### PR TITLE
[BE] fix: OverDueUserCabinetInfoDto에 cabinetId 추가

### DIFF
--- a/backend/src/admin/dto/Overdue.user.cabinet.info.dto.ts
+++ b/backend/src/admin/dto/Overdue.user.cabinet.info.dto.ts
@@ -8,6 +8,12 @@ export class OverdueUserCabinetInfoDto {
   intra_id: string; // 42 로그인 ID
 
   @ApiProperty({
+    description: '캐비닛 고유 아이디',
+    example: '35',
+  })
+  cabinet_id: number;
+  
+  @ApiProperty({
     description: '캐비닛 위치',
     example: '1f-100',
   })

--- a/backend/src/admin/search/repository/search.repository.ts
+++ b/backend/src/admin/search/repository/search.repository.ts
@@ -322,6 +322,7 @@ export class AdminSearchRepository implements IAdminSearchRepository {
     const rtn = {
       result: result[0].map((overdueLent) => ({
         intra_id: overdueLent.user.intra_id,
+        cabinet_id: overdueLent.lent_cabinet_id,
         location:
           overdueLent.cabinet.floor + 'f-' + overdueLent.cabinet.cabinet_num,
         overdueDays: Math.trunc(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

프론트분들의 요청에 따라 연체중인 유저 목록을 불러올 때 cabinet_id까지 보낼 수 있도록 수정했습니다.
