### PR TITLE
[FE] FIX: 다중 선택 처음 선택하면 다중 선택 안되는 버그 수정 #989

### DIFF
--- a/frontend/src/pages/admin/AdminMainPage.tsx
+++ b/frontend/src/pages/admin/AdminMainPage.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { currentFloorSectionState } from "@/recoil/selectors";
-import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import {
+  useRecoilState,
+  useRecoilValue,
+  useResetRecoilState,
+  useSetRecoilState,
+} from "recoil";
 import {
   currentFloorNumberState,
   currentSectionNameState,
+  selectedTypeOnSearchState,
 } from "@/recoil/atoms";
 import { currentCabinetIdState, targetCabinetInfoState } from "@/recoil/atoms";
 import useMenu from "@/hooks/useMenu";
@@ -26,6 +32,7 @@ const MainPage = () => {
   } = useMultiSelect();
   const resetTargetCabinetInfo = useResetRecoilState(targetCabinetInfoState);
   const resetCurrentCabinetId = useResetRecoilState(currentCabinetIdState);
+  const setSelectedTypeOnSearch = useSetRecoilState(selectedTypeOnSearchState);
   const currentFloorNumber = useRecoilValue<number>(currentFloorNumberState);
   useEffect(() => {
     closeAll();
@@ -97,7 +104,10 @@ const MainPage = () => {
         <MultiSelectButton
           theme={isMultiSelect ? "fill" : "line"}
           text="다중 선택 모드"
-          onClick={toggleMultiSelectMode}
+          onClick={() => {
+            toggleMultiSelectMode();
+            setSelectedTypeOnSearch("CABINET");
+          }}
         />
       </div>
       <CabinetListWrapperStyled>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

다중 선택 모드 를 선택하면

selectedTypeOnSearch 이 "USER" 인 상태로 요청을 보내는 상황이라 
다중선택에 대한 CabinetInfoArea가 나오지 않았던 것으로 확인했습니다.

그래서 "다중 선택 모드" 버튼을 누르면

selectedTypeOnSearch를 CABINET으로 변경해 주는 부분을 추가하였습니다.

수고 많으셨습니다

그리고 

다중선택 도중에 상태 관리를 누르면 터지는 현상이 보입니다
