### PR TITLE
[COMMON] cicd workflow 분리

### DIFF
--- a/.github/workflows/backend-cicd.yaml
+++ b/.github/workflows/backend-cicd.yaml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   backend-CI:
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.modified, 'backend/')"
     services:
       mariadb:
         image: mariadb
@@ -73,37 +74,10 @@ jobs:
           DEBUG_LOG: true
         run: npm run test:e2e --prefix backend
 
-  frontend-CI:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 체크아웃
-        uses: actions/checkout@v2
-      - name: Node.js 16.x Version
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
-      - name: 종속 모듈들 캐싱
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/frontend/node_modules
-          key: npm-packages-${{ hashFiles('**/frontend/package-lock.json') }}
-        id: cache
-      - name: 종속 모듈들 설치
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm install --prefix frontend
-      # - name: lint 체크
-      #   run: npm run lint --prefix frontend
-      - name: 빌드 체크
-        run: npm run build --prefix frontend
-      # - name: 단위 테스트 체크
-      #   run: npm run test --prefix frontend
-      # - name: 통합 테스트 체크
-      #   run: npm run test:e2e --prefix frontend
-
-  CD-develop:
+  backend-CD-develop:
     name: deploy-develop
     runs-on: ubuntu-latest
-    needs: [backend-CI, frontend-CI]
+    needs: [backend-CI]
     if: ${{ github.ref == 'refs/heads/dev' }}
     steps:
       - name: 리모트 쉘 접속
@@ -123,16 +97,13 @@ jobs:
             echo "앱 빌드"
             cd $HOME/42cabi_dev/backend
             npm install
-            npm run build:fe
-            npm run deploy:dev
-            npm run invalidate:dev
             npm run build
             echo "env 파일 복사"
             cp $HOME/42cabi_dev.env $HOME/42cabi_dev/backend/.env
             echo "앱 배포 (reload)"
             pm2 reload cabi_dev
 
-  CD-main:
+  backend-CD-main:
     name: deploy-main
     runs-on: ubuntu-latest
     needs: [backend-CI, frontend-CI]
@@ -155,9 +126,6 @@ jobs:
             echo "앱 빌드"
             cd $HOME/42cabi_main/backend
             npm install
-            npm run build:fe
-            npm run deploy:main
-            npm run invalidate:main
             npm run build
             echo "env 파일 복사"
             cp $HOME/42cabi_main.env $HOME/42cabi_main/backend/.env

--- a/.github/workflows/backend-cicd.yaml
+++ b/.github/workflows/backend-cicd.yaml
@@ -106,7 +106,7 @@ jobs:
   backend-CD-main:
     name: deploy-main
     runs-on: ubuntu-latest
-    needs: [backend-CI, frontend-CI]
+    needs: [backend-CI]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: 리모트 쉘 접속

--- a/.github/workflows/backend-cicd.yaml
+++ b/.github/workflows/backend-cicd.yaml
@@ -1,10 +1,12 @@
 name: CI/CD
-on: [push]
+on:
+  push:
+    paths:
+      - "backend/**"
 
 jobs:
   backend-CI:
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.modified, 'backend/')"
     services:
       mariadb:
         image: mariadb

--- a/.github/workflows/frontend-cicd.yaml
+++ b/.github/workflows/frontend-cicd.yaml
@@ -1,0 +1,97 @@
+name: CI/CD
+on: [push]
+
+jobs:
+  frontend-CI:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.modified, 'frontend/')"
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v2
+      - name: Node.js 16.x Version
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: 종속 모듈들 캐싱
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/frontend/node_modules
+          key: npm-packages-${{ hashFiles('**/frontend/package-lock.json') }}
+        id: cache
+      - name: 종속 모듈들 설치
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install --prefix frontend
+      # - name: lint 체크
+      #   run: npm run lint --prefix frontend
+      - name: 빌드 체크
+        run: npm run build --prefix frontend
+      # - name: 단위 테스트 체크
+      #   run: npm run test --prefix frontend
+      # - name: 통합 테스트 체크
+      #   run: npm run test:e2e --prefix frontend
+
+  frontend-CD-develop:
+    name: deploy-develop
+    runs-on: ubuntu-latest
+    needs: [frontend-CI]
+    if: ${{ github.ref == 'refs/heads/dev' }}
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v2
+      - name: Node.js 16.x Version
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: 종속 모듈들 캐싱
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/frontend/node_modules
+          key: npm-packages-${{ hashFiles('**/frontend/package-lock.json') }}
+        id: cache
+      - name: 종속 모듈들 설치
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install --prefix frontend
+
+      - name: 애플리케이션 빌드
+        run: npm run build
+
+      - name: AWS S3에 배포 및 CloudFront 캐시 무효화
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 sync ./deploy s3://dev.cabi --profile=CABI
+          aws cloudfront create-invalidation --profile=CABI --distribution-id EWPTW52IH5L5C --paths '/*'
+
+  frontend-CD-main:
+    name: deploy-main
+    runs-on: ubuntu-latest
+    needs: [frontend-CI]
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v2
+      - name: Node.js 16.x Version
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: 종속 모듈들 캐싱
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/frontend/node_modules
+          key: npm-packages-${{ hashFiles('**/frontend/package-lock.json') }}
+        id: cache
+      - name: 종속 모듈들 설치
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install --prefix frontend
+
+      - name: 애플리케이션 빌드
+        run: npm run build
+
+      - name: AWS S3에 배포 및 CloudFront 캐시 무효화
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 sync ./deploy s3://42cabi --profile=CABI
+          aws cloudfront create-invalidation --profile=CABI --distribution-id E12WMB9HCNB1DT --paths '/*'

--- a/.github/workflows/frontend-cicd.yaml
+++ b/.github/workflows/frontend-cicd.yaml
@@ -1,10 +1,12 @@
 name: CI/CD
-on: [push]
+on:
+  push:
+    paths:
+      - "frontend/**"
 
 jobs:
   frontend-CI:
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.modified, 'frontend/')"
     steps:
       - name: 체크아웃
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

이슈에 작성한대로 backend와 frontend workflow를 분리시켰습니다.
### 기존
어느 디렉토리에서 수정사항이 일어났는지에 대한 고려 없이, backend-CI와 frontend-CI가 하나의 워크플로우 안에서 동작했습니다.
때문에 frontend 디렉토리에서만 수정된 내용이더라도 backend-CI까지 같이 돌았습니다.
이 문제는 dev나 main으로 병합할 때 더 크게 와 닿게 되는 문제였습니다. frontend에서 모달 하나 추가하여 배포하려고 하는데, CD는 CI 작업이 모두 완료되어야 실행되기 때문에 수정하지도 않은 backend-CI를 모두 기다려야 합니다.
뿐만 아니라 CD에서도 수정하지도 않은 backend 코드를 build하고 배포하는 과정도 이루어집니다. 게다가 s3에 frontend 코드를 업로드하는 상황임에도 ec2에 접속 후 aws cli를 통해 배포하기 때문에 frontend 배포 과정이 ec2에 종속되는 문제도 있습니다.

### 변경 후
backend와 frontend가 별도의 workflow로 동작하기 때문에, frontend 디렉토리에서 변경된 내용은 frontend workflow만 동작합니다.
따라서 이제 dev나 main으로 병합하여 CD를 실행하려고 할 때, 변경하지 않은 backend에 대한 CI를 기다릴 필요가 없습니다.
또한 CD에서도 backend workflow에서는 더이상 frontend 코드를 s3에 업로드하지 않습니다. frontend 코드를 업로드하는 일은 frontend workflow에서만 이루어집니다. github actions에서 자체적으로 aws-cli 명령어를 지원해주기 때문에, aws key id와 aws secret access key만 github 환경변수로 등록해주면 되기 때문에 배포를 위한 별도의 환경이 필요하지 않습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1056
