### PR TITLE
[FE] BUG: 공유 사물함 대여 시작 되기 전에는 날짜가 나오지 않도록 수정 #1024

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "42cabi_v4",
+  "name": "cabi_backend",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "42cabi_v4",
+      "name": "cabi_backend",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {

--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -35,7 +35,9 @@ const LentModal: React.FC<{
   const [myInfo, setMyInfo] = useRecoilState(userState);
   const setMyLentInfo =
     useSetRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
-  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
+  const [targetCabinetInfo, setTargetCabinetInfo] = useRecoilState(
+    targetCabinetInfoState
+  );
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
   );
@@ -43,7 +45,11 @@ const LentModal: React.FC<{
   const formattedExpireDate = getExpireDateString(props.lentType);
   const privateLentDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
     귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
-  const shareLentDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
+  const shareLentDetail = `${
+    targetCabinetInfo.lent_info.length === 2
+      ? `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
+      : ""
+  }
 대여 후 ${
     import.meta.env.VITE_SHARE_EARLY_RETURN_PERIOD
   }시간 이내 취소(반납) 시,

--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -46,7 +46,8 @@ const LentModal: React.FC<{
   const privateLentDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
     귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
   const shareLentDetail = `${
-    targetCabinetInfo.lent_info.length === 2
+    targetCabinetInfo.lent_info.length > 0 &&
+    targetCabinetInfo.lent_info[0].expire_time !== null
       ? `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
       : ""
   }

--- a/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/recoil/atoms";
 import {
   axiosCabinetById,
-  axiosGetOverdueUserList,
   axiosMyLentInfo,
   axiosReturn,
 } from "@/api/axios/axios.custom";
@@ -24,7 +23,6 @@ import { getExpireDateString } from "@/utils";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
-import { handleOverdueUserList } from "@/components/AdminInfo/convertFunctions";
 
 const ReturnModal: React.FC<{
   lentType: string;
@@ -34,7 +32,6 @@ const ReturnModal: React.FC<{
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
   const [modalTitle, setModalTitle] = useState<string>("");
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
-  const setOverdueUserList = useSetRecoilState(overdueCabinetListState);
   const [myInfo, setMyInfo] = useRecoilState(userState);
   const [myLentInfo, setMyLentInfo] =
     useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
@@ -47,7 +44,11 @@ const ReturnModal: React.FC<{
     "myCabinet",
     myLentInfo.lent_info ? myLentInfo.lent_info[0].expire_time : undefined
   );
-  const returnDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
+  const returnDetail = `${
+    formattedExpireDate.split("/")[0] === "9999"
+      ? ""
+      : `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
+  }
 지금 반납 하시겠습니까?`;
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
@@ -70,7 +71,6 @@ const ReturnModal: React.FC<{
       } catch (error) {
         throw error;
       }
-  
     } catch (error: any) {
       setHasErrorOnResponse(true);
       setModalTitle(error.response.data.message);

--- a/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
@@ -39,13 +39,12 @@ const ReturnModal: React.FC<{
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
   );
-
   const formattedExpireDate = getExpireDateString(
     "myCabinet",
     myLentInfo.lent_info ? myLentInfo.lent_info[0].expire_time : undefined
   );
   const returnDetail = `${
-    formattedExpireDate.split("/")[0] === "9999"
+    myLentInfo && myLentInfo.lent_info[0].expire_time === null
       ? ""
       : `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1024


현재 인원이 1명 이하일 때에는 대여날짜 문구 표시 되지 않도록 수정
<img width="385" alt="Screen Shot 2023-03-26 at 3 51 04 PM" src="https://user-images.githubusercontent.com/55866366/227760219-31b285c9-858f-4edd-99ab-953ea189f2c0.png">


대여가 시작되지 않은 공유 사물함의 경우 반납할 때 9999/12/31 이라는 날짜가 나오던 부분 나오지 않도록 수정

<img width="391" alt="Screen Shot 2023-03-26 at 3 51 24 PM" src="https://user-images.githubusercontent.com/55866366/227760237-c1efc7de-1a45-4d8c-be71-2609cab5cb1c.png">
