### PR TITLE
[FE] FEAT: 3층 사물함 반납 시 비밀번호 입력 모달 띄우기 #1059

### DIFF
--- a/backend/src/dto/lent.cabinet.data.dto.ts
+++ b/backend/src/dto/lent.cabinet.data.dto.ts
@@ -11,4 +11,5 @@ export class LentCabinetDataDto {
   lent_count: number; // 해당 케비넷을 대여한 사람의 수
   expire_time?: Date; // 사물함이 대여 중일 때 대여한 유저의 만료 시간
   max_user: number; // 해당 사물함을 최대로 빌릴 수 있는 유저 수
+  floor: number; // 층
 }

--- a/backend/src/lent/lent.component.ts
+++ b/backend/src/lent/lent.component.ts
@@ -1,4 +1,5 @@
 import {
+	BadRequestException,
   forwardRef,
   HttpException,
   HttpStatus,
@@ -200,7 +201,9 @@ export class LentTools {
     // 2. cabinet_status에 따라 처리.
     switch (cabinet.status) {
       case CabinetStatusType.AVAILABLE:
-        if (lent_count - 1 === 0) {
+
+        if (lent_count - 1 === 0 
+		&& !this.isMemoUpdateRequiredReturn(cabinet_id)) {
           await this.clearCabinetInfo(cabinet_id);
         }
         break;
@@ -215,7 +218,9 @@ export class LentTools {
             cabinet_id,
             CabinetStatusType.AVAILABLE,
           );
-          await this.clearCabinetInfo(cabinet_id);
+          if (!await this.isMemoUpdateRequiredReturn(cabinet_id)) {
+            await this.clearCabinetInfo(cabinet_id);
+          }
         }
         break;
       case CabinetStatusType.BANNED:
@@ -259,5 +264,17 @@ export class LentTools {
 
   async getLentCabinetId(user_id: number): Promise<number> {
     return await this.lentRepository.getLentCabinetId(user_id);
+  }
+
+  async isMemoUpdateRequiredReturn(cabinet_id: number): Promise<boolean> {
+	try {
+		const cabinet = await this.lentRepository.getLentCabinetData(cabinet_id);
+    return (cabinet.lent_count === 1 && cabinet.floor === 3);
+	} catch (e) {
+		throw new HttpException(
+		`대여한 사물함이 없습니다`,
+		HttpStatus.FORBIDDEN,
+		);
+	}
   }
 }

--- a/backend/src/lent/lent.controller.ts
+++ b/backend/src/lent/lent.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   HttpException,
   HttpStatus,
@@ -34,12 +35,13 @@ import { UserSessionDto } from 'src/dto/user.session.dto';
 import { QueryFailedError } from 'typeorm';
 import { BanCheckGuard } from '../ban/guard/ban.check.guard';
 import { LentService } from './lent.service';
+import { CabinetInfoService } from 'src/cabinet/cabinet.info.service';
 
 @ApiTags('Lent')
 @Controller('/api/lent')
 export class LentController {
   private logger = new Logger(LentController.name);
-  constructor(private lentService: LentService) {}
+  constructor(private lentService: LentService, private cabinetService: CabinetInfoService) {}
 
   @ApiOperation({
     summary: '특정 캐비넷 대여 시도',
@@ -182,6 +184,38 @@ export class LentController {
     try {
       this.logger.debug(`Called ${this.returnCabinet.name}`);
       return await this.lentService.returnCabinet(user);
+    } catch (err) {
+      this.logger.error(err);
+      if (err instanceof HttpException) {
+        throw err;
+      } else {
+        throw new InternalServerErrorException(`서버 에러가 발생했습니다`);
+      }
+    }
+  }
+
+  @ApiOperation({
+    summary: '메모 작성 후 대여한 사물함을 반납',
+    description: '자신이 대여한 캐비넷을 반납합니다.',
+  })
+  @ApiNoContentResponse({
+    description: 'Delete 성공 시, 204 No_Content를 응답합니다.',
+  })
+  @ApiForbiddenResponse({
+    description:
+      '사물함을 빌리지 않았는데 호출할 때, 403 Forbidden을 응답합니다.',
+  })
+  @Patch('/return-memo')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(JwtAuthGuard)
+  async returnCabinetAndUpdateMemo(
+		@User() user: UserSessionDto, 
+		@Body() memo: UpdateCabinetMemoRequestDto
+	): Promise<void> {
+    try {
+      this.logger.debug(`Called ${this.returnCabinet.name}`);
+	  await this.updateLentCabinetMemo(memo, user);
+      return await this.lentService.returnCabinet(user, true);
     } catch (err) {
       this.logger.error(err);
       if (err instanceof HttpException) {

--- a/backend/src/lent/lent.service.ts
+++ b/backend/src/lent/lent.service.ts
@@ -117,7 +117,7 @@ export class LentService {
     );
   }
 
-  async returnCabinet(user: UserDto): Promise<void> {
+  async returnCabinet(user: UserDto, isMemoUpdated: boolean = false ): Promise<void> {
     this.logger.debug(`Called ${LentService.name} ${this.returnCabinet.name}`);
     try {
       // 1. 해당 유저가 대여중인 cabinet_id를 가져온다.
@@ -128,6 +128,13 @@ export class LentService {
         throw new HttpException(
           `대여한 사물함이 없습니다`,
           HttpStatus.FORBIDDEN,
+        );
+      }
+      if (await this.lentTools.isMemoUpdateRequiredReturn(cabinet_id)
+		&&	isMemoUpdated == false) {
+        throw  new HttpException(
+          `사물함 반납 시 사물함 메모를 작성해야 합니다`,
+          HttpStatus.I_AM_A_TEAPOT,
         );
       }
       const [lent, lent_type] = await this.lentTools.returnStateTransition(

--- a/backend/src/lent/repository/lent.repository.ts
+++ b/backend/src/lent/repository/lent.repository.ts
@@ -213,7 +213,7 @@ export class lentRepository implements ILentRepository {
   async getLentCabinetData(cabinet_id: number): Promise<LentCabinetDataDto> {
     const result = await this.cabinetRepository
       .createQueryBuilder('c')
-      .select(['c.cabinet_status', 'c.lent_type', 'c.max_user', 'c.cabinet_id'])
+      .select(['c.cabinet_status', 'c.lent_type', 'c.max_user', 'c.cabinet_id', 'c.floor'])
       .leftJoin(Lent, 'l', 'l.lent_cabinet_id = c.cabinet_id')
       .addSelect('l.expire_time', 'expire_time')
       .addSelect('l.lent_id', 'lent_id')
@@ -236,6 +236,7 @@ export class lentRepository implements ILentRepository {
       expire_time:
         result[0].lent_id === null ? undefined : result[0].expire_time,
       max_user: result[0].c_max_user,
+      floor: result[0].c_floor,
     };
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="ko">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-Q41WN2559Z"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-Q41WN2559Z");
+    </script>
     <meta charset="UTF-8" />
     <link rel="icon" href="/src/assets/images/logo.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="/src/assets/images/logo.png" />

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -121,6 +121,17 @@ export const axiosReturn = async (): Promise<any> => {
   }
 };
 
+const axiosSendCabinetPasswordURL = "/api/lent/return-memo";
+export const axiosSendCabinetPassword = async (password: string) => {
+  try {
+    const response = await instance.patch(axiosSendCabinetPasswordURL, {
+      cabinet_memo: password,
+    });
+  } catch (error) {
+    throw error;
+  }
+};
+
 const axiosMyLentLogURL = "/api/my_lent_info/log";
 export const axiosMyLentLog = async (page: number): Promise<any> => {
   try {

--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -65,6 +65,11 @@ export const modalPropsMap = {
     title: "사용이 불가한 사물함입니다",
     confirmMessage: "",
   },
+  PASSWORD_CHECK: {
+    type: "confirm",
+    title: "반납 시  비밀번호",
+    confirmMessage: "확인했습니다",
+  },
   MODAL_RETURN: {
     type: "confirm",
     title: "사물함 반납하기",

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -39,9 +39,10 @@ const CabinetInfoArea: React.FC<{
   const [showUnavailableModal, setShowUnavailableModal] =
     useState<boolean>(false);
   const [showLentModal, setShowLentModal] = useState<boolean>(false);
-  const [showReturnModal, setShowReturnModal] = useState<boolean>(true);
+  const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
-  const [showPasswordCheckModal, setPasswordCheckModal] = useState<boolean>(true);
+  const [showPasswordCheckModal, setPasswordCheckModal] =
+    useState<boolean>(false);
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
@@ -71,9 +72,12 @@ const CabinetInfoArea: React.FC<{
   const handleCloseUnavailableModal = () => {
     setShowUnavailableModal(false);
   };
+  const handleOpenPasswordCheckModal = () => {
+    setPasswordCheckModal(true);
+  };
   const handleClosePasswordCheckModal = () => {
     setPasswordCheckModal(false);
-  }
+  };
 
   if (!selectedCabinetInfo)
     //아무 사물함도 선택하지 않았을 때
@@ -160,11 +164,14 @@ const CabinetInfoArea: React.FC<{
       {showReturnModal && (
         <ReturnModal
           lentType={selectedCabinetInfo!.lentType}
+          handleOpenPasswordCheckModal={handleOpenPasswordCheckModal}
           closeModal={handleCloseReturnModal}
         />
-      )} 
+      )}
       {showMemoModal && <MemoModalContainer onClose={handleCloseMemoModal} />}
-      {showPasswordCheckModal && (<PasswordCheckModalContainer onClose={handleClosePasswordCheckModal} />)}
+      {showPasswordCheckModal && (
+        <PasswordCheckModalContainer onClose={handleClosePasswordCheckModal} />
+      )}
     </CabinetDetailAreaStyled>
   );
 };

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -14,6 +14,7 @@ import {
   cabinetLabelColorMap,
   cabinetStatusColorMap,
 } from "@/assets/data/maps";
+import PasswordCheckModalContainer from "../Modals/PasswordCheckModal/PasswordCheckModal.container";
 
 export interface ISelectedCabinetInfo {
   floor: number;
@@ -38,9 +39,9 @@ const CabinetInfoArea: React.FC<{
   const [showUnavailableModal, setShowUnavailableModal] =
     useState<boolean>(false);
   const [showLentModal, setShowLentModal] = useState<boolean>(false);
-  const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
+  const [showReturnModal, setShowReturnModal] = useState<boolean>(true);
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
-  useState<boolean>(false);
+  const [showPasswordCheckModal, setPasswordCheckModal] = useState<boolean>(true);
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
@@ -70,6 +71,9 @@ const CabinetInfoArea: React.FC<{
   const handleCloseUnavailableModal = () => {
     setShowUnavailableModal(false);
   };
+  const handleClosePasswordCheckModal = () => {
+    setPasswordCheckModal(false);
+  }
 
   if (!selectedCabinetInfo)
     //아무 사물함도 선택하지 않았을 때
@@ -158,8 +162,9 @@ const CabinetInfoArea: React.FC<{
           lentType={selectedCabinetInfo!.lentType}
           closeModal={handleCloseReturnModal}
         />
-      )}
+      )} 
       {showMemoModal && <MemoModalContainer onClose={handleCloseMemoModal} />}
+      {showPasswordCheckModal && (<PasswordCheckModalContainer onClose={handleClosePasswordCheckModal} />)}
     </CabinetDetailAreaStyled>
   );
 };

--- a/frontend/src/components/Common/Button.tsx
+++ b/frontend/src/components/Common/Button.tsx
@@ -64,6 +64,7 @@ const ButtonContainerStyled = styled.button`
       color: var(--gray-color);
       border: 1px solid var(--gray-color);
     `}
+
   @media (max-height: 745px) {
     margin-bottom: 8px;
   }

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
@@ -23,10 +23,11 @@ import { getExpireDateString } from "@/utils";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
-import PasswordCheckModal, { IPasswordState } from "./PasswordCheckModal";
+import PasswordCheckModal from "./PasswordCheckModal";
+import PasswordContainer from "./PasswordContainer";
 
 const PasswordCheckModalContainer: React.FC<{
-  onClose: ()=>void;
+  onClose: () => void;
 }> = (props) => {
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
@@ -35,77 +36,33 @@ const PasswordCheckModalContainer: React.FC<{
   const [myInfo, setMyInfo] = useRecoilState(userState);
   const [myLentInfo, setMyLentInfo] =
     useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
-  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
-  const setIsCurrentSectionRender = useSetRecoilState(
-    isCurrentSectionRenderState
-  );
-  const [passwordState, setPasswordState] = useState<IPasswordState>({
-    num1 : null,
-    num2 : null,
-    num3 : null,
-    num4 : null
-  })
 
-  const returnModalContents: IModalContents = {
+  const passwordCheckModalContents: IModalContents = {
     type: "hasProceedBtn",
     icon: checkIcon,
-    title: '반납 시  비밀번호',
+    title: "반납 시  비밀번호",
     detail: `비밀번호는 <strong>1111</strong>로 초기화해서
     반납하시는 것을 권장합니다.`,
     proceedBtnText:
       modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
-    onClickProceed: async (e:React.MouseEvent<Element, MouseEvent>)=>{},
+    onClickProceed: async (e: React.MouseEvent<Element, MouseEvent>) => {},
+    renderAdditionalComponent: () => <PasswordContainer onChange={onChange} password={password} />,
     closeModal: props.onClose,
   };
 
-  const onKeyDown = (index:number, e:React.KeyboardEvent) => {
-    const currentInput = inputs.current[index];
-    const previousInput = inputs.current[index - 1];
+  const [password, setPassword] = useState("");
 
-    if (e.key === 'Backspace' && currentInput && currentInput.value.length === 1) {
-      e.preventDefault();
-      currentInput.value='';
-      setPasswordState({
-        ...passwordState,
-        ['num' + (index + 1)] : null
-      })
-      return;
-    }
-
-    if (e.key === 'Backspace' && currentInput && currentInput.value === '') {
-      e.preventDefault();
-
-      if (previousInput) {
-        previousInput.focus();
-        previousInput.value = '';
-        setPasswordState({
-          ...passwordState
-        })
-      }
-    }
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const regex = /^[0-9]{0,4}$/;
+    if (!regex.test(e.target.value)) return;
+    setPassword(e.target.value);
   };
-
-  const onChangeInput = (index:number, e:React.ChangeEvent<HTMLInputElement>) => {
-    const regex = /^[0-9]+$/;
-    if(!regex.test(e.currentTarget.value)) return;
-    setPasswordState({
-      ...passwordState,
-      [e.target.name] : e.currentTarget.value
-    })
-    const input = e.target;
-    const { value } = input;
-
-    if (value.length === 1 && index < inputs.current.length - 1 ) {
-      inputs.current[index + 1].focus();
-    }
-  }
-  
-  const inputs = useRef<HTMLInputElement[]>([]);
-
 
   return (
     <ModalPortal>
-      {!showResponseModal && <PasswordCheckModal onKeyDown={onKeyDown} inputs={inputs} onChangeInput={onChangeInput} passwordState={passwordState} modalContents={returnModalContents} />}
+      {!showResponseModal && (
+        <PasswordCheckModal password={password} modalContents={passwordCheckModalContents} />
+      )}
       {showResponseModal &&
         (hasErrorOnResponse ? (
           <FailResponseModal

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
@@ -1,0 +1,125 @@
+import React, { useRef, useState } from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  currentCabinetIdState,
+  isCurrentSectionRenderState,
+  myCabinetInfoState,
+  overdueCabinetListState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
+import {
+  axiosCabinetById,
+  axiosMyLentInfo,
+  axiosReturn,
+} from "@/api/axios/axios.custom";
+import Modal, { IModalContents } from "@/components/Modals/Modal";
+import {
+  SuccessResponseModal,
+  FailResponseModal,
+} from "@/components/Modals/ResponseModal/ResponseModal";
+import ModalPortal from "@/components/Modals/ModalPortal";
+import { getExpireDateString } from "@/utils";
+import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
+import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
+import checkIcon from "@/assets/images/checkIcon.svg";
+import PasswordCheckModal, { IPasswordState } from "./PasswordCheckModal";
+
+const PasswordCheckModalContainer: React.FC<{
+  onClose: ()=>void;
+}> = (props) => {
+  const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
+  const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
+  const [modalTitle, setModalTitle] = useState<string>("");
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  const [myInfo, setMyInfo] = useRecoilState(userState);
+  const [myLentInfo, setMyLentInfo] =
+    useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
+  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+  const [passwordState, setPasswordState] = useState<IPasswordState>({
+    num1 : null,
+    num2 : null,
+    num3 : null,
+    num4 : null
+  })
+
+  const returnModalContents: IModalContents = {
+    type: "hasProceedBtn",
+    icon: checkIcon,
+    title: '반납 시  비밀번호',
+    detail: `비밀번호는 <strong>1111</strong>로 초기화해서
+    반납하시는 것을 권장합니다.`,
+    proceedBtnText:
+      modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
+    onClickProceed: async (e:React.MouseEvent<Element, MouseEvent>)=>{},
+    closeModal: props.onClose,
+  };
+
+  const onKeyDown = (index:number, e:React.KeyboardEvent) => {
+    const currentInput = inputs.current[index];
+    const previousInput = inputs.current[index - 1];
+
+    if (e.key === 'Backspace' && currentInput && currentInput.value.length === 1) {
+      e.preventDefault();
+      currentInput.value='';
+      setPasswordState({
+        ...passwordState,
+        ['num' + (index + 1)] : null
+      })
+      return;
+    }
+
+    if (e.key === 'Backspace' && currentInput && currentInput.value === '') {
+      e.preventDefault();
+
+      if (previousInput) {
+        previousInput.focus();
+        previousInput.value = '';
+        setPasswordState({
+          ...passwordState
+        })
+      }
+    }
+  };
+
+  const onChangeInput = (index:number, e:React.ChangeEvent<HTMLInputElement>) => {
+    const regex = /^[0-9]+$/;
+    if(!regex.test(e.currentTarget.value)) return;
+    setPasswordState({
+      ...passwordState,
+      [e.target.name] : e.currentTarget.value
+    })
+    const input = e.target;
+    const { value } = input;
+
+    if (value.length === 1 && index < inputs.current.length - 1 ) {
+      inputs.current[index + 1].focus();
+    }
+  }
+  
+  const inputs = useRef<HTMLInputElement[]>([]);
+
+
+  return (
+    <ModalPortal>
+      {!showResponseModal && <PasswordCheckModal onKeyDown={onKeyDown} inputs={inputs} onChangeInput={onChangeInput} passwordState={passwordState} modalContents={returnModalContents} />}
+      {showResponseModal &&
+        (hasErrorOnResponse ? (
+          <FailResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.onClose}
+          />
+        ) : (
+          <SuccessResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.onClose}
+          />
+        ))}
+    </ModalPortal>
+  );
+};
+
+export default PasswordCheckModalContainer;

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
@@ -20,9 +20,8 @@ import {
   FailResponseModal,
 } from "@/components/Modals/ResponseModal/ResponseModal";
 import ModalPortal from "@/components/Modals/ModalPortal";
-import { getExpireDateString } from "@/utils";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
-import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
+import { modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
 import PasswordCheckModal from "./PasswordCheckModal";
 import PasswordContainer from "./PasswordContainer";

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
@@ -44,7 +44,10 @@ const PasswordCheckModalContainer: React.FC<{
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const regex = /^[0-9]{0,4}$/;
-    if (!regex.test(e.target.value)) return;
+    if (!regex.test(e.target.value)) {
+      e.target.value = password;
+      return;
+    }
     setPassword(e.target.value);
   };
 

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.container.tsx
@@ -12,6 +12,7 @@ import {
   axiosCabinetById,
   axiosMyLentInfo,
   axiosReturn,
+  axiosSendCabinetPassword,
 } from "@/api/axios/axios.custom";
 import Modal, { IModalContents } from "@/components/Modals/Modal";
 import {
@@ -31,26 +32,16 @@ const PasswordCheckModalContainer: React.FC<{
 }> = (props) => {
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
-  const [modalTitle, setModalTitle] = useState<string>("");
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
-  const [myInfo, setMyInfo] = useRecoilState(userState);
-  const [myLentInfo, setMyLentInfo] =
-    useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
-
-  const passwordCheckModalContents: IModalContents = {
-    type: "hasProceedBtn",
-    icon: checkIcon,
-    title: "반납 시  비밀번호",
-    detail: `비밀번호는 <strong>1111</strong>로 초기화해서
-    반납하시는 것을 권장합니다.`,
-    proceedBtnText:
-      modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
-    onClickProceed: async (e: React.MouseEvent<Element, MouseEvent>) => {},
-    renderAdditionalComponent: () => <PasswordContainer onChange={onChange} password={password} />,
-    closeModal: props.onClose,
-  };
-
+  const [modalTitle, setModalTitle] = useState<string>("");
   const [password, setPassword] = useState("");
+  const [myInfo, setMyInfo] = useRecoilState(userState);
+  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+  const setMyLentInfo =
+    useSetRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const regex = /^[0-9]{0,4}$/;
@@ -58,10 +49,54 @@ const PasswordCheckModalContainer: React.FC<{
     setPassword(e.target.value);
   };
 
+  const onSendPassword = async () => {
+    try {
+      await axiosSendCabinetPassword(password);
+      //userCabinetId 세팅
+      setMyInfo({ ...myInfo, cabinet_id: -1 });
+      setIsCurrentSectionRender(true);
+      setModalTitle("반납되었습니다");
+      // 캐비닛 상세정보 바꾸는 곳
+      try {
+        const { data } = await axiosCabinetById(currentCabinetId);
+        setTargetCabinetInfo(data);
+      } catch (error) {
+        throw error;
+      }
+      try {
+        const { data: myLentInfo } = await axiosMyLentInfo();
+        setMyLentInfo(myLentInfo);
+      } catch (error) {
+        throw error;
+      }
+    } catch (error) {
+      throw error;
+    } finally {
+      setShowResponseModal(true);
+    }
+  };
+
+  const passwordCheckModalContents: IModalContents = {
+    type: "hasProceedBtn",
+    icon: checkIcon,
+    title: modalPropsMap["PASSWORD_CHECK"].title,
+    detail: `비밀번호는 <strong>1111</strong>로 초기화해서
+    반납하시는 것을 권장합니다.`,
+    proceedBtnText: modalPropsMap["PASSWORD_CHECK"].confirmMessage,
+    onClickProceed: onSendPassword,
+    renderAdditionalComponent: () => (
+      <PasswordContainer onChange={onChange} password={password} />
+    ),
+    closeModal: props.onClose,
+  };
+
   return (
     <ModalPortal>
       {!showResponseModal && (
-        <PasswordCheckModal password={password} modalContents={passwordCheckModalContents} />
+        <PasswordCheckModal
+          password={password}
+          modalContents={passwordCheckModalContents}
+        />
       )}
       {showResponseModal &&
         (hasErrorOnResponse ? (

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
@@ -1,0 +1,195 @@
+import styled, { css } from "styled-components";
+import Button from "@/components/Common/Button";
+import React, { ReactElement } from "react";
+import useMultiSelect from "@/hooks/useMultiSelect";
+
+export interface IModalContents {
+  type: string; // hasProceedBtn(모달 외부 클릭이나 취소 버튼으로 끔), noBtn(모달 내/외부 클릭으로 끔)
+  icon?: string; // checkIcon, errorIcon import 해서 넘기거나 다른 아이콘 사용 가능
+  iconScaleEffect?: boolean; // iconEffect 적용 여부
+  title?: string; // 모달 제목
+  detail?: string; // 모달 본문
+  renderAdditionalComponent?: () => ReactElement; // 모달에 추가로 띄울 UI를 렌더해주는 함수
+  proceedBtnText?: string; // 확인 버튼의 텍스트(기본값: 확인)
+  onClickProceed?: ((e: React.MouseEvent) => Promise<void>) | null; // 확인 버튼의 동작함수
+  cancleBtnText?: string; // 취소 버튼의 텍스트(기본값: 취소)
+  closeModal: React.MouseEventHandler; // 모달 닫는 함수
+}
+
+export interface IPasswordState {
+  [key:string] : number | null
+}
+
+
+const PasswordCheckModal: React.FC<{ onKeyDown:Function, onChangeInput:Function, passwordState : IPasswordState, modalContents: IModalContents, inputs :React.MutableRefObject<HTMLInputElement[]> }> = ({ onKeyDown, onChangeInput, passwordState, modalContents, inputs}) => {
+  const {
+    type,
+    icon,
+    iconScaleEffect,
+    title,
+    detail,
+    renderAdditionalComponent,
+    proceedBtnText,
+    onClickProceed,
+    cancleBtnText,
+    closeModal,
+  } = modalContents;
+  const { isMultiSelect, closeMultiSelectMode } = useMultiSelect();
+  const assignRef = (index:number) => (el : HTMLInputElement | null) => {
+    if(!el) return;
+    inputs.current[index] = el;
+  };
+
+  return (
+    <>
+      <BackgroundStyled
+        onClick={(e) => {
+          closeModal(e);
+          if (isMultiSelect) {
+            closeMultiSelectMode();
+          }
+        }}
+      />
+      <ModalStyled onClick={type === "noBtn" ? closeModal : undefined}>
+        {/* {icon && (
+          <img src={icon} style={{ width: "70px", marginBottom: "20px" }} />
+        )} */}
+        {icon && (
+          <ModalIconImgStyled src={icon} iconScaleEffect={iconScaleEffect} />
+        )}
+        <H2Styled>{title}</H2Styled>
+        {detail && (
+          <DetailStyled dangerouslySetInnerHTML={{ __html: detail }} />
+        )}
+        <PasswordContainer>
+          {new Array(4).fill(0).map((_, idx) =>  <Input onKeyDown={(e)=>onKeyDown(idx, e)} isEmpty={passwordState[('num' + (idx + 1))]} onChange={(e)=>onChangeInput(idx, e)} maxLength={1} ref={assignRef(idx)} value={passwordState['num' + (idx + 1)]?? ''} name={"num" + (idx + 1)}/>)}
+        </PasswordContainer>
+        {renderAdditionalComponent && renderAdditionalComponent()}
+        {type === "hasProceedBtn" && (
+          <ButtonWrapperStyled>
+            <Button
+              onClick={closeModal}
+              text={cancleBtnText || "취소"}
+              theme="line"
+            />
+            <Button
+              onClick={(e) => {
+                onClickProceed!(e);
+              }}
+              text={proceedBtnText || "확인"}
+              theme="fill"
+            />
+          </ButtonWrapperStyled>
+        )}
+      </ModalStyled>
+    </>
+  );
+};
+
+const Input = styled.input<{isEmpty : number | null}>`
+  width:20%;
+  height:100%;
+  border-radius:10px;
+  outline:none;
+  border:${({isEmpty}) => isEmpty ? '1px solid var(--main-color)' : '1px solid #dfd0fe'}
+`
+
+const PasswordContainer = styled.div`
+max-width: 240px;
+width: 100%;
+height: 60px;
+margin:0 auto;
+margin-top: 20px;
+display:flex;
+justify-content:space-between;
+align-items:center;
+
+`
+
+const ModalStyled = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 360px;
+  background: white;
+  z-index: 1000;
+  border-radius: 10px;
+  transform: translate(-50%, -50%);
+  animation: fadeInModal 0.5s;
+  @keyframes fadeInModal {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1.5;
+    }
+  }
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  text-align: center;
+  padding: 40px 20px;
+`;
+
+const ModalIconImgStyled = styled.img<{ iconScaleEffect: boolean | undefined }>`
+  width: 70px;
+  margin-bottom: 20px;
+  ${(props) =>
+    props.iconScaleEffect &&
+    css`
+      animation: scaleUpModalIcon 1s;
+      @keyframes scaleUpModalIcon {
+        0% {
+          width: 0px;
+        }
+        100% {
+          width: 70px;
+        }
+      }
+    `}
+`;
+
+export const DetailStyled = styled.p`
+  margin-top: 20px;
+  letter-spacing: -0.02rem;
+  line-height: 1.5rem;
+  font-size: 14px;
+  font-weight: 300;
+  white-space: break-spaces;
+`;
+
+const H2Styled = styled.h2`
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  white-space: break-spaces;
+`;
+
+const BackgroundStyled = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgb(0, 0, 0);
+  opacity: 0.4;
+  animation: fadeInBg 0.5s;
+  @keyframes fadeInBg {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 0.4;
+    }
+  }
+  z-index: 1000;
+`;
+
+const ButtonWrapperStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 30px;
+`;
+
+export default PasswordCheckModal;

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
@@ -45,9 +45,6 @@ const PasswordCheckModal: React.FC<{
         }}
       />
       <ModalStyled onClick={type === "noBtn" ? closeModal : undefined}>
-        {/* {icon && (
-          <img src={icon} style={{ width: "70px", marginBottom: "20px" }} />
-        )} */}
         {icon && (
           <ModalIconImgStyled src={icon} iconScaleEffect={iconScaleEffect} />
         )}

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
@@ -16,12 +16,10 @@ export interface IModalContents {
   closeModal: React.MouseEventHandler; // 모달 닫는 함수
 }
 
-export interface IPasswordState {
-  [key:string] : number | null
-}
-
-
-const PasswordCheckModal: React.FC<{ onKeyDown:Function, onChangeInput:Function, passwordState : IPasswordState, modalContents: IModalContents, inputs :React.MutableRefObject<HTMLInputElement[]> }> = ({ onKeyDown, onChangeInput, passwordState, modalContents, inputs}) => {
+const PasswordCheckModal: React.FC<{
+  modalContents: IModalContents;
+  password: string;
+}> = ({ modalContents, password }) => {
   const {
     type,
     icon,
@@ -35,10 +33,6 @@ const PasswordCheckModal: React.FC<{ onKeyDown:Function, onChangeInput:Function,
     closeModal,
   } = modalContents;
   const { isMultiSelect, closeMultiSelectMode } = useMultiSelect();
-  const assignRef = (index:number) => (el : HTMLInputElement | null) => {
-    if(!el) return;
-    inputs.current[index] = el;
-  };
 
   return (
     <>
@@ -61,50 +55,46 @@ const PasswordCheckModal: React.FC<{ onKeyDown:Function, onChangeInput:Function,
         {detail && (
           <DetailStyled dangerouslySetInnerHTML={{ __html: detail }} />
         )}
-        <PasswordContainer>
-          {new Array(4).fill(0).map((_, idx) =>  <Input onKeyDown={(e)=>onKeyDown(idx, e)} isEmpty={passwordState[('num' + (idx + 1))]} onChange={(e)=>onChangeInput(idx, e)} maxLength={1} ref={assignRef(idx)} value={passwordState['num' + (idx + 1)]?? ''} name={"num" + (idx + 1)}/>)}
-        </PasswordContainer>
         {renderAdditionalComponent && renderAdditionalComponent()}
-        {type === "hasProceedBtn" && (
-          <ButtonWrapperStyled>
-            <Button
-              onClick={closeModal}
-              text={cancleBtnText || "취소"}
-              theme="line"
-            />
-            <Button
-              onClick={(e) => {
-                onClickProceed!(e);
-              }}
-              text={proceedBtnText || "확인"}
-              theme="fill"
-            />
-          </ButtonWrapperStyled>
-        )}
+        <ButtonWrapperStyled>
+          <Button
+            onClick={closeModal}
+            text={cancleBtnText || "취소"}
+            theme="line"
+          />
+          <Button
+            onClick={(e) => {
+              onClickProceed!(e);
+            }}
+            text={proceedBtnText || "확인"}
+            theme="fill"
+            disabled={password.length < 4}
+          />
+        </ButtonWrapperStyled>
       </ModalStyled>
     </>
   );
 };
 
-const Input = styled.input<{isEmpty : number | null}>`
-  width:20%;
-  height:100%;
-  border-radius:10px;
-  outline:none;
-  border:${({isEmpty}) => isEmpty ? '1px solid var(--main-color)' : '1px solid #dfd0fe'}
-`
+const Input = styled.input<{ isEmpty: number | null }>`
+  width: 20%;
+  height: 100%;
+  border-radius: 10px;
+  outline: none;
+  border: ${({ isEmpty }) =>
+    isEmpty ? "1px solid var(--main-color)" : "1px solid #dfd0fe"};
+`;
 
 const PasswordContainer = styled.div`
-max-width: 240px;
-width: 100%;
-height: 60px;
-margin:0 auto;
-margin-top: 20px;
-display:flex;
-justify-content:space-between;
-align-items:center;
-
-`
+  max-width: 240px;
+  width: 100%;
+  height: 60px;
+  margin: 0 auto;
+  margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 const ModalStyled = styled.div`
   position: fixed;

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
@@ -15,13 +15,8 @@ const PasswordContainer = ({
   };
 
   useEffect(() => {
-    const temp: string[] = [];
-    let num = Number(password);
-    while (num) {
-      temp.unshift((num % 10) + "");
-      num = Math.floor(num / 10);
-    }
-    while (temp.length < 4) {
+    const temp = [...password.split("")];
+    for (let i = 0; i < 4 - password.length; i++) {
       temp.push("");
     }
     setList([...temp]);

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
@@ -26,7 +26,12 @@ const PasswordContainer = ({
     <>
       <PasswordStyled>
         {list.map((val, idx) => (
-          <PasswordNumber onClick={onClick} key={idx} val={val}>
+          <PasswordNumber
+            className={idx === 0 && val === "" ? "active" : ""}
+            onClick={onClick}
+            key={idx}
+            val={val}
+          >
             {val}
           </PasswordNumber>
         ))}
@@ -38,7 +43,8 @@ const PasswordContainer = ({
 
 const Input = styled.input`
   height: 0;
-  color: white;
+  color: transparent;
+  caret-color: transparent;
 `;
 
 const PasswordNumber = styled.div<{ val: string }>`
@@ -52,6 +58,9 @@ const PasswordNumber = styled.div<{ val: string }>`
   align-items: center;
   font-size: 2rem;
   color: var(--main-color);
+  &.active {
+    border: 2px solid var(--main-color);
+  }
 `;
 
 const PasswordStyled = styled.div`

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+const PasswordContainer = ({
+  onChange,
+  password,
+}: {
+  onChange: React.ChangeEventHandler;
+  password: string;
+}) => {
+  const [list, setList] = useState(["", "", "", ""]);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const onClick = () => {
+    if (inputRef.current) inputRef.current.focus();
+  };
+
+  useEffect(() => {
+    const temp: string[] = [];
+    let num = Number(password);
+    while (num) {
+      temp.unshift((num % 10) + "");
+      num = Math.floor(num / 10);
+    }
+    while (temp.length < 4) {
+      temp.push("");
+    }
+    setList([...temp]);
+    if (inputRef.current) inputRef.current.focus();
+  });
+  return (
+    <>
+      <PasswordStyled>
+        {list.map((val, idx) => (
+          <PasswordNumber onClick={onClick} key={idx} val={val}>
+            {val}
+          </PasswordNumber>
+        ))}
+      </PasswordStyled>
+      <Input ref={inputRef} onChange={onChange} maxLength={4} />
+    </>
+  );
+};
+
+const Input = styled.input`
+  height: 0;
+  color: white;
+`;
+
+const PasswordNumber = styled.div<{ val: string }>`
+  width: 20%;
+  height: 100%;
+  border-radius: 10px;
+  border: ${({ val }) =>
+    val ? "2px solid var(--main-color)" : "1px solid var(--lightpurple-color)"};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  color: var(--main-color);
+`;
+
+const PasswordStyled = styled.div`
+  width: 240px;
+  height: 60px;
+  margin: 0 auto;
+  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export default PasswordContainer;

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
@@ -26,7 +26,7 @@ const PasswordContainer = ({
     }
     setList([...temp]);
     if (inputRef.current) inputRef.current.focus();
-  });
+  }, [password]);
   return (
     <>
       <PasswordStyled>

--- a/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
@@ -23,10 +23,12 @@ import { getExpireDateString } from "@/utils";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
+import { AxiosError } from "axios";
 
 const ReturnModal: React.FC<{
   lentType: string;
   closeModal: React.MouseEventHandler;
+  handleOpenPasswordCheckModal: Function;
 }> = (props) => {
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
@@ -71,6 +73,11 @@ const ReturnModal: React.FC<{
         throw error;
       }
     } catch (error: any) {
+      if (error.response.status === 418) {
+        props.closeModal(e);
+        props.handleOpenPasswordCheckModal();
+        return;
+      }
       setHasErrorOnResponse(true);
       setModalTitle(error.response.data.message);
     } finally {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1059

어디까지 내다 보신 겁니까 @SeyoungCho 님.... `renderAdditionalComponent` 이거 보고 식겁했습니다

기존 모달에서 수정한 것은 거의 없고 password props 추가하느라 새로운 파일로 만들었습니다.

인신님이 말씀하신대로 input태그를 숨겨놓고 div에 비밀번호를 보여주는 방식으로 제작했습니다.

input은 width:0, height:0, color:white로 안 보이게 숨겨놨습니다.

로컬 서버에서 `return-memo` api 호출 잘 되는 것 까지 확인했습니다.

dev로 올리고 모바일 환경 테스트 해봐야할 것 같습니다.
