### PR TITLE
[BE] HOTFIX : SET_EXPIRE_AVAILABLE 공유사물함이  1명에서 2명으로 넘어가는 경우에 시간 설정하는 로직이 없던 것 수정/#1050

### DIFF
--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -98,6 +98,7 @@ export class LentTools {
           if (cabinet.status === CabinetStatusType.SET_EXPIRE_AVAILABLE) {
             // 만료시간이 PENALTY_DAY_SHARE + 2 이하로 남은 경우 excepction_type을 LENT_UNDER_PENALTY_DAY_SHARE로 설정.
             const now = new Date();
+			console.debug(cabinet.expire_time);
             const expire_time = cabinet.expire_time;
             const diff = await this.dateCalculator.calDateDiff(
               now,
@@ -114,33 +115,41 @@ export class LentTools {
           }
         }
         // 대여 처리
-        const new_lent = await this.lentRepository.lentCabinet(
-          user,
-          cabinet_id,
-          cabinet.new_lent_id,
-        );
-        if (cabinet.lent_count + 1 === cabinet.max_user) {
-          if (cabinet.status === CabinetStatusType.AVAILABLE) {
-            // 해당 대여로 처음으로 풀방이 되면 만료시간 설정
-            await this.setExpireTimeAll(
-              cabinet_id,
-              new_lent.lent_time,
-              cabinet.lent_type,
-            );
-          } else {
-            // 기존 유저의 만료시간으로 만료시간 설정
-            await this.lentRepository.setExpireTime(
-              new_lent.lent_id,
-              cabinet.expire_time,
-            );
-          }
-          // 상태를 SET_EXPIRE_FULL로 변경
-          await this.cabinetInfoService.updateCabinetStatus(
-            cabinet_id,
-            CabinetStatusType.SET_EXPIRE_FULL,
-          );
-        }
-        break;
+		if (excepction_type === LentExceptionType.LENT_SUCCESS) {
+			const new_lent = await this.lentRepository.lentCabinet(
+			  user,
+			  cabinet_id,
+			  cabinet.new_lent_id,
+			);
+			if (cabinet.lent_count + 1 === cabinet.max_user) {
+			  if (cabinet.status === CabinetStatusType.AVAILABLE) {
+				// 해당 대여로 처음으로 풀방이 되면 만료시간 설정
+				await this.setExpireTimeAll(
+				  cabinet_id,
+				  new_lent.lent_time,
+				  cabinet.lent_type,
+				);
+			  } else {
+				// 기존 유저의 만료시간으로 만료시간 설정
+				await this.lentRepository.setExpireTime(
+				  new_lent.lent_id,
+				  cabinet.expire_time,
+				);
+			  }
+			  // 상태를 SET_EXPIRE_FULL로 변경
+			  await this.cabinetInfoService.updateCabinetStatus(
+				  cabinet_id,
+				  CabinetStatusType.SET_EXPIRE_FULL,
+				);
+			}
+			else {
+				await this.lentRepository.setExpireTime(
+					new_lent.lent_id,
+					cabinet.expire_time,
+				  );
+			}
+			break;
+		}
 
       case CabinetStatusType.SET_EXPIRE_FULL:
         excepction_type = LentExceptionType.LENT_FULL;

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -98,7 +98,6 @@ export class LentTools {
           if (cabinet.status === CabinetStatusType.SET_EXPIRE_AVAILABLE) {
             // 만료시간이 PENALTY_DAY_SHARE + 2 이하로 남은 경우 excepction_type을 LENT_UNDER_PENALTY_DAY_SHARE로 설정.
             const now = new Date();
-			console.debug(cabinet.expire_time);
             const expire_time = cabinet.expire_time;
             const diff = await this.dateCalculator.calDateDiff(
               now,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1050

공유사물함 3명이 채워진 후 2명이 나가서 1명이 남은 상황에서 다른 1명이 들어와서 총 2명이 된 경우에 처리되는 로직이 없어서 만료기간이 9999-12-30으로 초기화 되는 버그를 수정하였습니다.
-> lent.component.ts의 lentStateTransition에서 처음 exception을 설정하는 부분 이후에 lent 하는 것을 막기 위해 if문을 추가하였고,
cabinet.lent_count + 1 === max_user인 경우에서, 0 -> 1과 2->3은 정상작동 하였으나, 1->2인 경우에 처리해주는 로직이 없어서 추가하였습니다.

+
아래 사진에 해당하는 부분은 현재 이 버그가 원인인 것으로 추정되나, 더 점검해봐야할 것 같습니다.
![image](https://user-images.githubusercontent.com/91823083/233979342-d1620fba-ecf0-4902-8170-e0143b0c817a.png)

