### PR TITLE
[FE] FIX: Admin Info 페이지에서 background 두 번 나오는 현상 해결 #996

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -20,4 +20,4 @@ services:
     ports:
       - '80:80'
     volumes:
-      - ../dev/:/etc/nginx/conf.d/
+      - ~/yooh/dev/:/etc/nginx/conf.d/

--- a/frontend/src/pages/admin/AdminInfoPage.tsx
+++ b/frontend/src/pages/admin/AdminInfoPage.tsx
@@ -25,7 +25,6 @@ import PieChart from "../../components/AdminInfo/Chart/PieChart";
 import AdminTable from "../../components/AdminInfo/Table/AdminTable";
 
 const AdminInfo = () => {
-  const [toggle, setToggle] = useState(false);
   const [overdueUserList, setOverdueUserList] = useRecoilState<IData[]>(
     overdueCabinetListState
   );
@@ -38,7 +37,7 @@ const AdminInfo = () => {
     ICabinetNumbersPerFloor[]
   >([]);
   const [monthlyData, setMonthlyData] = useState<IMonthlyData[]>([]);
-  const { openCabinet, closeCabinet } = useMenu();
+  const { openCabinet } = useMenu();
   const setSelectedTypeOnSearch = useSetRecoilState(selectedTypeOnSearchState);
   const setTargetCabinetInfo = useSetRecoilState<CabinetInfo>(
     targetCabinetInfoState
@@ -46,11 +45,7 @@ const AdminInfo = () => {
   const setCurrentCabinetId = useSetRecoilState(currentCabinetIdState);
   const setTargetUserInfo = useSetRecoilState(targetUserInfoState);
 
-  const onClick = (
-    e: React.MouseEvent<Element>,
-    setToggle: React.Dispatch<React.SetStateAction<boolean>>,
-    type: string
-  ) => {
+  const onClick = (e: React.MouseEvent<Element>, type: string) => {
     const target = e.currentTarget as HTMLTableElement;
     const str = target.dataset.info;
     openCabinet();
@@ -81,7 +76,6 @@ const AdminInfo = () => {
         console.log(error);
       }
     }
-    setToggle(true);
   };
 
   useEffect(() => {
@@ -111,7 +105,7 @@ const AdminInfo = () => {
         <H2styled>반납지연 유저</H2styled>
         <AdminTable
           data={overdueUserList}
-          handleClick={(e) => onClick(e, setToggle, "overdue")}
+          handleClick={(e) => onClick(e, "overdue")}
           thInfo={["Intra ID", "위치", "연체일"]}
           ratio={["33%", "33%", "33%"]}
         />
@@ -120,7 +114,7 @@ const AdminInfo = () => {
         <H2styled>사용정지 유저</H2styled>
         <AdminTable
           data={bannedUserList}
-          handleClick={(e) => onClick(e, setToggle, "banned")}
+          handleClick={(e) => onClick(e, "banned")}
           thInfo={["Intra ID", "사용정지 일", "기간"]}
           ratio={["33%", "33%", "33%"]}
         />
@@ -129,19 +123,12 @@ const AdminInfo = () => {
         <H2styled>고장 사물함</H2styled>
         <AdminTable
           data={brokenCabinetList}
-          handleClick={(e) => onClick(e, setToggle, "broken")}
+          handleClick={(e) => onClick(e, "broken")}
           thInfo={["위치 정보", "확인 일자", "사유"]}
           ratio={["30%", "40%", "30%"]}
           fontSize={["1rem", "0.8rem", "1rem"]}
         />
       </ContainerStyled>
-      <BackgroundStyled
-        onClick={() => {
-          closeCabinet();
-          setToggle(false);
-        }}
-        toggle={toggle}
-      />
     </AdminInfoStyled>
   );
 };
@@ -151,17 +138,6 @@ const H2styled = styled.h2`
   padding-top: 15px;
   text-align: center;
   font-weight: bold;
-`;
-
-const BackgroundStyled = styled.div<{ toggle: boolean }>`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  left: 0;
-  top: 0;
-  z-index: 2;
-  display: ${({ toggle }) => (toggle ? "block" : "none")};
 `;
 
 const ContainerStyled = styled.div`


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/996

기존 openCabinet() 훅에서 딸려오는 background와 제가 따로 만든  background가 중첩되는 현상이였습니다.

수정하였습니다.
