### PR TITLE
[BE] BUG: JPQL @Param 추가

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
@@ -7,6 +7,7 @@ import org.ftclub.cabinet.cabinet.domain.CabinetPlace;
 import org.ftclub.cabinet.cabinet.domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,7 +17,7 @@ public interface CabinetRepository extends JpaRepository<Cabinet, Long> {
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE p.location.building = :building")
-	Optional<List<Integer>> findAllFloorsByBuilding(String building);
+	Optional<List<Integer>> findAllFloorsByBuilding(@Param("building") String building);
 
 	@Query("SELECT DISTINCT p.location.building "
 			+ "FROM Cabinet c "
@@ -27,24 +28,26 @@ public interface CabinetRepository extends JpaRepository<Cabinet, Long> {
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE p.location.building = :building AND p.location.floor = :floor")
-	Optional<List<String>> findAllSectionsByBuildingAndFloor(String building, Integer floor);
+	Optional<List<String>> findAllSectionsByBuildingAndFloor(
+			@Param("building") String building,
+			@Param("floor") Integer floor);
 
 	@Query("SELECT c.cabinetId "
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE p.location.section = :section")
-	Optional<List<Long>> findAllCabinetIdsBySection(String section);
+	Optional<List<Long>> findAllCabinetIdsBySection(@Param("section") String section);
 
 
 	@Query("SELECT c.statusNote "
 			+ "FROM Cabinet c ")
-	Optional<String> findStatusNoteById(Long cabinetId);
+	Optional<String> findStatusNoteById(@Param("cabinetId") Long cabinetId);
 
 	@Query("SELECT p.location "
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE c.cabinetId = :cabinetId")
-	Optional<Location> findLocationById(Long cabinetId);
+	Optional<Location> findLocationById(@Param("cabinetId") Long cabinetId);
 
 
 	@Query(value = "SELECT AUTO_INCREMENT "
@@ -57,18 +60,22 @@ public interface CabinetRepository extends JpaRepository<Cabinet, Long> {
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE p.location = :location")
-	Optional<CabinetPlace> findCabinetPlaceByLocation(Location location);
+	Optional<CabinetPlace> findCabinetPlaceByLocation(@Param("location") Location location);
 
 	@Query("SELECT c "
 			+ "FROM Cabinet c "
 			+ "JOIN c.cabinetPlace p "
 			+ "WHERE p.location.building = :building AND p.location.floor = :floor AND p.location.section = :section")
-	Optional<List<Cabinet>> findAllByBuildingAndFloorAndSection(String building, Integer floor,
-			String section);
+	Optional<List<Cabinet>> findAllByBuildingAndFloorAndSection(
+			@Param("building") String building,
+			@Param("floor") Integer floor,
+			@Param("section") String section);
 
 	@Query("SELECT COUNT(p.location.building) > 0 " +
 			"FROM Cabinet c " +
 			"JOIN c.cabinetPlace p " +
 			"WHERE p.location.building = :building AND p.location.floor = :floor")
-	boolean existsBuildingAndFloor(String building, Integer floor);
+	boolean existsBuildingAndFloor(
+			@Param("building") String building,
+			@Param("floor") Integer floor);
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -6,6 +6,7 @@ import org.ftclub.cabinet.lent.domain.LentHistory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -20,7 +21,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param cabinetId 찾으려는 cabinet id
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link Optional}
 	 */
-	Optional<LentHistory> findFirstByCabinetIdAndEndedAtIsNull(Long cabinetId);
+	Optional<LentHistory> findFirstByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
 
 	/**
 	 * 유저를 기준으로 아직 반납하지 않은 {@link LentHistory}중 하나를 가져옵니다.
@@ -28,7 +29,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param userId 찾으려는 user id
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link Optional}
 	 */
-	Optional<LentHistory> findFirstByUserIdAndEndedAtIsNull(Long userId);
+	Optional<LentHistory> findFirstByUserIdAndEndedAtIsNull(@Param("userId") Long userId);
 
 	/**
 	 * 유저가 지금까지 빌렸던 {@link LentHistory}들을 가져옵니다. {@link Pageable}이 적용되었습니다.
@@ -37,7 +38,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param pageable pagination 정보
 	 * @return {@link LentHistory}들의 정보
 	 */
-	List<LentHistory> findByUserId(Long userId, Pageable pageable);
+	List<LentHistory> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
 	/**
 	 * 캐비넷의 {@link LentHistory}들을 가져옵니다. {@link Pageable}이 적용되었습니다.
@@ -46,7 +47,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param pageable  pagination 정보
 	 * @return {@link LentHistory}들의 정보
 	 */
-	List<LentHistory> findByCabinetId(Long cabinetId, Pageable pageable);
+	List<LentHistory> findByCabinetId(@Param("cabinetId") Long cabinetId, Pageable pageable);
 
 	/**
 	 * 유저가 빌리고 있는 사물함의 개수를 가져옵니다.
@@ -57,7 +58,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
 			"WHERE lh.endedAt = null and lh.userId = :userId")
-	int countUserActiveLent(Long userId);
+	int countUserActiveLent(@Param("userId") Long userId);
 
 	/**
 	 * 사물함을 빌리고 있는 유저의 수를 가져옵니다.
@@ -68,7 +69,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
 			"WHERE lh.endedAt = null and lh.cabinetId = :cabinetId")
-	int countCabinetActiveLent(Long cabinetId);
+	int countCabinetActiveLent(@Param("cabinetId") Long cabinetId);
 
 	/**
 	 * 유저가 지금까지 빌렸던 사물함의 개수를 가져옵니다.
@@ -79,7 +80,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
 			"WHERE lh.userId = :userId")
-	int countUserAllLent(Long userId);
+	int countUserAllLent(@Param("userId") Long userId);
 
 	/**
 	 * 사물함을 빌렸던 유저의 수를 가져옵니다.
@@ -90,7 +91,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT count(lh)" +
 			"FROM LentHistory lh " +
 			"WHERE lh.cabinetId = :cabinetId")
-	int countCabinetAllLent(Long cabinetId);
+	int countCabinetAllLent(@Param("cabinetId") Long cabinetId);
 
 
 	/**
@@ -102,5 +103,5 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT lh " +
 			"FROM LentHistory lh " +
 			"WHERE lh.cabinetId = :cabinetId and lh.endedAt is null")
-	List<LentHistory> findAllActiveLentByCabinetId(Long cabinetId);
+	List<LentHistory> findAllActiveLentByCabinetId(@Param("cabinetId") Long cabinetId);
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/BanHistoryRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/BanHistoryRepository.java
@@ -15,14 +15,15 @@ import org.springframework.stereotype.Repository;
 public interface BanHistoryRepository extends JpaRepository<BanHistory, Long> {
 
 	@Query("SELECT b FROM BanHistory b WHERE b.userId = :userId AND b.unbannedAt > :today")
-	List<BanHistory> findUserActiveBanList(@Param("userId") Long userId,
+	List<BanHistory> findUserActiveBanList(
+			@Param("userId") Long userId,
 			@Param("today") Date today);
 
 	@Query("SELECT b FROM BanHistory b WHERE b.userId = :userId")
 	List<BanHistory> findBanHistoriesByUserId(@Param("userId") Long userId);
 
 	@Query("SELECT b FROM BanHistory b WHERE b.unbannedAt > :today ")
-	Page<BanHistory> findActiveBanList(Pageable pageable, Date today);
+	Page<BanHistory> findActiveBanList(Pageable pageable, @Param("today") Date today);
 
 	@Query("SELECT b FROM BanHistory b WHERE b.unbannedAt = (SELECT MAX(b2.unbannedAt) FROM BanHistory b2) AND b.userId = :userId")
 	Optional<BanHistory> findRecentBanHistoryByUserId(@Param("userId") Long userId);

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,14 +15,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT lh.name " +
 			"FROM User lh " +
 			"WHERE lh.userId = :userId")
-	String findNameById(Long userId);
+	String findNameById(@Param("userId") Long userId);
 
 	@Query("SELECT u FROM User u WHERE u.userId = :userId")
-	User getUser(Long userId);
+	User getUser(@Param("userId") Long userId);
 
 	@Query("SELECT u FROM User u WHERE u.name = :name")
-	Optional<User> findByName(String name);
+	Optional<User> findByName(@Param("name") String name);
 
 	@Query("SELECT u FROM User u WHERE u.name LIKE %:name%")
-	Page<User> findByPartialName(String name, Pageable pageable);
+	Page<User> findByPartialName(@Param("name") String name, Pageable pageable);
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

기존의 JPQL의 parameter를 사용할 시에 명시하지 않은 @Param으로 인하여 JPA가 제대로 쿼리를 수행하지 못하는 문제가 발생하였습니다.

```
org.springframework.dao.InvalidDataAccessApiUsageException: For queries with named parameters you need to provide names for method parameters; Use @Param for query method parameters, or when on Java 8+ use the javac flag -parameters; nested exception is java.lang.IllegalStateException: For queries with named parameters you need to provide names for method parameters; Use @Param for query method parameters, or when on Java 8+ use the javac flag -parameters
```

해결 방법은 @Param을 통해 명시하거나, ?1과 같은 파라미터 인덱스를 지정하거나, 컴파일 시에 -parameters 플래그를 추가하는 것이었고, 제 경우에는 앞의 두가지 방법은 해결할 수 있었으나 세번째 방법은 해결되지 못했습니다.
?1 과 같이 파라미터의 인덱스를 지정하면 파라미터 순서에 의존하게 된다는 문제가 있을 수 있을 것 같고, 명시적인 변수 사용을 위해서 @Param으로 변경하였습니다. 

+ @eunbi9n 이 브랜치를 기준으로 userFacadeServiceTest에서 깨지는 케이스가 있는데 한번 확인해주시고 수정 부탁드립니다..!