### PR TITLE
[BE] BUG: 인트라 로그인 시 토큰 생성 오류 수정

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/TokenProvider.java
@@ -21,50 +21,53 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TokenProvider {
 
-	private final JwtProperties jwtProperties;
+    private final JwtProperties jwtProperties;
 
-	private final GoogleApiProperties googleApiProperties;
+    private final GoogleApiProperties googleApiProperties;
 
-	private final FtApiProperties ftApiProperties;
+    private final FtApiProperties ftApiProperties;
 
-	/**
-	 * JWT 토큰에 담을 클레임(Payload)을 생성합니다.
-	 *
-	 * @param provider API 제공자 이름
-	 * @param profile  API 제공자로부터 받은 프로필
-	 * @return JWT 클레임(Payload)
-	 */
-	public Map<String, Object> makeClaims(String provider, JSONObject profile) {
-		Map<String, Object> claims = new HashMap<>();
-		if (provider == googleApiProperties.getName()) {
-			claims.put("email", profile.get("email").toString());
-		}
-		if (provider == ftApiProperties.getName()) {
-			claims.put("name", profile.get("login").toString());
-			claims.put("email", profile.get("email").toString());
-			claims.put("blackholedAt", profile.getJSONArray("cursus_users")
-					.getJSONObject(1)
-					.get("blackholed_at"));
-			claims.put("role", UserRole.USER);
-		}
-		return claims;
-	}
+    /**
+     * JWT 토큰에 담을 클레임(Payload)을 생성합니다.
+     *
+     * @param provider API 제공자 이름
+     * @param profile  API 제공자로부터 받은 프로필
+     * @return JWT 클레임(Payload)
+     */
+    public Map<String, Object> makeClaims(String provider, JSONObject profile) {
+        Map<String, Object> claims = new HashMap<>();
+        if (provider == googleApiProperties.getName()) {
+            claims.put("email", profile.get("email").toString());
+        }
+        if (provider == ftApiProperties.getName()) {
+            claims.put("name", profile.get("login").toString());
+            claims.put("email", profile.get("email").toString());
+            claims.put("blackholedAt", profile.getJSONArray("cursus_users")
+                    .getJSONObject(1)
+                    .get("blackholed_at") != JSONObject.NULL ?
+                    profile.getJSONArray("cursus_users")
+                            .getJSONObject(1)
+                            .get("blackholed_at") : null);
+            claims.put("role", UserRole.USER);
+        }
+        return claims;
+    }
 
-	/**
-	 * JWT 토큰을 생성합니다.
-	 *
-	 * @param provider API 제공자 이름
-	 * @param profile  API 제공자로부터 받은 프로필
-	 * @param now      현재 시각
-	 * @return JWT 토큰
-	 */
-	public String createToken(String provider, JSONObject profile, Date now) {
-		return Jwts.builder()
-				.setClaims(makeClaims(provider, profile))
-				.signWith(jwtProperties.getSigningKey(), SignatureAlgorithm.HS256)
-				.setExpiration(DateUtil.addDaysToDate(now, jwtProperties.getExpiry()))
-				.compact();
-	}
+    /**
+     * JWT 토큰을 생성합니다.
+     *
+     * @param provider API 제공자 이름
+     * @param profile  API 제공자로부터 받은 프로필
+     * @param now      현재 시각
+     * @return JWT 토큰
+     */
+    public String createToken(String provider, JSONObject profile, Date now) {
+        return Jwts.builder()
+                .setClaims(makeClaims(provider, profile))
+                .signWith(jwtProperties.getSigningKey(), SignatureAlgorithm.HS256)
+                .setExpiration(DateUtil.addDaysToDate(now, jwtProperties.getExpiry()))
+                .compact();
+    }
 
 
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

블랙홀 날짜가 `JSONObject.NULL`인 경우에 claims에 `JSONObject.NULL`가 아닌 null를 담도록 수정했습니다.

P.S
```
{
  "role": "USER",
  "name": "sichoi",
  "email": "sichoi@student.42seoul.kr",
  "exp": 1686491036
}
```
이렇게 하니까 생성된 토큰에는 아예 `blackholedAt` 필드가 포함되지 않네요....
`io.jsonwebtoken.Jwts` 라이브러리에서 null인 키값은 토큰에 포함되지 않도록 하는게 아닐까합니다..!
추후에 `UserSessionDto`에 토큰에 저장된 블랙홀 정보를 얻으려고 시도하는 경우에 버그가 발생할 수 있을 것 같아 메모 남겨둡니다.

https://github.com/innovationacademy-kr/42cabi/issues/1103
