### PR TITLE
[BE] BUG: 캐비닛 렌트 타입 변경시 max_user 변경 반영 #1005

### DIFF
--- a/backend/src/admin/cabinet/cabinet.service.ts
+++ b/backend/src/admin/cabinet/cabinet.service.ts
@@ -121,7 +121,7 @@ export class AdminCabinetService {
     const result = [];
     for (const cabinetId of bundle) {
       try {
-        await this.adminCabinetRepository.updateLentType(cabinetId, lentType);
+        await this.updateLentType(cabinetId, lentType);
       } catch (e) {
         result.push(cabinetId);
         continue;

--- a/backend/src/admin/cabinet/cabinet.service.ts
+++ b/backend/src/admin/cabinet/cabinet.service.ts
@@ -75,6 +75,12 @@ export class AdminCabinetService {
     );
     await this.throwIfNotExistedCabinet(cabinetId);
     await this.throwIfHasBorrower(cabinetId);
+	if (lentType == LentType.PRIVATE)
+		await this.adminCabinetRepository.updateCabinetMaxUser(cabinetId, 1);
+	if (lentType == LentType.SHARE)
+		await this.adminCabinetRepository.updateCabinetMaxUser(cabinetId, 3);
+	if (lentType == LentType.CLUB)
+		await this.adminCabinetRepository.updateCabinetMaxUser(cabinetId, 1);
     await this.adminCabinetRepository.updateLentType(cabinetId, lentType);
   }
 
@@ -143,6 +149,17 @@ export class AdminCabinetService {
     if (status === CabinetStatusType.BROKEN)
       await this.throwIfHasBorrower(cabinetId);
     await this.adminCabinetRepository.updateCabinetStatus(cabinetId, status);
+  }
+
+  async updateCabinetMaxUser(
+    cabinetId: number,
+	maxUser: number,
+  ): Promise<void> {
+    this.logger.debug(
+      `Called ${AdminCabinetService.name} ${this.updateCabinetMaxUser.name}`,
+    );
+    await this.throwIfNotExistedCabinet(cabinetId);
+    await this.adminCabinetRepository.updateCabinetMaxUser(cabinetId, maxUser);
   }
 
   async isCabinetExist(cabinetId: number): Promise<boolean> {

--- a/backend/src/admin/cabinet/repository/cabinet.repository.interface.ts
+++ b/backend/src/admin/cabinet/repository/cabinet.repository.interface.ts
@@ -71,4 +71,15 @@ export interface IAdminCabinetRepository {
    * @param cabinetId
    */
   isCabinetExist(cabinetId: number): Promise<boolean>;
+
+   /**
+   * 특정 사물함의 max_user를 변경합니다.
+   *
+   * @param cabinetId
+   * @param maxUser
+   */
+	updateCabinetMaxUser(
+		cabinetId: number,
+		maxUser: number,
+	  ): Promise<void>;
 }

--- a/backend/src/admin/cabinet/repository/cabinet.repository.ts
+++ b/backend/src/admin/cabinet/repository/cabinet.repository.ts
@@ -133,6 +133,22 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
       .execute();
   }
 
+  async updateCabinetMaxUser(
+    cabinetId: number,
+	max_user: number,
+  ): Promise<void> {
+	await this.cabinetRepository
+      .createQueryBuilder(this.updateCabinetMaxUser.name)
+      .update()
+      .set({
+        max_user,
+      })
+      .where({
+        cabinet_id: cabinetId,
+      })
+      .execute();
+  }
+
   async isCabinetExist(cabinetId: number): Promise<boolean> {
     const result = await this.cabinetRepository.findOne({
       where: {

--- a/backend/src/admin/cabinet/repository/cabinet.repository.ts
+++ b/backend/src/admin/cabinet/repository/cabinet.repository.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import Cabinet from 'src/entities/cabinet.entity';
 import CabinetStatusType from 'src/enums/cabinet.status.type.enum';
 import LentType from 'src/enums/lent.type.enum';
+import { IsolationLevel, Propagation, Transactional } from 'typeorm-transactional';
 
 export class AdminCabinetRepository implements IAdminCabinetRepository {
   constructor(
@@ -62,7 +63,11 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
 
     return result.map((c) => c.lent_cabinet_id);
   }
-
+  
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async updateLentType(cabinetId: number, lentType: LentType): Promise<void> {
     await this.cabinetRepository
       .createQueryBuilder(this.updateLentType.name)
@@ -91,6 +96,10 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
     return result.lent.length === 0 ? false : true;
   }
 
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async updateStatusNote(cabinetId: number, statusNote: string): Promise<void> {
     await this.cabinetRepository
       .createQueryBuilder(this.updateLentType.name)
@@ -104,6 +113,10 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
       .execute();
   }
 
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async updateCabinetTitle(cabinetId: number, title: string): Promise<void> {
     await this.cabinetRepository
       .createQueryBuilder(this.updateCabinetTitle.name)
@@ -117,6 +130,10 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
       .execute();
   }
 
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async updateCabinetStatus(
     cabinetId: number,
     status: CabinetStatusType,
@@ -133,6 +150,10 @@ export class AdminCabinetRepository implements IAdminCabinetRepository {
       .execute();
   }
 
+  @Transactional({
+    propagation: Propagation.REQUIRED,
+    isolationLevel: IsolationLevel.SERIALIZABLE,
+  })
   async updateCabinetMaxUser(
     cabinetId: number,
 	max_user: number,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1005

updateCabinetMaxUser(cabinetId: number, maxUser: number)
메서드를 어드민 캐비닛 서비스에 추가하였습니다.
차후에 재사용이 가능하도록 maxUser를 그대로 받아서 변경할 수 있게끔 구현했습니다.

해당 메서드를 이용해서, admin cabinetService에서 사용되고 있는 updateLentType에 현재 대여타입 별로 maxUser를 설정하도록 변경하였고, bundle의 경우 기존 리포지토리 함수를 직접적으로 사용하던 것을 서비스의 updateLentType를 사용하도록 하여 다중 선택으로 대여 타입을 변경하여도 max_user가 변경될 수 있도록 수정하였습니다.

