### PR TITLE
[FE] FEAT: 검색 페이지 - 상세정보란 관리자 모달 연결, 사물함 반납 버튼 비활성화 조건 추가 #999

### DIFF
--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -40,9 +40,6 @@ const AdminCabinetInfoArea: React.FC<{
 
   const isLented: boolean = selectedCabinetInfo?.userNameList.at(0) !== "-";
 
-  console.log(selectedCabinetInfo);
-  console.log(isLented);
-
   const handleOpenAdminReturnModal = () => {
     setShowAdminReturnModal(true);
   };

--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -38,6 +38,11 @@ const AdminCabinetInfoArea: React.FC<{
 
   const { resetMultiSelectMode, isSameStatus, isSameType } = useMultiSelect();
 
+  const isLented: boolean = selectedCabinetInfo?.userNameList.at(0) !== "-";
+
+  console.log(selectedCabinetInfo);
+  console.log(isLented);
+
   const handleOpenAdminReturnModal = () => {
     setShowAdminReturnModal(true);
   };
@@ -161,6 +166,9 @@ const AdminCabinetInfoArea: React.FC<{
           onClick={handleOpenAdminReturnModal} //todo: admin 단일 반납 모달 만들기
           text="반납"
           theme="fill"
+          disabled={
+            selectedCabinetInfo!.lentType === CabinetType.CLUB || !isLented
+          }
         />
         <ButtonContainer
           onClick={handleOpenStatusModal} //todo: admin 단일 상태관리 모달 만들기

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -92,6 +92,7 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
         detailMessage: getDetailMessage(targetCabinetInfo),
         detailMessageColor: getDetailMessageColor(targetCabinetInfo),
         isAdmin: isAdmin,
+        isLented: targetCabinetInfo.lent_info.length !== 0,
       }
     : null;
 

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -27,6 +27,7 @@ export interface ISelectedCabinetInfo {
   detailMessage: string | null;
   detailMessageColor: string;
   isAdmin: boolean;
+  isLented: boolean;
 }
 
 const CabinetInfoArea: React.FC<{

--- a/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/AdminReturnModal.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
 import {
   currentCabinetIdState,
   isCurrentSectionRenderState,
   numberOfAdminWorkState,
   overdueCabinetListState,
   targetCabinetInfoState,
+  targetUserInfoState,
 } from "@/recoil/atoms";
 import {
   axiosAdminReturn,
@@ -27,6 +28,7 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 import Selector from "@/components/Common/Selector";
 import useMultiSelect from "@/hooks/useMultiSelect";
 import { handleOverdueUserList } from "@/components/AdminInfo/convertFunctions";
+import { UserInfo } from "@/types/dto/user.dto";
 
 const AdminReturnModal: React.FC<{
   lentType?: CabinetType;
@@ -44,6 +46,8 @@ const AdminReturnModal: React.FC<{
   const setNumberOfAdminWork = useSetRecoilState<number>(
     numberOfAdminWorkState
   );
+  const [targetUserInfo, setTargetUserInfo] =
+    useRecoilState(targetUserInfoState);
   const targetCabinetInfo = useRecoilValue<CabinetInfo>(targetCabinetInfoState);
   const [selectedUserIds, setSelectedUserIds] = useState<number[]>([]);
   const { targetCabinetInfoList, isMultiSelect, closeMultiSelectMode } =
@@ -106,6 +110,14 @@ const AdminReturnModal: React.FC<{
       try {
         const { data } = await axiosCabinetById(currentCabinetId);
         setTargetCabinetInfo(data);
+        if (targetUserInfo) {
+          const changedInfo: UserInfo = {
+            ...targetUserInfo,
+            cabinetId: undefined,
+            cabinetInfo: undefined,
+          };
+          setTargetUserInfo(changedInfo);
+        }
       } catch (error) {
         throw error;
       }

--- a/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
+++ b/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
@@ -1,5 +1,5 @@
-import { useRecoilValue } from "recoil";
-import { targetUserInfoState } from "@/recoil/atoms";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { targetUserInfoState, currentCabinetIdState } from "@/recoil/atoms";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import UserInfoArea, {
   ISelectedUserInfo,
@@ -10,6 +10,7 @@ import useMenu from "@/hooks/useMenu";
 
 const UserInfoAreaContainer = (): JSX.Element => {
   const targetUserInfo = useRecoilValue(targetUserInfoState);
+  const setCurrentCabinetId = useSetRecoilState(currentCabinetIdState);
   const { closeCabinet } = useMenu();
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
@@ -84,17 +85,7 @@ const UserInfoAreaContainer = (): JSX.Element => {
     } else return "var(--black)";
   };
 
-  // dummy data
-  // make with targetUserInfo state
-  // const userInfoData: ISelectedUserInfo = {
-  //   intraId: "jaesjeon",
-  //   isBanned: false,
-  // };
-  // const userInfoData: ISelectedUserInfo = {
-  //   intraId: "jaesjeon",
-  //   isBanned: true,
-  //   bannedInfo: "2099-12-31 까지 대여가 불가능합니다.",
-  // };
+  if (targetUserInfo?.cabinetId) setCurrentCabinetId(targetUserInfo.cabinetId);
 
   const userInfoData: ISelectedUserInfo | undefined = targetUserInfo
     ? {

--- a/frontend/src/components/UserInfoArea/UserInfoArea.tsx
+++ b/frontend/src/components/UserInfoArea/UserInfoArea.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { useRecoilValue } from "recoil";
+import { numberOfAdminWorkState } from "@/recoil/atoms";
 import styled, { css } from "styled-components";
 import ButtonContainer from "@/components/Common/Button";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
@@ -6,7 +8,7 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 import ChangeToHTML from "@/components/TopNav/SearchBar/SearchListItem/ChangeToHTML";
 import cabiLogo from "@/assets/images/logo.svg";
 import BanModal from "@/components/Modals/BanModal/BanModal";
-import ReturnModal from "@/components/Modals/ReturnModal/ReturnModal";
+import AdminReturnModal from "@/components/Modals/ReturnModal/AdminReturnModal";
 import {
   cabinetIconSrcMap,
   cabinetLabelColorMap,
@@ -39,13 +41,16 @@ const UserInfoArea: React.FC<{
 }> = (props) => {
   const { selectedUserInfo, userLentInfo, closeCabinet } = props;
   const [showBanModal, setShowBanModal] = useState<boolean>(false);
-  const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
+  const [showAdminReturnModal, setShowAdminReturnModal] =
+    useState<boolean>(false);
+  const numberOfAdminWork = useRecoilValue(numberOfAdminWorkState);
+  numberOfAdminWork;
 
-  const handleOpenReturnModal = () => {
-    setShowReturnModal(true);
+  const handleOpenAdminReturnModal = () => {
+    setShowAdminReturnModal(true);
   };
-  const handleCloseReturnModal = () => {
-    setShowReturnModal(false);
+  const handleCloseAdminReturnModal = () => {
+    setShowAdminReturnModal(false);
   };
   const handleOpenBanModal = () => {
     setShowBanModal(true);
@@ -128,15 +133,9 @@ const UserInfoArea: React.FC<{
       </TextStyled>
       <CabinetInfoButtonsContainerStyled>
         <ButtonContainer
-          onClick={handleOpenReturnModal}
+          onClick={handleOpenAdminReturnModal}
           text="반납"
           theme="fill"
-        />
-        <ButtonContainer
-          onClick={handleOpenBanModal}
-          text="상태 관리"
-          theme="line"
-          disabled={selectedUserInfo.isBanned === false}
         />
         <ButtonContainer onClick={closeCabinet} text="닫기" theme="grayLine" />
       </CabinetInfoButtonsContainerStyled>
@@ -148,10 +147,10 @@ const UserInfoArea: React.FC<{
           ? `${userLentInfo.expireDate.toString().substring(0, 10)}`
           : null}
       </CabinetLentDateInfoStyled>
-      {showReturnModal && (
-        <ReturnModal
+      {showAdminReturnModal && (
+        <AdminReturnModal
           lentType={userLentInfo.lentType}
-          closeModal={handleCloseReturnModal}
+          closeModal={handleCloseAdminReturnModal}
         />
       )}
     </CabinetDetailAreaStyled>

--- a/frontend/src/recoil/atoms.ts
+++ b/frontend/src/recoil/atoms.ts
@@ -113,7 +113,7 @@ export const numberOfAdminWorkState = atom<number>({
 
 export const selectedTypeOnSearchState = atom<string>({
   key: "SelectedTypeOnSearch",
-  default: "USER",
+  default: "CABINET",
 });
 
 export const targetUserInfoState = atom<UserInfo>({


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/999

### 추가 기능
1. 검색 페이지 - 유저 상세 정보 컴포넌트
  a. 반납
  b. 밴 해제
2. 사물함 상세 정보 컴포넌트 - 반납 버튼
  a. 대여 중이 아니거나 동아리 사물함인 경우 버튼 비활성화
