### PR TITLE
[FE] FEAT/FIX: Admin 로그인 실패 시 모달 추가 및 사파리 admin 로그인 폼 수정 #1109

### DIFF
--- a/backend/src/admin/auth/auth.controller.ts
+++ b/backend/src/admin/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -7,10 +8,8 @@ import {
   Inject,
   Logger,
   Post,
-  Redirect,
   Req,
   Res,
-  UnauthorizedException,
   UseFilters,
   UseGuards,
   ValidationPipe,
@@ -63,7 +62,7 @@ export class AdminAuthController {
     @Res() res: Response,
   ): Promise<void> {
     if (!(await this.adminAuthService.isAdminLoginVerified(loginInfo))) {
-      throw new UnauthorizedException(
+      throw new BadRequestException(
         '아이디 또는 비밀번호가 일치하지 않습니다.',
       );
     }

--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -6,6 +6,7 @@ export enum additionalModalType {
   MODAL_UNAVAILABLE_ALREADY_LENT = "MODAL_UNAVAILABLE_ALREADY_LENT",
   MODAL_ADMIN_RETURN = "MODAL_ADMIN_RETURN",
   MODAL_BAN = "MODAL_BAN",
+  MODAL_ADMIN_LOGIN_FAILURE = "MODAL_ADMIN_LOGIN_FAILURE",
 }
 
 export const cabinetIconSrcMap = {
@@ -89,6 +90,11 @@ export const modalPropsMap = {
     type: "confirm",
     title: "밴 해제하기",
     confirmMessage: "해제",
+  },
+  MODAL_ADMIN_LOGIN_FAILURE: {
+    type: "error",
+    title: "아이디 또는 비밀번호가\n일치하지 않습니다",
+    confirmMessage: "",
   },
 };
 

--- a/frontend/src/components/Login/AdminLoginTemplate.tsx
+++ b/frontend/src/components/Login/AdminLoginTemplate.tsx
@@ -206,7 +206,7 @@ const LoginCardStyled = styled.div`
   justify-content: space-between;
   align-items: center;
   flex-direction: column;
-  padding: 85px 0;
+  padding: 85px 40px;
   background-color: var(--white);
 `;
 
@@ -234,15 +234,17 @@ const CardInputBoxStyled = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  margin: 40px 0 10px;
+  width: 200px;
+  padding: 40px 0 10px;
 `;
 
 const CardInputStyled = styled.input<{ isFocus: boolean }>`
   text-align: left;
   padding-left: 15px;
   font-family: var(--main-font);
-  font-size: 18px;
+  font-size: 14px;
   letter-spacing: 0.05rem;
+  width: 100%;
   height: 48px;
   background-color: var(--white);
   border-radius: 8px;

--- a/frontend/src/components/Login/AdminLoginTemplate.tsx
+++ b/frontend/src/components/Login/AdminLoginTemplate.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import axios from "axios";
 import styled from "styled-components";
 import "@/assets/css/loginPage.css";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
@@ -20,7 +21,15 @@ const AdminLoginTemplate = (props: {
   const [isPwFocused, setIsPwFocused] = useState(false);
   const [adminId, setAdminId] = useState("");
   const [adminPw, setAdminPw] = useState("");
+  const [showUnavailableModal, setShowUnavailableModal] = useState(false);
 
+  const handleOpenUnavailableModal = () => {
+    setShowUnavailableModal(true);
+  };
+  const handleCloseUnavailableModal = () => {
+    setIsClicked(false);
+    setShowUnavailableModal(false);
+  };
   const handleLoginButton = async () => {
     if (adminId === "" || adminPw === "") {
       alert("아이디와 비밀번호를 입력해주세요.");
@@ -32,6 +41,13 @@ const AdminLoginTemplate = (props: {
         navigate("/admin/home");
       }
     } catch (error) {
+      if (
+        axios.isAxiosError(error) &&
+        error.response &&
+        error.response.status == 400
+      ) {
+        handleOpenUnavailableModal();
+      }
       console.error(error);
     }
     setIsClicked(true);
@@ -114,6 +130,12 @@ const AdminLoginTemplate = (props: {
           </CardGoogleOauthStyled>
         </LoginCardStyled>
       </RightSectionStyled>
+      {showUnavailableModal && (
+        <UnavailableModal
+          status={additionalModalType.MODAL_ADMIN_LOGIN_FAILURE}
+          closeModal={handleCloseUnavailableModal}
+        />
+      )}
     </LoginPageStyled>
   );
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

기존에는 Admin 아이디 혹은 비밀번호가 잘못 입력됐을 시 401 상태 코드를 받아 alert를 띄운 후 login 페이지로 강제 리다이렉션하는 방식으로 처리해 주었다면, 이번 수정에서 Sanan님과 회의를 거친 결과 로그인 실패 시 401(Unauthorized) -> 400(Bad request) 상태 코드를 받게 한 후 로그인 실패 모달을 띄우도록 수정했습니다.

<img width="672" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/101867295/e6d89b1a-87b0-4907-a1d8-a60fcaf08809">

이 외 Safari에서의 Cross browsing을 원활하게 지원하도록 코드를 수정해 주었습니다.

Closes #1109