### PR TITLE
[BE] SPRING Test에서 @AuthGuard를 사용하는 경우 토큰을 Mocking하는 TestUtils 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.modelmapper:modelmapper:3.1.1'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/org/ftclub/cabinet/CabinetApplication.java
+++ b/backend/src/main/java/org/ftclub/cabinet/CabinetApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 public class CabinetApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(CabinetApplication.class, args);
 	}
 

--- a/backend/src/main/java/org/ftclub/cabinet/auth/AuthAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/AuthAspect.java
@@ -24,7 +24,7 @@ public class AuthAspect {
 
 	private final JwtProperties jwtProperties;
 
-	@Before(value = "@annotation(authGuard)")
+	@Before(value = "@annotation(authGuard) || @within(authGuard)")
 	public void AuthToken(AuthGuard authGuard) {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
 				.getRequest();

--- a/backend/src/main/java/org/ftclub/cabinet/auth/AuthAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/AuthAspect.java
@@ -6,8 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.ftclub.cabinet.config.JwtProperties;
+import org.ftclub.cabinet.exception.ControllerException;
 import org.ftclub.cabinet.exception.ExceptionStatus;
-import org.ftclub.cabinet.exception.ServiceException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -30,25 +30,25 @@ public class AuthAspect {
 				.getRequest();
 		String mainTokenName = jwtProperties.getMainTokenName();
 		String adminTokenName = jwtProperties.getAdminTokenName();
-
+		
 		switch (authGuard.level()) {
 			case ADMIN_ONLY:
 				if (!cookieManager.isCookieExists(request, adminTokenName)
 						|| !tokenValidator.isTokenValid(request)) {
-					throw new ServiceException(ExceptionStatus.UNAUTHORIZED);
+					throw new ControllerException(ExceptionStatus.UNAUTHORIZED_ADMIN);
 				}
 				break;
 			case USER_ONLY:
 				if (!cookieManager.isCookieExists(request, mainTokenName)
 						|| !tokenValidator.isTokenValid(request)) {
-					throw new ServiceException(ExceptionStatus.UNAUTHORIZED);
+					throw new ControllerException(ExceptionStatus.UNAUTHORIZED_USER);
 				}
 				break;
 			case USER_OR_ADMIN:
 				if ((!cookieManager.isCookieExists(request, mainTokenName)
 						&& !cookieManager.isCookieExists(request, adminTokenName))
 						|| !tokenValidator.isTokenValid(request)) {
-					throw new ServiceException(ExceptionStatus.UNAUTHORIZED);
+					throw new ControllerException(ExceptionStatus.UNAUTHORIZED);
 				}
 				break;
 		}

--- a/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
@@ -28,7 +28,6 @@ public class TokenProvider {
 		Map<String, Object> claims = new HashMap<>();
 		if (provider == googleApiProperties.getName()) {
 			claims.put("email", profile.get("email").toString());
-
 		}
 		if (provider == ftApiProperties.getName()) {
 			claims.put("name", profile.get("login").toString());

--- a/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
@@ -35,7 +35,7 @@ public class TokenProvider {
 			claims.put("email", profile.get("email").toString());
 			claims.put("blackholedAt", profile.getJSONArray("cursus_users")
 					.getJSONObject(1)
-					.get("blackholedAt"));
+					.get("blackholed_at"));
 			claims.put("role", UserRole.USER);
 		}
 		return claims;

--- a/backend/src/main/java/org/ftclub/cabinet/auth/TokenValidator.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/TokenValidator.java
@@ -4,10 +4,12 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import java.util.Base64;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ftclub.cabinet.config.JwtProperties;
+import org.json.JSONObject;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -44,5 +46,13 @@ public class TokenValidator {
 			log.info("JWT 토큰이 잘못되었습니다.");
 		}
 		return false;
+	}
+
+	public JSONObject getPayloadJson(final String token) {
+		final String payloadJWT = token.split("\\.")[1];
+		Base64.Decoder decoder = Base64.getUrlDecoder();
+
+		final String payload = new String(decoder.decode(payloadJWT));
+		return new JSONObject(payload);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/auth/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/User.java
@@ -1,0 +1,12 @@
+package org.ftclub.cabinet.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface User {
+
+}

--- a/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
@@ -8,6 +8,8 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.ftclub.cabinet.config.JwtProperties;
 import org.ftclub.cabinet.dto.UserSessionDto;
+import org.ftclub.cabinet.exception.ControllerException;
+import org.ftclub.cabinet.exception.ExceptionStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -30,6 +32,9 @@ public class UserAspect {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
 				.getRequest();
 		Object[] args = joinPoint.getArgs();
+		if (!args[0].getClass().equals(UserSessionDto.class)) {
+			throw new ControllerException(ExceptionStatus.INCORRECT_ARGUMENT);
+		}
 		args[0] = getUserSessionDtoByRequest(request);
 		return joinPoint.proceed(args);
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
@@ -31,9 +31,10 @@ public class UserAspect {
 			throws Throwable {
 		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
 				.getRequest();
+		//@User를 쓰려면 반드시 첫 매개변수에 UserSessionDto로 설정해주어야 함.
 		Object[] args = joinPoint.getArgs();
 		if (!args[0].getClass().equals(UserSessionDto.class)) {
-			throw new ControllerException(ExceptionStatus.INCORRECT_ARGUMENT);
+			throw new ControllerException(ExceptionStatus.INTERNAL_SERVER_ERROR);
 		}
 		args[0] = getUserSessionDtoByRequest(request);
 		return joinPoint.proceed(args);

--- a/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/UserAspect.java
@@ -1,0 +1,44 @@
+package org.ftclub.cabinet.auth;
+
+import java.util.Date;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.ftclub.cabinet.config.JwtProperties;
+import org.ftclub.cabinet.dto.UserSessionDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class UserAspect {
+
+	//private final UserMapper ...
+	//private final UserService ...
+	//컨트롤러가 아니므로 Facade를 주입받지는 않지만, 서비스와 매퍼를 주입받아서 UserSessionDto를 생성해 줌.
+	private final CookieManager cookieManager;
+	private final TokenValidator tokenValidator;
+	private final JwtProperties jwtProperties;
+
+	@Around("execution(* *(.., @User (*), ..))")
+	public Object setUserSessionDto(ProceedingJoinPoint joinPoint)
+			throws Throwable {
+		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+				.getRequest();
+		Object[] args = joinPoint.getArgs();
+		args[0] = getUserSessionDtoByRequest(request);
+		return joinPoint.proceed(args);
+	}
+
+	public UserSessionDto getUserSessionDtoByRequest(HttpServletRequest req) {
+		String name = tokenValidator.getPayloadJson(
+						cookieManager.getCookie(req, jwtProperties.getMainTokenName())).get("name")
+				.toString();
+		//To-Do: name을 기준으로 service에게 정보를 받고, 매핑한다.
+		return new UserSessionDto(1L, name, "userEmail", 1, 1, new Date(), true);
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/dto/UserSessionDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/UserSessionDto.java
@@ -6,18 +6,18 @@ import lombok.Getter;
 @Getter
 public class UserSessionDto extends UserDto {
 
-    private final Integer tokenIssuedAt;
-    private final Integer tokenExpiresAt;
-    private final Date blackHoledAt;
-    private final boolean isStaff;
+	private final Integer tokenIssuedAt;
+	private final Integer tokenExpiresAt;
+	private final Date blackHoledAt;
+	private final Boolean isStaff;
 
-    public UserSessionDto(Long userId, String name, String email,
-            Integer tokenIssuedAt, Integer tokenExpiresAt, Date blackHoledAt, boolean isStaff) {
-        super(userId, name, email);
-        this.tokenIssuedAt = tokenIssuedAt;
-        this.tokenExpiresAt = tokenExpiresAt;
-        this.blackHoledAt = blackHoledAt;
-        this.isStaff = isStaff;
-    }
+	public UserSessionDto(Long userId, String name, String email,
+			Integer tokenIssuedAt, Integer tokenExpiresAt, Date blackHoledAt, Boolean isStaff) {
+		super(userId, name, email);
+		this.tokenIssuedAt = tokenIssuedAt;
+		this.tokenExpiresAt = tokenExpiresAt;
+		this.blackHoledAt = blackHoledAt;
+		this.isStaff = isStaff;
+	}
 
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
@@ -24,13 +24,15 @@ public enum ExceptionStatus {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다"),
 	OAUTH_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "인증 서버와 통신 중 에러가 발생했습니다"),
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 정보가 유효하지 않습니다\\n다시 로그인해주세요"),
+	UNAUTHORIZED_ADMIN(HttpStatus.UNAUTHORIZED, "관리자 로그인 정보가 유효하지 않습니다\\n다시 로그인해주세요"),
+	UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "사용자 로그인 정보가 유효하지 않습니다\\n다시 로그인해주세요"),
 	UNCHANGEABLE_CABINET(HttpStatus.BAD_REQUEST, "사물함의 상태를 변경할 수 없습니다."),
 	LENT_ALREADY_EXISTED(HttpStatus.BAD_REQUEST, "이미 대여중인 사물함이 있습니다"),
 	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 입력입니다"),
 	INCORRECT_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
-    PRIVATE_BANNED_USER(HttpStatus.BAD_REQUEST, "PRIVATE 밴 상태의 유저입니다."),
-    PUBLIC_BANNED_USER(HttpStatus.BAD_REQUEST, "PUBLIC 밴 상태의 유저입니다."),
-    BLACKHOLED_USER(HttpStatus.BAD_REQUEST, "블랙홀 상태의 유저입니다.");
+	PRIVATE_BANNED_USER(HttpStatus.BAD_REQUEST, "PRIVATE 밴 상태의 유저입니다."),
+	PUBLIC_BANNED_USER(HttpStatus.BAD_REQUEST, "PUBLIC 밴 상태의 유저입니다."),
+	BLACKHOLED_USER(HttpStatus.BAD_REQUEST, "블랙홀 상태의 유저입니다.");
 
 	ExceptionStatus(HttpStatus status, String message) {
 		this.statusCode = status.value();

--- a/backend/src/test/java/org/ftclub/cabinet/auth/controller/AdminAuthControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/auth/controller/AdminAuthControllerTest.java
@@ -3,14 +3,11 @@ package org.ftclub.cabinet.auth.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.ftclub.cabinet.auth.AdminAuthController;
-import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest(properties = {"spring.config.location=classpath:application-oauth.yml"})
 @AutoConfigureMockMvc
@@ -18,12 +15,6 @@ public class AdminAuthControllerTest {
 
 	@Autowired
 	MockMvc mvc;
-
-	@Before
-	void setUp() {
-		mvc = MockMvcBuilders.standaloneSetup(AdminAuthController.class)
-				.build();
-	}
 
 	@Test
 	void 어드민_로그인_요청() throws Exception {

--- a/backend/src/test/java/org/ftclub/cabinet/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/auth/controller/AuthControllerTest.java
@@ -3,14 +3,11 @@ package org.ftclub.cabinet.auth.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.ftclub.cabinet.auth.AdminAuthController;
-import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest(properties = {"spring.config.location=classpath:application-oauth.yml"})
 @AutoConfigureMockMvc
@@ -18,13 +15,7 @@ public class AuthControllerTest {
 
 	@Autowired
 	MockMvc mvc;
-
-	@Before
-	void setUp() {
-		mvc = MockMvcBuilders.standaloneSetup(AdminAuthController.class)
-				.build();
-	}
-
+	
 	@Test
 	void 유저_로그인_요청() throws Exception {
 		//리디렉션 302

--- a/backend/src/test/java/org/ftclub/cabinet/auth/domain/TokenProviderTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/auth/domain/TokenProviderTest.java
@@ -49,7 +49,7 @@ public class TokenProviderTest {
 				ftProfile);
 
 		Assertions.assertEquals(googleEmail, googleClaims.get("email"));
-		Assertions.assertEquals(ftIntraId, ftClaims.get("intra_id"));
+		Assertions.assertEquals(ftIntraId, ftClaims.get("name"));
 		Assertions.assertEquals(ftEmail, ftClaims.get("email"));
 		Assertions.assertEquals(UserRole.USER, ftClaims.get("role"));
 	}

--- a/backend/src/test/java/org/ftclub/cabinet/auth/domain/TokenValidatorTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/auth/domain/TokenValidatorTest.java
@@ -3,7 +3,9 @@ package org.ftclub.cabinet.auth.domain;
 import java.util.Date;
 import org.ftclub.cabinet.auth.TokenProvider;
 import org.ftclub.cabinet.auth.TokenValidator;
+import org.ftclub.cabinet.config.JwtProperties;
 import org.ftclub.cabinet.utils.DateUtil;
+import org.ftclub.testutils.TestControllerUtils;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,9 @@ public class TokenValidatorTest {
 
 	@Autowired
 	TokenProvider tokenProvider;
+
+	@Autowired
+	JwtProperties jwtProperties;
 
 	@Test
 	void 헤더의_토큰_유효한지_아닌지() {
@@ -49,5 +54,11 @@ public class TokenValidatorTest {
 
 		Assert.assertEquals(true, tokenValidator.checkTokenValidity(validToken));
 		Assert.assertEquals(false, tokenValidator.checkTokenValidity(invalidToken));
+	}
+
+	@Test
+	void 토큰_페이로드_가져오기() {
+		String userToken = TestControllerUtils.getTestUserToken(jwtProperties.getSigningKey());
+		Assert.assertEquals("testUserName", tokenValidator.getPayloadJson(userToken).get("name"));
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/AdminCabinetControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/AdminCabinetControllerTest.java
@@ -1,7 +1,6 @@
 package org.ftclub.cabinet.cabinet.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.ftclub.testutils.TestControllerUtils.mockRequest;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,13 +9,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 import org.ftclub.cabinet.cabinet.domain.CabinetStatus;
+import org.ftclub.cabinet.config.JwtProperties;
+import org.ftclub.testutils.TestControllerUtils;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -28,37 +32,52 @@ public class AdminCabinetControllerTest {
 	@Autowired
 	MockMvc mvc;
 
+	@Autowired
+	JwtProperties jwtProperties;
+
+	String adminToken;
+	Cookie cookie;
+
 	@Before
 	void setUp() {
-		mvc = MockMvcBuilders.standaloneSetup(CabinetController.class)
+		mvc = MockMvcBuilders.standaloneSetup(AdminCabinetController.class)
 				.build();
+	}
+
+	@BeforeEach
+	void setToken() {
+		adminToken = TestControllerUtils.getTestAdminToken(jwtProperties.getSigningKey());
+		cookie = TestControllerUtils.getTokenCookie("관리자", adminToken);
 	}
 
 	@Test
 	void 사물함_정보_가져오기() throws Exception {
 		//정상 입력
-		mvc.perform(get("/api/admin/cabinets/{cabinetId}", 1))
+		mvc.perform(mockRequest(HttpMethod.GET, cookie,
+						"/api/admin/cabinets/{cabinetId}", 1))
 				.andExpect(status().isOk());
 
 		//잘못된 입력
-		mvc.perform(get("/api/admin/cabinets/{cabinetId}", "사십이"))
+		mvc.perform(mockRequest(HttpMethod.GET, cookie,
+						"/api/admin/cabinets/{cabinetId}", "사십이"))
 				.andExpect(status().isBadRequest());
-
 	}
 
 	@Test
 	void 사물함_상태_업데이트() throws Exception {
-
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/status/{status}",
 						1, "AVAILABLE"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/status/{status}",
 						1, "NONE_EXISTS"))
 				.andExpect(status().isBadRequest());
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/status/{status}",
 						"사십이", CabinetStatus.AVAILABLE))
 				.andExpect(status().isBadRequest());
 	}
@@ -66,15 +85,18 @@ public class AdminCabinetControllerTest {
 	@Test
 	void 사물함_대여_타입_업데이트() throws Exception {
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
 						1, "PRIVATE"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
 						1, "NONE_EXISTS"))
 				.andExpect(status().isBadRequest());
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie,
+						"/api/admin/cabinets/{cabinetId}/lent-types/{lentType}",
 						"사십이", "PRVIATE"))
 				.andExpect(status().isBadRequest());
 	}
@@ -89,24 +111,27 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status-note",
-						1)
-						.content(rightRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/status-note",
+								1)
+								.content(rightRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status-note",
-						1)
-						.content(wrongRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/status-note",
+								1)
+								.content(wrongRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		// 빈 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/status-note",
-						1)
-						.content(emptyRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/status-note",
+								1)
+								.content(emptyRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 	}
 
@@ -120,21 +145,21 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/title",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/title",
 						1)
 						.content(rightRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/title",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/title",
 						1)
 						.content(wrongRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		// 빈 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/title",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/title",
 						1)
 						.content(emptyRequestBody)
 						.contentType("application/json"))
@@ -153,21 +178,21 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/grid",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/grid",
 						1)
 						.content(rightRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/grid",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/grid",
 						1)
 						.content(wrongRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		//빈 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/grid",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/grid",
 						1)
 						.content(emptyRequestBody)
 						.contentType("application/json"))
@@ -184,24 +209,27 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/visible-num",
-						1)
-						.content(rightRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/visible-num",
+								1)
+								.content(rightRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/visible-num",
-						1)
-						.content(wrongRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/visible-num",
+								1)
+								.content(wrongRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		// 빈 입력
-		mvc.perform(patch("/api/admin/cabinets/{cabinetId}/visible-num",
-						1)
-						.content(emptyRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/{cabinetId}/visible-num",
+								1)
+								.content(emptyRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 	}
 
@@ -216,27 +244,27 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/status/{status}",
 						"AVAILABLE")
 						.content(rightRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/status/{status}",
 						"AVAILABLE")
 						.content(wrongRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
-		mvc.perform(patch("/api/admin/cabinets/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/status/{status}",
 						"WRONG_STATUS")
 						.content(rightRequestBody)
 						.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		// 빈 입력
-		mvc.perform(patch("/api/admin/cabinets/status/{status}",
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/status/{status}",
 						"AVAILABLE")
 						.content(emptyRequestBody)
 						.contentType("application/json"))
@@ -254,30 +282,34 @@ public class AdminCabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		// 정상 입력
-		mvc.perform(patch("/api/admin/cabinets/lent-types/{lentType}",
-						"SHARE")
-						.content(rightRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/lent-types/{lentType}",
+								"SHARE")
+								.content(rightRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isOk());
 
 		// 잘못된 입력
-		mvc.perform(patch("/api/admin/cabinets/lent-types/{lentType}",
-						"SHARE")
-						.content(wrongRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/lent-types/{lentType}",
+								"SHARE")
+								.content(wrongRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
-		mvc.perform(patch("/api/admin/cabinets/lent-types/{lentType}",
-						"WRONG_TYPE")
-						.content(rightRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/lent-types/{lentType}",
+								"WRONG_TYPE")
+								.content(rightRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 
 		// 빈 입력
-		mvc.perform(patch("/api/admin/cabinets/lent-types/{lentType}",
-						"SHARE")
-						.content(emptyRequestBody)
-						.contentType("application/json"))
+		mvc.perform(
+						mockRequest(HttpMethod.PATCH, cookie, "/api/admin/cabinets/lent-types/{lentType}",
+								"SHARE")
+								.content(emptyRequestBody)
+								.contentType("application/json"))
 				.andExpect(status().isBadRequest());
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/AdminCabinetControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/AdminCabinetControllerTest.java
@@ -14,7 +14,6 @@ import javax.transaction.Transactional;
 import org.ftclub.cabinet.cabinet.domain.CabinetStatus;
 import org.ftclub.cabinet.config.JwtProperties;
 import org.ftclub.testutils.TestControllerUtils;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +21,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,12 +35,6 @@ public class AdminCabinetControllerTest {
 
 	String adminToken;
 	Cookie cookie;
-
-	@Before
-	void setUp() {
-		mvc = MockMvcBuilders.standaloneSetup(AdminCabinetController.class)
-				.build();
-	}
 
 	@BeforeEach
 	void setToken() {

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/CabinetControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/CabinetControllerTest.java
@@ -10,7 +10,6 @@ import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 import org.ftclub.cabinet.config.JwtProperties;
 import org.ftclub.testutils.TestControllerUtils;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -33,12 +31,6 @@ public class CabinetControllerTest {
 
 	String userToken;
 	Cookie cookie;
-
-	@Before
-	void setUp() {
-		mvc = MockMvcBuilders.standaloneSetup(CabinetController.class)
-				.build();
-	}
 
 	@BeforeEach
 	void setToken() {

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/CabinetControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/controller/CabinetControllerTest.java
@@ -1,18 +1,22 @@
 package org.ftclub.cabinet.cabinet.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.ftclub.testutils.TestControllerUtils.mockRequest;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.Map;
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
+import org.ftclub.cabinet.config.JwtProperties;
+import org.ftclub.testutils.TestControllerUtils;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -24,28 +28,43 @@ public class CabinetControllerTest {
 	@Autowired
 	MockMvc mvc;
 
+	@Autowired
+	JwtProperties jwtProperties;
+
+	String userToken;
+	Cookie cookie;
+
 	@Before
 	void setUp() {
 		mvc = MockMvcBuilders.standaloneSetup(CabinetController.class)
 				.build();
 	}
 
+	@BeforeEach
+	void setToken() {
+		userToken = TestControllerUtils.getTestUserToken(jwtProperties.getSigningKey());
+		cookie = TestControllerUtils.getTokenCookie("사용자", userToken);
+	}
+
 	@Test
 	void 건물_층_정보_가져오기() throws Exception {
 		//항상 정상 입력
-		mvc.perform(get("/api/cabinets/buildings/floors"))
+		mvc.perform(mockRequest(HttpMethod.GET, cookie,
+						"/api/cabinets/buildings/floors"))
 				.andExpect(status().isOk());
 	}
 
 	@Test
 	void 구역별_사물함_가져오기() throws Exception {
 		//정상 입력
-		mvc.perform(get("/api/cabinets/buildings/{building}/floors/{floor}",
+		mvc.perform(mockRequest(HttpMethod.GET, cookie,
+						"/api/cabinets/buildings/{building}/floors/{floor}",
 						"새롬관", 2))
 				.andExpect(status().isOk());
 
 		//잘못된 입력
-		mvc.perform(get("/api/cabinets/buildings/{building}/floors/{floor}",
+		mvc.perform(mockRequest(HttpMethod.GET, cookie,
+						"/api/cabinets/buildings/{building}/floors/{floor}",
 						42, "포티투"))
 				.andExpect(status().isBadRequest());
 	}
@@ -53,13 +72,17 @@ public class CabinetControllerTest {
 	@Test
 	void 사물함_정보_가져오기() throws Exception {
 		//정상 입력
-		mvc.perform(get("/api/cabinets/{cabinetId}", 1))
+		mvc.perform(
+						mockRequest(HttpMethod.GET, cookie, "/api/cabinets/{cabinetId}",
+								1))
 				.andExpect(status().isOk());
 
 		//잘못된 입력
-		mvc.perform(get("/api/cabinets/{cabinetId}", "사십이"))
+		mvc.perform(
+						mockRequest(HttpMethod.GET, cookie, "/api/cabinets/{cabinetId}",
+								"사십이"))
 				.andExpect(status().isBadRequest());
-		
+
 	}
 
 	@Test
@@ -72,19 +95,19 @@ public class CabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		//정상 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/title", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/title", 1)
 						.contentType("application/json")
 						.content(rightRequestBody))
 				.andExpect(status().isOk());
 
 		//잘못된 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/title", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/title", 1)
 						.contentType("application/json")
 						.content(wrongRequestBody))
 				.andExpect(status().isBadRequest());
 
 		//빈 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/title", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/title", 1)
 						.contentType("application/json")
 						.content(emptyRequestBody))
 				.andExpect(status().isBadRequest());
@@ -100,19 +123,19 @@ public class CabinetControllerTest {
 		String emptyRequestBody = new ObjectMapper().writeValueAsString(emptyRequest);
 
 		//정상 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/memo", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/memo", 1)
 						.contentType("application/json")
 						.content(rightRequestBody))
 				.andExpect(status().isOk());
 
 		//잘못된 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/memo", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/memo", 1)
 						.contentType("application/json")
 						.content(wrongRequestBody))
 				.andExpect(status().isBadRequest());
 
 		//빈 입력
-		mvc.perform(patch("/api/cabinets/{cabinetId}/memo", 1)
+		mvc.perform(mockRequest(HttpMethod.PATCH, cookie, "/api/cabinets/{cabinetId}/memo", 1)
 						.contentType("application/json")
 						.content(emptyRequestBody))
 				.andExpect(status().isBadRequest());

--- a/backend/src/test/java/org/ftclub/testutils/TestControllerUtils.java
+++ b/backend/src/test/java/org/ftclub/testutils/TestControllerUtils.java
@@ -1,0 +1,78 @@
+package org.ftclub.testutils;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.Cookie;
+import org.ftclub.cabinet.user.domain.UserRole;
+import org.ftclub.cabinet.utils.DateUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class TestControllerUtils {
+
+	public static String getTestAdminToken(Key signingKey) {
+		Map<String, Object> claim = new HashMap<>();
+		claim.put("email", "test@gmail.com");
+		return Jwts.builder()
+				.setClaims(claim)
+				.signWith(signingKey, SignatureAlgorithm.HS256)
+				.setExpiration(DateUtil.addDaysToDate(new Date(), 10))
+				.compact();
+	}
+
+	public static String getTestUserToken(Key signingKey) {
+		Map<String, Object> claim = new HashMap<>();
+		claim.put("name", "testUserName");
+		claim.put("email", "test@student.42seoul.kr");
+		claim.put("blackholedAt", new Date());
+		claim.put("role", UserRole.USER);
+		return Jwts.builder()
+				.setClaims(claim)
+				.signWith(signingKey, SignatureAlgorithm.HS256)
+				.setExpiration(DateUtil.addDaysToDate(new Date(), 10))
+				.compact();
+	}
+
+	public static Cookie getTokenCookie(String role, String token) {
+		String tokenName;
+		if (role.equals("관리자")) {
+			tokenName = "admin_access_token";
+		} else if (role.equals("사용자")) {
+			tokenName = "access_token";
+		} else {
+			tokenName = "invalid_token";
+		}
+		return new Cookie(tokenName, token);
+	}
+
+	public static MockHttpServletRequestBuilder mockRequest(HttpMethod method, Cookie cookie,
+			String url, Object... uriVars) {
+		if (method.equals(HttpMethod.GET)) {
+			return MockMvcRequestBuilders.get(url, uriVars)
+					.cookie(cookie)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + cookie.getValue());
+		}
+		if (method.equals(HttpMethod.POST)) {
+			return MockMvcRequestBuilders.post(url, uriVars)
+					.cookie(cookie)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + cookie.getValue());
+		}
+		if (method.equals(HttpMethod.PATCH)) {
+			return MockMvcRequestBuilders.patch(url, uriVars)
+					.cookie(cookie)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + cookie.getValue());
+		}
+		if (method.equals(HttpMethod.DELETE)) {
+			return MockMvcRequestBuilders.delete(url, uriVars)
+					.cookie(cookie)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + cookie.getValue());
+		}
+		throw new RuntimeException("Invalid HTTP Method Type!!!!!!!!");
+	}
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [X] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

변경 사항

1. AuthGuard에 따라 AuthAspect에서 컨트롤러 클래스에 어노테이션을 붙이는 경우 잘 작동하지 않던 점을 수정했습니다.
-> 메서드, 컨트롤러 클래스 자체에서의 우선순위를 구조적으로 둘 수 없어서, 만약 메서드 별로 AuthLevel을 다르게 설정하시려면 모든 메서드에 별개로 달아주셔야 하고, 아니면 컨트롤러 전체에 적용하는 하나의 어노테이션만 사용할 수 있습니다.

2. @AuthGuard를 사용하고 있는 어플리케이션 컨텍스트를 그대로 가져와 테스트하는 방식이므로, AuthGuard를 통과할 수 있는 토큰이 있어야 컨트롤러의 작동 여부를 제대로 확인할 수 있었습니다. 따라서, TestControllerUtils 클래스를 생성하였는데, 가지고 있는 메서드는
어드민 토큰, 유저 토큰, 쿠키 만들기, MockServletRequestBuilder를 이용한 메서드 별 저희 서비스의 인증 방식(헤더에 토큰을 담아서 요청 + 쿠키에 토큰이 있는지 확인)에 맞추어 요청을 보낼 수 있는 mockRequest(사실상 빌더) 메서드를 만들어 놨습니다.

사용법은 다음과 같습니다.
컨트롤러 테스트 클래스에 JwtProperties를 @Autowired로 주입합니다 - Utils 클래스에서 주입을 하는 방법을 모르겠어서 이렇게 했습니다.
사용하고자 하는 token, cookie를 선언하고, @BeforeEach에서 TestControllerUtils를 통해 set합니다.
mvc를 통해 perform할 때, mockRequest(HTTP 메서드, 쿠키, uri, uri 변수들)을 입력하여 요청하시면 됩니다.

마땅한 방법이 떠오르지 않았고, 레퍼런스를 잘 찾지 못해서 일단 되는대로 작동하게 해놨습니다. 더 좋은 방법이 있다면 알려주세요!
