### PR TITLE
[FE] REFACTOR: Common 컴포넌트들의 서식과 import 경로 수정 #1137

### DIFF
--- a/frontend/src/components/Common/Dropdown.tsx
+++ b/frontend/src/components/Common/Dropdown.tsx
@@ -102,10 +102,6 @@ const DropdownItemContainerStyled = styled.div<{ isVisible: boolean }>`
     css`
       visibility: hidden;
     `}
-  div {
-    &: first-child {
-
-    }
   }
 `;
 

--- a/frontend/src/components/Common/Selector.tsx
+++ b/frontend/src/components/Common/Selector.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import PillButton from "./PillButton";
+import PillButton from "@/components/Common/PillButton";
 
 interface ISelectorProps {
   iconSrc?: string;

--- a/frontend/src/components/Common/WarningNotification.tsx
+++ b/frontend/src/components/Common/WarningNotification.tsx
@@ -18,8 +18,6 @@ const WarningNotification: React.FC<WarningNotificationProps> = ({
   );
 };
 
-export default WarningNotification;
-
 const WarningIcon = styled.div<{ isVisible: boolean }>`
   display: ${({ isVisible }) => (isVisible ? "block" : "none")};
   background-image: url("/src/assets/images/warningTriangleIcon.svg");
@@ -32,6 +30,7 @@ const WarningIcon = styled.div<{ isVisible: boolean }>`
     opacity: 1;
   }
 `;
+
 const WarningBox = styled.div`
   position: relative;
   margin: 10px auto;
@@ -48,8 +47,9 @@ const WarningBox = styled.div`
   white-space: pre-line;
   z-index: 100;
   transition: visibility 0.5s, color 0.5s, background-color 0.5s, width 0.5s,
-    padding 0.5s ease-in-out;
+  padding 0.5s ease-in-out;
 `;
+
 const WarningWrapper = styled.div<{ isVisible: boolean }>`
   display: ${({ isVisible }) => (isVisible ? "block" : "none")};
   position: relative;
@@ -62,7 +62,9 @@ const WarningWrapper = styled.div<{ isVisible: boolean }>`
     background-color: rgba(0, 0, 0, 0.8);
     &:before {
       border-color: transparent transparent rgba(0, 0, 0, 0.8)
-        rgba(0, 0, 0, 0.8);
+      rgba(0, 0, 0, 0.8);
     }
   }
 `;
+  
+export default WarningNotification;


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

Common 컴포넌트 중 Dropdown, Selector, WarningNotification 컴포넌트들의 서식을 컨벤션에 맞게 수정하였습니다.

Dropdown: DropdownItemContainerStyled 내의 div Selector 가 비어있어 제거하였습니다.

Selector: PillButton 의 import 경로를 현재폴더 기준에서 '@'를 사용하는 절대경로로 변경하였습니다.

WarningNotification: export 의 위치를 코드 최하단으로 내리고, styled css 사이 줄바꿈을 넣고 들여쓰기를 알맞게 적용했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1137
