### PR TITLE
[FE] FEAT: 타 사물함 대여 잔여일 표시#1106

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -47,6 +47,7 @@ const getDetailMessage = (selectedCabinetInfo: CabinetInfo): string | null => {
   else if (lent_type === "CLUB") return "동아리 사물함";
   // 사용 중 사물함
   else if (
+    status === CabinetStatus.SET_EXPIRE_AVAILABLE ||
     status === CabinetStatus.SET_EXPIRE_FULL ||
     status === CabinetStatus.EXPIRED
   )

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -52,6 +52,11 @@ const CabinetInfoArea: React.FC<{
   const isMine: boolean = myCabinetId
     ? selectedCabinetInfo?.cabinetId === myCabinetId
     : false;
+  const isAvailable: boolean =
+    selectedCabinetInfo?.status === "AVAILABLE" ||
+    selectedCabinetInfo?.status === "SET_EXPIRE_AVAILABLE"
+      ? true
+      : false;
 
   const handleOpenLentModal = () => {
     if (myCabinetId) return handleOpenUnavailableModal();
@@ -140,6 +145,7 @@ const CabinetInfoArea: React.FC<{
               onClick={handleOpenLentModal}
               text="대여"
               theme="fill"
+              disabled={isAvailable ? false : true}
             />
             <ButtonContainer onClick={closeCabinet} text="취소" theme="line" />
           </>

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -56,16 +56,6 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
     cabinetLabelText = "사용불가";
   }
 
-  const handleOpenUnavailableModal = () => {
-    if (
-      props.status === "BANNED" ||
-      props.status === "BROKEN" ||
-      props.status === "SET_EXPIRE_FULL" ||
-      props.status === "EXPIRED"
-    )
-      setShowUnavailableModal(true);
-  };
-
   const handleCloseUnavailableModal = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     setShowUnavailableModal(false);
@@ -76,12 +66,6 @@ const CabinetListItem = (props: CabinetInfo): JSX.Element => {
       closeCabinet();
       return;
     }
-    if (
-      !isMine &&
-      status !== CabinetStatus.AVAILABLE &&
-      status !== CabinetStatus.SET_EXPIRE_AVAILABLE
-    )
-      return handleOpenUnavailableModal();
 
     setCurrentCabinetId(cabinetId);
     async function getData(cabinetId: number) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> https://github.com/innovationacademy-kr/42cabi/issues/1106

타 사물함 선택 시 이용 중인 사용자와 대여 잔여일을 확인할 수 있도록 하였습니다. 기존에는 SET_EXPIRE_AVAILABLE 상태에서 대여 잔여일이 표시가 안 되었는데, 확인할 수 있도록 수정했습니다.

<img width="294" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/101867295/87458e6f-699c-487b-b972-18e0b01a9a3d">
<img width="261" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/101867295/6d6ca8f1-2b1b-4427-b3ea-fda6aaac2b2f">
 
Closes #1106 
