### PR TITLE
[FE] BUG: 대여 시작 안 한 공유 사물함 기한 9999로 나오는 버그 수정 #1073

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -29,6 +29,15 @@ export interface ISelectedCabinetInfo {
   isAdmin: boolean;
   isLented: boolean;
 }
+//{selectedCabinetInfo!.expireDate
+//  ? `${selectedCabinetInfo!.expireDate.toString().substring(0, 10)}`
+//  : null}
+
+const setExprieDate = (date: Date | undefined) => {
+  if (!date) return null;
+  if (date.toString().slice(0, 4) === "9999") return null;
+  return date.toString().slice(0, 10);
+};
 
 const CabinetInfoArea: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
@@ -44,6 +53,7 @@ const CabinetInfoArea: React.FC<{
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
+  console.log("selectedCabinetInfo", selectedCabinetInfo);
 
   const handleOpenLentModal = () => {
     if (myCabinetId) return handleOpenUnavailableModal();
@@ -137,9 +147,7 @@ const CabinetInfoArea: React.FC<{
         {selectedCabinetInfo!.detailMessage}
       </CabinetLentDateInfoStyled>
       <CabinetLentDateInfoStyled textColor="var(--black)">
-        {selectedCabinetInfo!.expireDate
-          ? `${selectedCabinetInfo!.expireDate.toString().substring(0, 10)}`
-          : null}
+        {setExprieDate(selectedCabinetInfo!.expireDate)}
       </CabinetLentDateInfoStyled>
       {showUnavailableModal && (
         <UnavailableModal

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -29,9 +29,6 @@ export interface ISelectedCabinetInfo {
   isAdmin: boolean;
   isLented: boolean;
 }
-//{selectedCabinetInfo!.expireDate
-//  ? `${selectedCabinetInfo!.expireDate.toString().substring(0, 10)}`
-//  : null}
 
 const setExprieDate = (date: Date | undefined) => {
   if (!date) return null;
@@ -53,7 +50,6 @@ const CabinetInfoArea: React.FC<{
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
-  console.log("selectedCabinetInfo", selectedCabinetInfo);
 
   const handleOpenLentModal = () => {
     if (myCabinetId) return handleOpenUnavailableModal();


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1073

Lent DB를 조회 해봤을 때 어떤 공유사물함은 expire_time이 NULL이고, 어떤 사물함은 9999-12-31로 저장 되어 있었습니다.

따라서 expire_time이 NULL일 때와 사물함 반납 기한이 9999년일 때 표시 되지 않도록 수정하였습니다. 
