### PR TITLE
[FE] 다중선택모드에서 일괄 상태변경 시 변경사항이 모달에 반영 안되는 버그 수정 #1006

### DIFF
--- a/frontend/src/components/Common/Dropdown.tsx
+++ b/frontend/src/components/Common/Dropdown.tsx
@@ -2,14 +2,16 @@ import { useState } from "react";
 import styled, { css } from "styled-components";
 
 interface IDropdown {
-  options: { name: string; value: any }[];
+  options: { name: string; value: any; imageSrc?: string }[];
   defaultValue: string;
+  defaultImageSrc?: string;
   onChangeValue?: (param: any) => any;
 }
 
 const Dropdown = ({ options, defaultValue, onChangeValue }: IDropdown) => {
   const [currentName, setCurrentName] = useState(defaultValue);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const selectedIdx = options.findIndex((op) => op.name === currentName) ?? 0;
   return (
     <DropdownContainerStyled>
       <DropdownSelectionBoxStyled
@@ -18,7 +20,12 @@ const Dropdown = ({ options, defaultValue, onChangeValue }: IDropdown) => {
         }}
         isOpen={isOpen}
       >
-        <p>{currentName}</p>
+        {options[selectedIdx].imageSrc && (
+          <div style={{ width: "18px", height: "18px" }}>
+            <img src={options[selectedIdx].imageSrc} />
+          </div>
+        )}
+        <p style={{ paddingLeft: "10px" }}>{currentName}</p>
         <img src="/src/assets/images/dropdownChevron.svg" />
       </DropdownSelectionBoxStyled>
       <DropdownItemContainerStyled isVisible={isOpen}>
@@ -35,7 +42,12 @@ const Dropdown = ({ options, defaultValue, onChangeValue }: IDropdown) => {
               }}
               isSelected={option.name === currentName}
             >
-              <p>{option.name}</p>
+              {option.imageSrc && (
+                <div style={{ width: "18px", height: "18px" }}>
+                  <img src={option.imageSrc} />
+                </div>
+              )}
+              <p style={{ paddingLeft: "10px" }}>{option.name}</p>
             </DropdownItemStyled>
           );
         })}
@@ -53,25 +65,23 @@ const DropdownContainerStyled = styled.div`
 
 const DropdownSelectionBoxStyled = styled.div<{ isOpen: boolean }>`
   position: relative;
+  display: flex;
+  align-items: center;
   border: 1px solid var(--line-color);
   width: 100%;
   height: 60px;
   border-radius: 10px;
   text-align: start;
-  text-indent: 20px;
+  padding-left: 20px;
   font-size: 18px;
   color: var(--main-color);
-  & p {
-    position: absolute;
-    top: 32%;
-  }
-  & img {
+  & > img {
     filter: contrast(0.6);
     width: 14px;
     height: 8px;
-    position: relative;
+    position: absolute;
     top: 45%;
-    left: 80%;
+    left: 85%;
     ${({ isOpen }) =>
       isOpen === true &&
       css`
@@ -101,20 +111,18 @@ const DropdownItemContainerStyled = styled.div<{ isVisible: boolean }>`
 
 const DropdownItemStyled = styled.div<{ isSelected: boolean }>`
   position: relative;
+  display: flex;
+  align-items: center;
   background-color: ${({ isSelected }) => (isSelected ? "#f1f1f1" : "white")};
   border: 1px solid var(--line-color);
   border-width: 0px 1px 1px 1px;
   width: 100%;
   height: 60px;
   text-align: start;
-  text-indent: 20px;
+  padding-left: 20px;
   font-size: 18px;
   color: ${({ isSelected }) => (isSelected ? "var(--main-color)" : "black")};
   cursor: pointer;
-  & p {
-    position: absolute;
-    top: 30%;
-  }
   &:first-child {
     border-radius: 10px 10px 0px 0px;
     border-width: 1px 1px 1px 1px;

--- a/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.container.tsx
@@ -28,7 +28,7 @@ const StatusModalContainer = (props: {
   const [targetCabinetInfo, setTargetCabinetInfo] = useRecoilState<CabinetInfo>(
     targetCabinetInfoState
   );
-  const { targetCabinetInfoList } = useMultiSelect();
+  const { targetCabinetInfoList, setTargetCabinetInfoList } = useMultiSelect();
   const setNumberOfAdminWork = useSetRecoilState(numberOfAdminWorkState);
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
@@ -55,6 +55,18 @@ const StatusModalContainer = (props: {
           },
         };
   const setBrokenCabinetList = useSetRecoilState(brokenCabinetListState);
+  const buildNewCabinetInfoList = async () => {
+    return await Promise.all(
+      targetCabinetInfoList.map(async (cabinet) => {
+        try {
+          const { data } = await axiosCabinetById(cabinet.cabinet_id);
+          return data;
+        } catch (error) {
+          console.error(error);
+        }
+      })
+    );
+  };
 
   const onSaveEditStatus = (
     newCabinetType: CabinetType,
@@ -116,6 +128,10 @@ const StatusModalContainer = (props: {
           setIsCurrentSectionRender(true);
           setNumberOfAdminWork((prev) => prev + 1);
         })
+        .then(async () => {
+          const ret = await buildNewCabinetInfoList();
+          setTargetCabinetInfoList(ret);
+        })
         .catch((error) => {
           console.log(error.message);
         });
@@ -132,6 +148,10 @@ const StatusModalContainer = (props: {
           } catch (error) {
             throw error;
           }
+        })
+        .then(async () => {
+          const ret = await buildNewCabinetInfoList();
+          setTargetCabinetInfoList(ret);
         })
         .catch((error) => {
           console.log(error.message);

--- a/frontend/src/components/Modals/StatusModal/StatusModal.tsx
+++ b/frontend/src/components/Modals/StatusModal/StatusModal.tsx
@@ -5,7 +5,11 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 import ModalPortal from "../ModalPortal";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import Dropdown from "@/components/Common/Dropdown";
-import { cabinetStatusLabelMap, cabinetTypeLabelMap } from "@/assets/data/maps";
+import {
+  cabinetIconSrcMap,
+  cabinetStatusLabelMap,
+  cabinetTypeLabelMap,
+} from "@/assets/data/maps";
 import WarningNotification, {
   WarningNotificationProps,
 } from "@/components/Common/WarningNotification";
@@ -23,9 +27,21 @@ interface StatusModalContainerInterface {
 }
 
 const TYPE_OPTIONS = [
-  { name: "동아리 사물함", value: CabinetType.CLUB },
-  { name: "개인 사물함", value: CabinetType.PRIVATE },
-  { name: "공유 사물함", value: CabinetType.SHARE },
+  {
+    name: "개인 사물함",
+    value: CabinetType.PRIVATE,
+    imageSrc: cabinetIconSrcMap[CabinetType.PRIVATE],
+  },
+  {
+    name: "공유 사물함",
+    value: CabinetType.SHARE,
+    imageSrc: cabinetIconSrcMap[CabinetType.SHARE],
+  },
+  {
+    name: "동아리 사물함",
+    value: CabinetType.CLUB,
+    imageSrc: cabinetIconSrcMap[CabinetType.CLUB],
+  },
 ];
 
 const STATUS_OPTIONS = [
@@ -59,6 +75,7 @@ const StatusModal = ({
   const TYPE_DROP_DOWN_PROPS = {
     options: TYPE_OPTIONS,
     defaultValue: cabinetTypeLabelMap[newCabinetType],
+    defaultImageSrc: cabinetIconSrcMap[cabinetType],
     onChangeValue: handleDropdownChangeValue,
   };
 
@@ -93,6 +110,9 @@ const StatusModal = ({
               <ContentItemTitleStyled>사물함 타입</ContentItemTitleStyled>
               {mode === "read" ? (
                 <ContentItemContainerStyled mode={mode}>
+                  <div style={{ width: "18px", height: "18px" }}>
+                    <img src={cabinetIconSrcMap[cabinetType]} />
+                  </div>
                   <p>{cabinetTypeLabelMap[newCabinetType]}</p>
                 </ContentItemContainerStyled>
               ) : (
@@ -198,17 +218,18 @@ const ContentItemTitleStyled = styled.h3`
 
 const ContentItemContainerStyled = styled.div<{ mode: string }>`
   position: relative;
+  display: flex;
+  align-items: center;
   border: 1px solid var(--line-color);
   width: 100%;
   height: 60px;
   border-radius: 10px;
   text-align: start;
-  text-indent: 20px;
+  padding-left: 20px;
   font-size: 18px;
   color: var(--main-color);
-  & p {
-    position: absolute;
-    top: 32%;
+  & > p {
+    padding-left: 10px;
   }
 `;
 

--- a/frontend/src/hooks/useMultiSelect.ts
+++ b/frontend/src/hooks/useMultiSelect.ts
@@ -101,6 +101,7 @@ const useMultiSelect = () => {
   return {
     isMultiSelect,
     targetCabinetInfoList,
+    setTargetCabinetInfoList,
     setIsMultiSelect,
     resetIsMultiSelect,
     resetTargetCabinetInfoList,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1006
위 이슈에서 묘사된 버그 현상을 Promise.all을 사용하여 targetCabinetInfoList를 변경해주어 변경사항을 화면에 반영하는 방향으로 고쳤습니다. 
또한 상태관리 모달에서 보이는 드롭다운 메뉴에 이미지 넣기 기능을 추가하였습니다. 상태 관리 모달의 사물함 타입란에 이제 해당 사물함 타입의 아이콘이 보이게 됩니다. 
@42inshin 님과 함께 동료학습으로 작업하였습니다. 
<img width="395" alt="image" src="https://user-images.githubusercontent.com/45449387/225001669-75105c96-c5bc-45a7-a9d4-fb16fb2280c4.png">
Closes #1006 

