### PR TITLE
[FE] FIX: 프론트엔드 dev to main을 위한 작업 #1048

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,6 @@ const NotFoundPage = lazy(() => import("@/pages/NotFoundPage"));
 const LoginFailurePage = lazy(() => import("@/pages/LoginFailurePage"));
 const AdminLayout = lazy(() => import("@/pages/admin/AdminLayout"));
 const AdminLoginPage = lazy(() => import("@/pages/admin/AdminLoginPage"));
-const AdminLogPage = lazy(() => import("@/pages/admin/AdminLogPage"));
 const SearchPage = lazy(() => import("@/pages/admin/SearchPage"));
 const AdminLoginFailurePage = lazy(
   () => import("@/pages/admin/AdminLoginFailurePage")
@@ -35,7 +34,6 @@ function App(): React.ReactElement {
             <Route path="home" element={<AdminInfo />} />
             <Route path="main" element={<AdminMainPage />} />
             <Route path="search" element={<SearchPage />} />
-            <Route path="log" element={<AdminLogPage />} />
           </Route>
           <Route path="/login/failure" element={<LoginFailurePage />} />
           <Route

--- a/frontend/src/assets/data/mapPositionData.ts
+++ b/frontend/src/assets/data/mapPositionData.ts
@@ -97,7 +97,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 7,
       rowEnd: 8,
       name: "Cluster X - 7",
-      type: "cabinet",
+      type: "closed",
     },
     {
       colStart: 4,
@@ -105,7 +105,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 6,
       rowEnd: 7,
       name: "Cluster X - 6",
-      type: "cabinet",
+      type: "closed",
     },
     {
       colStart: 4,
@@ -113,7 +113,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 5,
       rowEnd: 6,
       name: "Cluster X - 5",
-      type: "cabinet",
+      type: "closed",
     },
     {
       colStart: 4,
@@ -121,7 +121,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 4,
       rowEnd: 5,
       name: "Cluster X - 4",
-      type: "cabinet",
+      type: "closed",
     },
     {
       colStart: 4,

--- a/frontend/src/components/CabinetList/CabinetList.container.tsx
+++ b/frontend/src/components/CabinetList/CabinetList.container.tsx
@@ -47,7 +47,12 @@ const CabinetListContainer = ({
         cabinetInfo={currentSectionCabinets}
         isAdmin={isAdmin}
       />
-      {currentSectionName == "E/V" && <EmptySection />}
+      {currentSectionName === "E/V" && (
+        <EmptySection message={"여기엔 사물함이 없어요!"} />
+      )}
+      {currentSectionName !== "E/V" && currentSectionCabinets.length === 0 && (
+        <EmptySection message={"사물함 오픈 준비중!"} />
+      )}
     </React.Fragment>
   );
 };

--- a/frontend/src/components/CabinetList/EmptySection/EmptySection.tsx
+++ b/frontend/src/components/CabinetList/EmptySection/EmptySection.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
-const EmptySection = (): JSX.Element => {
+const EmptySection = ({ message }: { message: string }): JSX.Element => {
   return (
     <EmptySectionStyled>
       <CabiImageStyled
         src="/src/assets/images/happyCcabi.png"
         alt="happy cabi"
       />
-      <ContentStyled>여기엔 사물함이 없어요!</ContentStyled>
+      <ContentStyled>{message}</ContentStyled>
     </EmptySectionStyled>
   );
 };

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -69,16 +69,18 @@ const LeftMainNav = ({
               Search
             </BottomBtnStyled>
           )}
-          <BottomBtnStyled
-            className={
-              pathname.includes("log") ? "active cabiButton" : " cabiButton"
-            }
-            src={"/src/assets/images/log.svg"}
-            onClick={onClickLentLogButton}
-          >
-            <div></div>
-            Log
-          </BottomBtnStyled>
+          {!isAdmin && (
+            <BottomBtnStyled
+              className={
+                pathname.includes("log") ? "active cabiButton" : " cabiButton"
+              }
+              src={"/src/assets/images/log.svg"}
+              onClick={onClickLentLogButton}
+            >
+              <div></div>
+              Log
+            </BottomBtnStyled>
+          )}
           <BottomBtnStyled
             src={"/src/assets/images/slack.svg"}
             className="cabiButton"

--- a/frontend/src/pages/admin/AdminLogPage.tsx
+++ b/frontend/src/pages/admin/AdminLogPage.tsx
@@ -1,3 +1,0 @@
-const AdminLogPage = () => <h1>log page</h1>;
-
-export default AdminLogPage;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> https://github.com/innovationacademy-kr/42cabi/issues/1048

### 작업 내용
- 3층 맵에서 DB에 올라가져있지 않은 사물함 섹션들 회색버튼으로 나오도록 처리
    - 누른 경우, "사물함 오픈 준비 중!" 이라는 문구 나오도록 처리
    
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/72684256/233760864-dbd8d623-ef80-4901-a4c2-42894ea74f65.png">

- admin log 페이지 삭제 및 admin에서 log 페이지로 가는 버튼 안나오도록 처리

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/72684256/233760888-8bc80cbf-f616-4c69-8afb-5b7efe3e180d.png">
