### PR TITLE
[FE] FIX: 3층 map 비활성화 -> 활성화로 변경 #1054

### DIFF
--- a/frontend/src/assets/data/mapPositionData.ts
+++ b/frontend/src/assets/data/mapPositionData.ts
@@ -97,7 +97,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 7,
       rowEnd: 8,
       name: "Cluster X - 7",
-      type: "closed",
+      type: "cabinet",
     },
     {
       colStart: 4,
@@ -105,7 +105,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 6,
       rowEnd: 7,
       name: "Cluster X - 6",
-      type: "closed",
+      type: "cabinet",
     },
     {
       colStart: 4,
@@ -113,7 +113,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 5,
       rowEnd: 6,
       name: "Cluster X - 5",
-      type: "closed",
+      type: "cabinet",
     },
     {
       colStart: 4,
@@ -121,7 +121,7 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowStart: 4,
       rowEnd: 5,
       name: "Cluster X - 4",
-      type: "closed",
+      type: "cabinet",
     },
     {
       colStart: 4,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> https://github.com/innovationacademy-kr/42cabi/issues/1054

3층 map 을 활성화 색으로 변경하기 위해서 mapPositionData.ts의 type을 closed -> cabinet으로 변경하였습니다.

Closes #1054 
