### PR TITLE
[COMMON] 어드민에서 검색 시 벤된 유저 UI 수정

### DIFF
--- a/frontend/src/components/Search/SearchItemByIntraId.tsx
+++ b/frontend/src/components/Search/SearchItemByIntraId.tsx
@@ -199,10 +199,10 @@ const NameWrapperStyled = styled.div`
 const IconStyled = styled.div<{ lent_type?: CabinetType }>`
   width: 18px;
   height: 28px;
-  background: url(${(props) =>
+  background-image: url((${(props) =>
       props.lent_type
         ? cabinetIconSrcMap[props.lent_type]
-        : cabinetIconSrcMap[CabinetType.PRIVATE]})
+        : cabinetIconSrcMap[CabinetType.PRIVATE]}))
     no-repeat center center / contain;
 `;
 

--- a/frontend/src/components/Search/SearchItemByIntraId.tsx
+++ b/frontend/src/components/Search/SearchItemByIntraId.tsx
@@ -106,7 +106,9 @@ const SearchItemByIntraId = (props: ISearchDetail) => {
       isSelected={currentIntraId === intra_id}
       onClick={clickSearchItem}
     >
-      <RectangleStyled>-</RectangleStyled>
+      <RectangleStyled banned={!!banned_date}>
+        {banned_date ? "!" : "-"}
+      </RectangleStyled>
       <TextWrapper>
         <LocationStyled>대여 중이 아닌 사용자</LocationStyled>
         <NameWrapperStyled>
@@ -146,15 +148,26 @@ const WrapperStyled = styled.div<{ isSelected: boolean }>`
   }
 `;
 
-const RectangleStyled = styled.div<{ status?: CabinetStatus }>`
+const RectangleStyled = styled.div<{
+  status?: CabinetStatus;
+  banned?: boolean;
+}>`
   width: 60px;
   height: 60px;
   border-radius: 10px;
   background-color: ${(props) =>
-    props.status ? cabinetStatusColorMap[props.status] : "var(--full)"};
+    props.banned
+      ? "var(--expired)"
+      : props.status
+      ? cabinetStatusColorMap[props.status]
+      : "var(--full)"};
   font-size: 26px;
   color: ${(props) =>
-    props.status ? cabinetLabelColorMap[props.status] : "var(--black)"};
+    props.banned
+      ? "var(--white)"
+      : props.status
+      ? cabinetLabelColorMap[props.status]
+      : "var(--black)"};
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1085

Close #1085 

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/72684256/235968838-b1225d00-b4c3-4f7d-a058-91c7edee1b9d.png">

기존에 벤 된 유저를 검색시 상세보기 영역에서만 ! + 빨간색 네모로 표시 되었으나, 검색 시에도 표시되도록 수정했습니다.

추가로, 검색 API에서 사용정지 정보(banned_date, unbanned_date)가 잘못 받아지는 버그가 있어서 sichoi 님과 함께 수정했습니다.

### [추가로 할 일]
공유 사물함으로 (대여 후 바로 반납 시)벤 된 유저의 경우, 개인 사물함을 빌릴 수 있어서 home의 사용정지 유저 표에서는 벤이라고 뜨나 실제로 검색해서 보면 개인 사물함을 사용하고 있는 유저들이 있습니다.
공유 사물함을 통해 벤 된 유저는 사용정지 유저에서 분리 또는 제외 하거나, 표시하는 방법을 다르게 해야 할 필요성이 보입니다.
