### PR TITLE
[FE] FEAT: 사물함/유저 대여 기록 조회 기능 구현 #1003

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -360,3 +360,39 @@ export const axiosGetOverdueUserList = async () => {
     throw error;
   }
 };
+
+const axiosGetCabinetLentLogURL = "/api/admin/log/cabinet/";
+export const axiosGetCabinetLentLog = async (
+  cabinetId: number,
+  page: number
+): Promise<any> => {
+  try {
+    const response = await instance.get(
+      axiosGetCabinetLentLogURL + cabinetId.toString(),
+      {
+        params: { page: page, length: 10 },
+      }
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosGetUserLentLogURL = "/api/admin/log/user/";
+export const axiosGetUserLentLog = async (
+  userId: number,
+  page: number
+): Promise<any> => {
+  try {
+    const response = await instance.get(
+      axiosGetUserLentLogURL + userId.toString(),
+      {
+        params: { page: page, length: 10 },
+      }
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -30,7 +30,13 @@ const AdminCabinetInfoArea: React.FC<{
   myCabinetId?: number;
   closeCabinet: () => void;
   multiSelectTargetInfo: IMultiSelectTargetInfo | null;
-}> = ({ selectedCabinetInfo, closeCabinet, multiSelectTargetInfo }) => {
+  openLent: React.MouseEventHandler;
+}> = ({
+  selectedCabinetInfo,
+  closeCabinet,
+  multiSelectTargetInfo,
+  openLent,
+}) => {
   const { targetCabinetInfoList, typeCounts } = multiSelectTargetInfo ?? {};
   const [showAdminReturnModal, setShowAdminReturnModal] =
     useState<boolean>(false);
@@ -142,6 +148,7 @@ const AdminCabinetInfoArea: React.FC<{
   // 단일 선택 시 보이는 cabinetInfoArea
   return (
     <CabinetDetailAreaStyled>
+      <LinkTextStyled onClick={openLent}>대여기록</LinkTextStyled>
       <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
         {selectedCabinetInfo!.floor + "F - " + selectedCabinetInfo!.section}
       </TextStyled>
@@ -230,6 +237,20 @@ const CabinetTypeIconStyled = styled.div<{ cabinetType: CabinetType }>`
   background-image: url(${(props) => cabinetIconSrcMap[props.cabinetType]});
   background-size: contain;
   background-repeat: no-repeat;
+`;
+
+const LinkTextStyled = styled.div`
+  position: absolute;
+  top: 3%;
+  right: 6%;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 0.875rem;
+  color: var(--lightpurple-color);
+  text-decoration: underline;
+  :hover {
+    cursor: pointer;
+  }
 `;
 
 const TextStyled = styled.p<{ fontSize: string; fontColor: string }>`

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -10,6 +10,7 @@ import useMultiSelect from "@/hooks/useMultiSelect";
 import AdminCabinetInfoArea, {
   IMultiSelectTargetInfo,
 } from "@/components/CabinetInfoArea/AdminCabinetInfoArea";
+import AdminCabinetLentLogContainer from "@/components/LentLog/AdminCabinetLentLog.container";
 
 const calExpiredTime = (expireTime: Date) =>
   Math.floor(
@@ -75,7 +76,7 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
   const targetCabinetInfo = useRecoilValue(targetCabinetInfoState);
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);
-  const { closeCabinet } = useMenu();
+  const { closeCabinet, toggleLent } = useMenu();
   const { isMultiSelect, targetCabinetInfoList } = useMultiSelect();
   const isAdmin = document.location.pathname.indexOf("/admin") > -1;
 
@@ -123,11 +124,15 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
     : null;
 
   return isAdmin ? (
-    <AdminCabinetInfoArea
-      selectedCabinetInfo={cabinetViewData}
-      closeCabinet={closeCabinet}
-      multiSelectTargetInfo={multiSelectInfo}
-    />
+    <>
+      <AdminCabinetInfoArea
+        selectedCabinetInfo={cabinetViewData}
+        closeCabinet={closeCabinet}
+        multiSelectTargetInfo={multiSelectInfo}
+        openLent={toggleLent}
+      />
+      {cabinetViewData && <AdminCabinetLentLogContainer />}
+    </>
   ) : (
     <CabinetInfoArea
       selectedCabinetInfo={cabinetViewData}

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.container.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.container.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import useMenu from "@/hooks/useMenu";
+import AdminCabinetLentLog from "@/components/LentLog/AdminCabinetLentLog";
+import { LentLogDto } from "@/types/dto/lent.dto";
+import { useRecoilValue } from "recoil";
+import { currentCabinetIdState } from "@/recoil/atoms";
+import { axiosGetCabinetLentLog } from "@/api/axios/axios.custom";
+
+const BAD_REQUEST = 400;
+
+const AdminCabinetLentLogContainer = () => {
+  const { closeLent } = useMenu();
+  const [logs, setLogs] = useState<
+    LentLogDto[] | typeof BAD_REQUEST | undefined
+  >(undefined);
+  const [page, setPage] = useState<number>(-1);
+  const [totalPage, setTotalPage] = useState<number>(-1);
+  const [isNeedUpdate, setIsNeedUpdate] = useState<boolean>(false);
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  async function getData(page: number) {
+    try {
+      const result = await axiosGetCabinetLentLog(currentCabinetId, page);
+      setTotalPage(Math.ceil(result.data.total_length / 10));
+      setLogs(result.data.result);
+    } catch {
+      setLogs(BAD_REQUEST);
+      setTotalPage(1);
+    }
+  }
+  useEffect(() => {
+    setPage(0);
+    getData(0);
+  }, [currentCabinetId]);
+
+  useEffect(() => {
+    if (isNeedUpdate || page > 0) {
+      setIsNeedUpdate(false);
+      getData(page);
+    }
+  }, [page]);
+
+  const onClickPrev = () => {
+    if (page == 0) return;
+    setIsNeedUpdate(true);
+    setPage((prev) => prev - 1);
+  };
+
+  const onClickNext = () => {
+    if (page == totalPage - 1) return;
+    setPage((prev) => prev + 1);
+  };
+
+  const closeAndResetLogPage = () => {
+    closeLent();
+    setIsNeedUpdate(true);
+    setPage(0);
+  };
+
+  return currentCabinetId ? (
+    <AdminCabinetLentLog
+      closeAndResetLogPage={closeAndResetLogPage}
+      logs={logs}
+      page={page}
+      totalPage={totalPage}
+      onClickPrev={onClickPrev}
+      onClickNext={onClickNext}
+    />
+  ) : (
+    <></>
+  );
+};
+
+export default AdminCabinetLentLogContainer;

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.container.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.container.tsx
@@ -15,7 +15,7 @@ const AdminCabinetLentLogContainer = () => {
   >(undefined);
   const [page, setPage] = useState<number>(-1);
   const [totalPage, setTotalPage] = useState<number>(-1);
-  const [isNeedUpdate, setIsNeedUpdate] = useState<boolean>(false);
+  const [needsUpdate, setNeedsUpdate] = useState<boolean>(false);
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
   async function getData(page: number) {
     try {
@@ -33,15 +33,15 @@ const AdminCabinetLentLogContainer = () => {
   }, [currentCabinetId]);
 
   useEffect(() => {
-    if (isNeedUpdate || page > 0) {
-      setIsNeedUpdate(false);
+    if (needsUpdate || page > 0) {
+      setNeedsUpdate(false);
       getData(page);
     }
   }, [page]);
 
   const onClickPrev = () => {
     if (page == 0) return;
-    setIsNeedUpdate(true);
+    setNeedsUpdate(true);
     setPage((prev) => prev - 1);
   };
 
@@ -52,11 +52,13 @@ const AdminCabinetLentLogContainer = () => {
 
   const closeAndResetLogPage = () => {
     closeLent();
-    setIsNeedUpdate(true);
+    setNeedsUpdate(true);
     setPage(0);
   };
 
-  return currentCabinetId ? (
+  if (!currentCabinetId) return null;
+
+  return (
     <AdminCabinetLentLog
       closeAndResetLogPage={closeAndResetLogPage}
       logs={logs}
@@ -65,8 +67,6 @@ const AdminCabinetLentLogContainer = () => {
       onClickPrev={onClickPrev}
       onClickNext={onClickNext}
     />
-  ) : (
-    <></>
   );
 };
 

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
@@ -1,0 +1,132 @@
+import styled, { css } from "styled-components";
+import AdminCabinetLogTable from "@/components/LentLog/LogTable/AdminCabinetLogTable";
+import { LentLogDto } from "@/types/dto/lent.dto";
+
+const BAD_REQUEST = 400;
+
+interface ILentLog {
+  closeAndResetLogPage: React.MouseEventHandler;
+  logs: LentLogDto[] | typeof BAD_REQUEST | undefined;
+  page: number;
+  totalPage: number;
+  onClickPrev: React.MouseEventHandler;
+  onClickNext: React.MouseEventHandler;
+}
+
+const AdminCabinetLentLog = ({
+  closeAndResetLogPage,
+  logs,
+  page,
+  totalPage,
+  onClickPrev,
+  onClickNext,
+}: ILentLog) => {
+  return (
+    <AdminLentLogStyled id="lentInfo">
+      <TitleContainer>
+        <TitleStyled>대여 기록</TitleStyled>
+        <GoBackButtonStyled onClick={closeAndResetLogPage}>
+          뒤로가기
+        </GoBackButtonStyled>
+      </TitleContainer>
+      <AdminCabinetLogTable lentLog={logs} />
+      <ButtonContainerStyled>
+        <PageButtonStyled
+          page={page}
+          totalPage={totalPage}
+          type="prev"
+          onClick={onClickPrev}
+        >
+          이전
+        </PageButtonStyled>
+        <PageButtonStyled
+          page={page}
+          totalPage={totalPage}
+          type="next"
+          onClick={onClickNext}
+        >
+          다음
+        </PageButtonStyled>
+      </ButtonContainerStyled>
+    </AdminLentLogStyled>
+  );
+};
+
+const PageButtonStyled = styled.div<{
+  page: number;
+  totalPage: number;
+  type: string;
+}>`
+  cursor: pointer;
+  color: var(--main-color);
+  position: absolute;
+  display: ${({ page, totalPage, type }) => {
+    if (type == "prev" && page == 0) return "none";
+    if (type == "next" && page == totalPage - 1) return "none";
+    return "block";
+  }};
+  ${({ type }) =>
+    type === "prev"
+      ? css`
+          left: 0;
+        `
+      : css`
+          right: 0;
+        `}
+`;
+
+const GoBackButtonStyled = styled.div`
+  position: absolute;
+  top: 3%;
+  right: 6%;
+  color: var(--lightpurple-color);
+  font-size: 0.875rem;
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
+const ButtonContainerStyled = styled.div`
+  position: relative;
+  width: 80%;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+  margin-top: 25px;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 30px;
+`;
+
+const TitleStyled = styled.h1`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+const AdminLentLogStyled = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 330px;
+  height: 100%;
+  padding: 40px 20px;
+  z-index: 9;
+  transform: translateX(120%);
+  transition: transform 0.3s ease-in-out;
+  box-shadow: 0 0 40px 0 var(--bg-shadow);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--white);
+  &.on {
+    transform: translateX(0);
+  }
+`;
+
+export default AdminCabinetLentLog;

--- a/frontend/src/components/LentLog/AdminUserLentLog.container.tsx
+++ b/frontend/src/components/LentLog/AdminUserLentLog.container.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import useMenu from "@/hooks/useMenu";
+import AdminUserLentLog from "@/components/LentLog/AdminUserLentLog";
+import { LentLogDto } from "@/types/dto/lent.dto";
+import { useRecoilValue } from "recoil";
+import { targetUserInfoState } from "@/recoil/atoms";
+import { axiosGetUserLentLog } from "@/api/axios/axios.custom";
+
+const BAD_REQUEST = 400;
+
+const AdminUserLentLogContainer = () => {
+  const { closeLent } = useMenu();
+  const [logs, setLogs] = useState<
+    LentLogDto[] | typeof BAD_REQUEST | undefined
+  >(undefined);
+  const [page, setPage] = useState<number>(-1);
+  const [totalPage, setTotalPage] = useState<number>(-1);
+  const [isNeedUpdate, setIsNeedUpdate] = useState<boolean>(false);
+  const targetUserInfo = useRecoilValue(targetUserInfoState);
+  async function getData(page: number) {
+    try {
+      const result = await axiosGetUserLentLog(targetUserInfo.userId, page);
+      setTotalPage(Math.ceil(result.data.total_length / 10));
+      setLogs(result.data.result);
+    } catch {
+      setLogs(BAD_REQUEST);
+      setTotalPage(1);
+    }
+  }
+
+  useEffect(() => {
+    setPage(0);
+    getData(0);
+  }, [targetUserInfo]);
+
+  useEffect(() => {
+    if (isNeedUpdate || page > 0) {
+      setIsNeedUpdate(false);
+      getData(page);
+    }
+  }, [page]);
+
+  const onClickPrev = () => {
+    if (page == 0) return;
+    setIsNeedUpdate(true);
+    setPage((prev) => prev - 1);
+  };
+
+  const onClickNext = () => {
+    if (page == totalPage - 1) return;
+    setPage((prev) => prev + 1);
+  };
+
+  const closeAndResetLogPage = () => {
+    closeLent();
+    setIsNeedUpdate(true);
+    setPage(0);
+  };
+
+  return targetUserInfo ? (
+    <AdminUserLentLog
+      closeAndResetLogPage={closeAndResetLogPage}
+      logs={logs}
+      page={page}
+      totalPage={totalPage}
+      onClickPrev={onClickPrev}
+      onClickNext={onClickNext}
+    />
+  ) : (
+    <></>
+  );
+};
+
+export default AdminUserLentLogContainer;

--- a/frontend/src/components/LentLog/AdminUserLentLog.container.tsx
+++ b/frontend/src/components/LentLog/AdminUserLentLog.container.tsx
@@ -15,7 +15,7 @@ const AdminUserLentLogContainer = () => {
   >(undefined);
   const [page, setPage] = useState<number>(-1);
   const [totalPage, setTotalPage] = useState<number>(-1);
-  const [isNeedUpdate, setIsNeedUpdate] = useState<boolean>(false);
+  const [needsUpdate, setNeedsUpdate] = useState<boolean>(false);
   const targetUserInfo = useRecoilValue(targetUserInfoState);
   async function getData(page: number) {
     try {
@@ -34,15 +34,15 @@ const AdminUserLentLogContainer = () => {
   }, [targetUserInfo]);
 
   useEffect(() => {
-    if (isNeedUpdate || page > 0) {
-      setIsNeedUpdate(false);
+    if (needsUpdate || page > 0) {
+      setNeedsUpdate(false);
       getData(page);
     }
   }, [page]);
 
   const onClickPrev = () => {
     if (page == 0) return;
-    setIsNeedUpdate(true);
+    setNeedsUpdate(true);
     setPage((prev) => prev - 1);
   };
 
@@ -53,11 +53,13 @@ const AdminUserLentLogContainer = () => {
 
   const closeAndResetLogPage = () => {
     closeLent();
-    setIsNeedUpdate(true);
+    setNeedsUpdate(true);
     setPage(0);
   };
 
-  return targetUserInfo ? (
+  if (!targetUserInfo) return null;
+
+  return (
     <AdminUserLentLog
       closeAndResetLogPage={closeAndResetLogPage}
       logs={logs}
@@ -66,8 +68,6 @@ const AdminUserLentLogContainer = () => {
       onClickPrev={onClickPrev}
       onClickNext={onClickNext}
     />
-  ) : (
-    <></>
   );
 };
 

--- a/frontend/src/components/LentLog/AdminUserLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminUserLentLog.tsx
@@ -1,0 +1,132 @@
+import styled, { css } from "styled-components";
+import LogTable from "@/components/LentLog/LogTable/LogTable";
+import { LentLogDto } from "@/types/dto/lent.dto";
+
+const BAD_REQUEST = 400;
+
+interface ILentLog {
+  closeAndResetLogPage: React.MouseEventHandler;
+  logs: LentLogDto[] | typeof BAD_REQUEST | undefined;
+  page: number;
+  totalPage: number;
+  onClickPrev: React.MouseEventHandler;
+  onClickNext: React.MouseEventHandler;
+}
+
+const AdminUserLentLog = ({
+  closeAndResetLogPage,
+  logs,
+  page,
+  totalPage,
+  onClickPrev,
+  onClickNext,
+}: ILentLog) => {
+  return (
+    <AdminLentLogStyled id="lentInfo">
+      <TitleContainer>
+        <TitleStyled>대여 기록</TitleStyled>
+        <GoBackButtonStyled onClick={closeAndResetLogPage}>
+          뒤로가기
+        </GoBackButtonStyled>
+      </TitleContainer>
+      <LogTable lentLog={logs} />
+      <ButtonContainerStyled>
+        <PageButtonStyled
+          page={page}
+          totalPage={totalPage}
+          type="prev"
+          onClick={onClickPrev}
+        >
+          이전
+        </PageButtonStyled>
+        <PageButtonStyled
+          page={page}
+          totalPage={totalPage}
+          type="next"
+          onClick={onClickNext}
+        >
+          다음
+        </PageButtonStyled>
+      </ButtonContainerStyled>
+    </AdminLentLogStyled>
+  );
+};
+const PageButtonStyled = styled.div<{
+  page: number;
+  totalPage: number;
+  type: string;
+}>`
+  cursor: pointer;
+  color: var(--main-color);
+  position: absolute;
+  display: ${({ page, totalPage, type }) => {
+    if (type == "prev" && page == 0) return "none";
+    if (type == "next" && (totalPage == -1 || page == totalPage - 1))
+      return "none";
+    return "block";
+  }};
+  ${({ type }) =>
+    type === "prev"
+      ? css`
+          left: 0;
+        `
+      : css`
+          right: 0;
+        `}
+`;
+
+const GoBackButtonStyled = styled.div`
+  position: absolute;
+  top: 3%;
+  color: var(--lightpurple-color);
+  right: 6%;
+  font-size: 0.875rem;
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
+const ButtonContainerStyled = styled.div`
+  position: relative;
+  width: 80%;
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+  margin-top: 25px;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 30px;
+`;
+
+const TitleStyled = styled.h1`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+const AdminLentLogStyled = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 330px;
+  height: 100%;
+  padding: 40px 20px;
+  z-index: 9;
+  transform: translateX(120%);
+  transition: transform 0.3s ease-in-out;
+  box-shadow: 0 0 40px 0 var(--bg-shadow);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--white);
+  &.on {
+    transform: translateX(0);
+  }
+`;
+
+export default AdminUserLentLog;

--- a/frontend/src/components/LentLog/LentLog.container.tsx
+++ b/frontend/src/components/LentLog/LentLog.container.tsx
@@ -24,18 +24,21 @@ const LentLogContainer = () => {
   }
   useEffect(() => {
     setPage(1);
-    getData(1);
   }, []);
+
+  useEffect(() => {
+    if (page >= 0) {
+      getData(page);
+    }
+  }, [page]);
 
   const onClickPrev = () => {
     if (page == 1) return;
-    setPage(page - 1);
-    getData(page - 1);
+    setPage((prev) => prev - 1);
   };
   const onClickNext = () => {
     if (page == totalPage) return;
-    setPage(page + 1);
-    getData(page + 1);
+    setPage((prev) => prev + 1);
   };
 
   return (

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -14,7 +14,7 @@ interface IlentLog {
   lentLog: LentLogDto[] | typeof BAD_REQUEST | undefined;
 }
 
-const LogTable = ({ lentLog }: IlentLog) => {
+const AdminCabinetLogTable = ({ lentLog }: IlentLog) => {
   if (lentLog === undefined) return <LoadingAnimation />;
 
   return (
@@ -22,7 +22,7 @@ const LogTable = ({ lentLog }: IlentLog) => {
       <LogTableStyled>
         <TheadStyled>
           <tr>
-            <th>위치</th>
+            <th>인트라 ID</th>
             <th>대여일</th>
             <th>반납일</th>
           </tr>
@@ -30,14 +30,9 @@ const LogTable = ({ lentLog }: IlentLog) => {
         {lentLog !== BAD_REQUEST && (
           <TbodyStyled>
             {lentLog.map(
-              (
-                { floor, section, cabinet_num, lent_time, return_time },
-                idx
-              ) => (
+              ({ floor, section, intra_id, lent_time, return_time }, idx) => (
                 <tr key={idx}>
-                  <td
-                    title={`${floor}층 ${section}`}
-                  >{`${floor}F - ${cabinet_num}번`}</td>
+                  <td title={`${floor}층 ${section}`}>{intra_id}</td>
                   <td title={new Date(lent_time).toLocaleString("ko-KR")}>
                     {new Date(lent_time).toLocaleString("ko-KR", dateOptions)}
                   </td>
@@ -102,4 +97,4 @@ const EmptyLogStyled = styled.div`
   padding: 20px 0;
 `;
 
-export default LogTable;
+export default AdminCabinetLogTable;

--- a/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
+++ b/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
@@ -7,11 +7,12 @@ import UserInfoArea, {
 } from "@/components/UserInfoArea/UserInfoArea";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import useMenu from "@/hooks/useMenu";
+import AdminUserLentLogContainer from "../LentLog/AdminUserLentLog.container";
 
 const UserInfoAreaContainer = (): JSX.Element => {
   const targetUserInfo = useRecoilValue(targetUserInfoState);
   const setCurrentCabinetId = useSetRecoilState(currentCabinetIdState);
-  const { closeCabinet } = useMenu();
+  const { closeCabinet, openLent } = useMenu();
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
     if (
@@ -113,11 +114,15 @@ const UserInfoAreaContainer = (): JSX.Element => {
   // *
 
   return (
-    <UserInfoArea
-      selectedUserInfo={userInfoData}
-      userLentInfo={userViewData}
-      closeCabinet={closeCabinet}
-    />
+    <>
+      <UserInfoArea
+        selectedUserInfo={userInfoData}
+        userLentInfo={userViewData}
+        closeCabinet={closeCabinet}
+        openLent={openLent}
+      />
+      {userInfoData && <AdminUserLentLogContainer />}
+    </>
   );
 };
 

--- a/frontend/src/components/UserInfoArea/UserInfoArea.tsx
+++ b/frontend/src/components/UserInfoArea/UserInfoArea.tsx
@@ -38,8 +38,9 @@ const UserInfoArea: React.FC<{
   selectedUserInfo?: ISelectedUserInfo;
   userLentInfo?: IUserLentInfo;
   closeCabinet: () => void;
+  openLent: React.MouseEventHandler;
 }> = (props) => {
-  const { selectedUserInfo, userLentInfo, closeCabinet } = props;
+  const { selectedUserInfo, userLentInfo, closeCabinet, openLent } = props;
   const [showBanModal, setShowBanModal] = useState<boolean>(false);
   const [showAdminReturnModal, setShowAdminReturnModal] =
     useState<boolean>(false);
@@ -73,6 +74,7 @@ const UserInfoArea: React.FC<{
   if (userLentInfo === undefined)
     return (
       <CabinetDetailAreaStyled>
+        <LinkTextStyled onClick={openLent}>대여기록</LinkTextStyled>
         <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
           대여 중이 아닌 사용자
         </TextStyled>
@@ -118,6 +120,7 @@ const UserInfoArea: React.FC<{
     );
   return (
     <CabinetDetailAreaStyled>
+      <LinkTextStyled onClick={openLent}>대여기록</LinkTextStyled>
       <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
         {userLentInfo.floor + "F - " + userLentInfo.section}
       </TextStyled>
@@ -190,6 +193,20 @@ const CabinetTypeIconStyled = styled.div<{ cabinetType: CabinetType }>`
   background-image: url(${(props) => cabinetIconSrcMap[props.cabinetType]});
   background-size: contain;
   background-repeat: no-repeat;
+`;
+
+const LinkTextStyled = styled.div`
+  position: absolute;
+  top: 3%;
+  right: 6%;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 0.875rem;
+  color: var(--lightpurple-color);
+  text-decoration: underline;
+  :hover {
+    cursor: pointer;
+  }
 `;
 
 const TextStyled = styled.p<{ fontSize: string; fontColor: string }>`

--- a/frontend/src/hooks/useMenu.ts
+++ b/frontend/src/hooks/useMenu.ts
@@ -57,7 +57,6 @@ const useMenu = () => {
 
   const openLent = () => {
     closeLeftNav();
-    // closeCabinet();
     closeMap();
     document.getElementById("lentInfo")?.classList.add("on");
     document.getElementById("menuBg")?.classList.add("on");

--- a/frontend/src/hooks/useMenu.ts
+++ b/frontend/src/hooks/useMenu.ts
@@ -57,7 +57,7 @@ const useMenu = () => {
 
   const openLent = () => {
     closeLeftNav();
-    closeCabinet();
+    // closeCabinet();
     closeMap();
     document.getElementById("lentInfo")?.classList.add("on");
     document.getElementById("menuBg")?.classList.add("on");
@@ -66,7 +66,6 @@ const useMenu = () => {
   const closeLent = () => {
     if (document.getElementById("lentInfo")?.classList.contains("on") == true) {
       document.getElementById("lentInfo")?.classList.remove("on");
-      document.getElementById("menuBg")?.classList.remove("on");
     }
   };
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1003

## 변경 사항
### 사물함/유저 대여 기록 조회 기능 추가
- yooh 님이 메인 서비스에서 만들어주셨던 개인 대여 로그 컴포넌트를 재활용했습니다.
- 단순히 포맷팅 변경임에도 컴포넌트를 복사하여 구현하여 겹치는 코드가 굉장히 많습니다.
- 선 기능 구현 정신(== 최적화 해야할 것 투성이)
