### PR TITLE
[FE] FIX: 장기 대여 사물함 롤백, 오타 수정 #1026

### DIFF
--- a/frontend/src/assets/css/homePage.css
+++ b/frontend/src/assets/css/homePage.css
@@ -1,11 +1,10 @@
-@media screen and (max-width: 1040px) {
+@media screen and (max-width: 1300px) {
   #infoWrap > .titleContainer {
     width: 90%;
     max-width: 600px;
   }
 
   #infoWrap .section {
-    display: flex;
     flex-direction: column;
     align-items: center;
   }

--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -10,7 +10,6 @@ export enum additionalModalType {
 
 export const cabinetIconSrcMap = {
   [CabinetType.PRIVATE]: "/src/assets/images/privateIcon.svg",
-  [CabinetType.LONGTERM]: "/src/assets/images/longTermIcon.svg",
   [CabinetType.SHARE]: "/src/assets/images/shareIcon.svg",
   [CabinetType.CLUB]: "/src/assets/images/clubIcon.svg",
 };
@@ -109,6 +108,5 @@ export const cabinetStatusLabelMap = {
 export const cabinetTypeLabelMap = {
   [CabinetType.CLUB]: "동아리 사물함",
   [CabinetType.PRIVATE]: "개인 사물함",
-  [CabinetType.LONGTERM]: "장기 대여 사물함",
   [CabinetType.SHARE]: "공유 사물함",
 };

--- a/frontend/src/assets/images/longTermIcon.svg
+++ b/frontend/src/assets/images/longTermIcon.svg
@@ -1,6 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3.41 22C3.41 18.13 7.26 15 12 15C12.96 15 13.89 15.13 14.76 15.37" stroke="#292D32" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M23.0031 17.9209H15" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M19.0016 14V22.03" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -45,7 +45,6 @@ const getDetailMessage = (selectedCabinetInfo: CabinetInfo): string | null => {
     return "사용 불가";
   // 동아리 사물함
   else if (lent_type === "CLUB") return "동아리 사물함";
-  else if (lent_type === "LONG_TERM") return "장기 대여 사물함";
   // 사용 중 사물함
   else if (
     status === CabinetStatus.SET_EXPIRE_FULL ||

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -77,7 +77,7 @@ const CabinetInfoArea: React.FC<{
       <NotSelectedStyled>
         <CabiLogoStyled src={cabiLogo} />
         <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
-          사물함/유저를 <br />
+          사물함를 <br />
           선택해주세요
         </TextStyled>
       </NotSelectedStyled>

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -101,7 +101,6 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
     if (props.lent_type === CabinetType.PRIVATE) lentType = "개인";
     else if (props.lent_type === CabinetType.SHARE) lentType = "공유";
     else if (props.lent_type === CabinetType.CLUB) lentType = "동아리";
-    else if (props.lent_type === CabinetType.LONGTERM) lentType = "장기 대여";
 
     if (!cabinetLabelText) return `[${lentType}]`;
     return `[${lentType}] ${cabinetLabelText}`;

--- a/frontend/src/components/Home/ServiceManual.tsx
+++ b/frontend/src/components/Home/ServiceManual.tsx
@@ -87,29 +87,6 @@ const ServiceManual = ({
             비밀번호는 동아리 내에서 공유하여 이용하세요.
           </p>
         </article>
-        <article className="article">
-          <div>
-            <img src="/src/assets/images/longTermIcon.svg" alt="" />
-          </div>
-          <h3>장기 대여 사물함</h3>
-          <p>
-            모집 기간에만 대여할 수 있습니다.
-            <br />
-            새로운 기수가 들어올 때 갱신됩니다.
-            <br />
-            사물함 대여는{" "}
-            <AtagStyled
-              href="https://42born2code.slack.com/archives/C02V6GE8LD7"
-              target="_blank"
-              title="슬랙 캐비닛 채널 새창으로 열기"
-            >
-              슬랙 캐비닛 채널
-            </AtagStyled>
-            로 문의주세요.
-            <br />
-            장기 대여 사물함은 <strong>반납</strong>할 수 없습니다.
-          </p>
-        </article>
       </InfoSectionStyled>
       <button onClick={lentStartHandler}>시작하기</button>
     </WrapperStyled>
@@ -152,8 +129,8 @@ const TitleContainerStyled = styled.div`
 `;
 
 const InfoSectionStyled = styled.section`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 50%);
+  display: flex;
+  justify-content: space-between;
   margin-top: 40px;
   width: 90%;
   max-width: 1500px;

--- a/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
+++ b/frontend/src/components/UserInfoArea/UserInfoArea.container.tsx
@@ -45,8 +45,6 @@ const UserInfoAreaContainer = (): JSX.Element => {
       return "사용 불가";
     // 동아리 사물함
     else if (selectedCabinetInfo.lent_type === "CLUB") return "동아리 사물함";
-    else if (selectedCabinetInfo.lent_type === "LONG_TERM")
-      return "장기 대여 사물함";
     // 사용 중 사물함
     else if (
       selectedCabinetInfo.status === CabinetStatus.SET_EXPIRE_FULL ||

--- a/frontend/src/types/enum/cabinet.type.enum.ts
+++ b/frontend/src/types/enum/cabinet.type.enum.ts
@@ -1,6 +1,5 @@
 enum CabinetType {
   PRIVATE = "PRIVATE",
-  LONGTERM = "LONG_TERM",
   SHARE = "SHARE",
   CLUB = "CLUB",
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1026

### 변경점
1. 메인 서비스 사물함 상세 구역 오타 수정: 사물함/유저 -> 사물함
2. 장기 대여 사물함 롤백
