### PR TITLE
[BE] entity 키 값 관리하는 방법을 하나로 묶음

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/Cabinet.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/Cabinet.java
@@ -7,9 +7,6 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -17,6 +14,7 @@ import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 /**
  * 사물함 엔티티
@@ -25,12 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "CABINET")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Cabinet {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "CABINET_ID")
-	private Long cabinetId;
+public class Cabinet extends IdentityKeyEntity {
 
 	/**
 	 * 사물함의 상태가 변경될 때 증가하는 버전입니다.
@@ -163,17 +156,6 @@ public class Cabinet {
 
 	public void writeMemo(String memo) {
 		this.memo = memo;
-	}
-
-	@Override
-	public boolean equals(final Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (!(other instanceof Cabinet)) {
-			return false;
-		}
-		return this.cabinetId.equals(((Cabinet) other).cabinetId);
 	}
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/CabinetPlace.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/CabinetPlace.java
@@ -1,15 +1,12 @@
 package org.ftclub.cabinet.cabinet.domain;
 
-import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 /**
  * 사물함들이 위치하는 구역에 대한 엔티티입니다.
@@ -18,19 +15,14 @@ import lombok.NoArgsConstructor;
 @Table(name = "CABINET_PLACE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class CabinetPlace {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "CABINET_PLACE_ID")
-	private Long cabinetPlaceId;
+public class CabinetPlace extends IdentityKeyEntity {
 
 	/**
 	 * {@link Location}
 	 */
 	@Embedded
 	private Location location;
-	
+
 	/**
 	 * {@link SectionFormation}
 	 */
@@ -52,16 +44,5 @@ public class CabinetPlace {
 	public static CabinetPlace of(Location location, SectionFormation sectionFormation,
 			MapArea mapArea) {
 		return new CabinetPlace(location, sectionFormation, mapArea);
-	}
-
-	@Override
-	public boolean equals(final Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (!(other instanceof CabinetPlace)) {
-			return false;
-		}
-		return this.cabinetPlaceId.equals(((CabinetPlace) other).cabinetPlaceId);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
@@ -3,9 +3,6 @@ package org.ftclub.cabinet.lent.domain;
 import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
@@ -14,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ftclub.cabinet.utils.DateUtil;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 /**
  * lent의 기록을 관리하기 위한 data mapper
@@ -22,12 +20,7 @@ import org.ftclub.cabinet.utils.DateUtil;
 @Table(name = "LENT_HISTORY")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LentHistory {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "LENT_HISTORY_ID")
-	private Long lentHistoryId;
+public class LentHistory extends IdentityKeyEntity {
 
 	/**
 	 * 낙관적 락을 위한 version
@@ -97,17 +90,6 @@ public class LentHistory {
 	 */
 	public static LentHistory of(Date startedAt, Long userId, Long cabinetId) {
 		return new LentHistory(startedAt, null, userId, cabinetId);
-	}
-
-	@Override
-	public boolean equals(final Object other) {
-		if (this == other) {
-			return true;
-		}
-		if (!(other instanceof LentHistory)) {
-			return false;
-		}
-		return (this.lentHistoryId.equals(((LentHistory) other).lentHistoryId));
 	}
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
@@ -22,73 +22,73 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class LentFacadeServiceImpl implements LentFacadeService {
 
-    private final LentRepository lentRepository;
-    private final UserExceptionHandlerService userExceptionHandler;
-    private final CabinetExceptionHandlerService cabinetExceptionHandler;
-    private final LentService lentService;
-    private final LentMapper lentMapper;
+	private final LentRepository lentRepository;
+	private final UserExceptionHandlerService userExceptionHandler;
+	private final CabinetExceptionHandlerService cabinetExceptionHandler;
+	private final LentService lentService;
+	private final LentMapper lentMapper;
 
-    @Override
-    public LentHistoryPaginationDto getAllUserLentHistories(Long userId, Integer page,
-            Integer length) {
-        userExceptionHandler.getUser(userId);
-        PageRequest pageable = PageRequest.of(page, length, Sort.by("STARTED_AT"));
-        List<LentHistory> lentHistories = lentRepository.findByUserId(userId, pageable);
-        int totalLength = lentRepository.countUserAllLent(userId);
-        return generateLentHistoryPaginationDto(lentHistories, totalLength);
-    }
+	@Override
+	public LentHistoryPaginationDto getAllUserLentHistories(Long userId, Integer page,
+			Integer length) {
+		userExceptionHandler.getUser(userId);
+		PageRequest pageable = PageRequest.of(page, length, Sort.by("STARTED_AT"));
+		List<LentHistory> lentHistories = lentRepository.findByUserId(userId, pageable);
+		int totalLength = lentRepository.countUserAllLent(userId);
+		return generateLentHistoryPaginationDto(lentHistories, totalLength);
+	}
 
-    @Override
-    public LentHistoryPaginationDto getAllCabinetLentHistories(Long cabinetId, Integer page,
-            Integer length) {
-        cabinetExceptionHandler.getCabinet(cabinetId);
-        PageRequest pageable = PageRequest.of(page, length, Sort.by("STARTED_AT"));
-        List<LentHistory> lentHistories = lentRepository.findByCabinetId(cabinetId, pageable);
-        int totalLength = lentRepository.countCabinetAllLent(cabinetId);
-        return generateLentHistoryPaginationDto(lentHistories, totalLength);
-    }
+	@Override
+	public LentHistoryPaginationDto getAllCabinetLentHistories(Long cabinetId, Integer page,
+			Integer length) {
+		cabinetExceptionHandler.getCabinet(cabinetId);
+		PageRequest pageable = PageRequest.of(page, length, Sort.by("STARTED_AT"));
+		List<LentHistory> lentHistories = lentRepository.findByCabinetId(cabinetId, pageable);
+		int totalLength = lentRepository.countCabinetAllLent(cabinetId);
+		return generateLentHistoryPaginationDto(lentHistories, totalLength);
+	}
 
-    @Override
-    public List<LentDto> getLentDtoList(Long cabinetId) {
-        cabinetExceptionHandler.getCabinet(cabinetId);
-        List<LentHistory> lentHistories = lentRepository.findAllActiveLentByCabinetId(cabinetId);
-        return lentHistories.stream()
-                .map(e -> new LentDto(
-                        e.getUserId(),
-                        userExceptionHandler.getUser(e.getUserId()).getName(),
-                        e.getLentHistoryId(),
-                        e.getStartedAt(),
-                        e.getExpiredAt()))
-                .collect(Collectors.toList());
-    }
+	@Override
+	public List<LentDto> getLentDtoList(Long cabinetId) {
+		cabinetExceptionHandler.getCabinet(cabinetId);
+		List<LentHistory> lentHistories = lentRepository.findAllActiveLentByCabinetId(cabinetId);
+		return lentHistories.stream()
+				.map(e -> new LentDto(
+						e.getUserId(),
+						userExceptionHandler.getUser(e.getUserId()).getName(),
+						e.getId(),
+						e.getStartedAt(),
+						e.getExpiredAt()))
+				.collect(Collectors.toList());
+	}
 
-    private LentHistoryPaginationDto generateLentHistoryPaginationDto(
-            List<LentHistory> lentHistories, int totalLength) {
-        List<LentHistoryDto> lentHistoryDto = lentHistories.stream()
-                .map(e -> lentMapper.toLentHistoryDto(e,
-                        userExceptionHandler.getUser(e.getUserId()),
-                        cabinetExceptionHandler.getCabinet(e.getCabinetId())))
-                .collect(Collectors.toList());
-        return new LentHistoryPaginationDto(lentHistoryDto, totalLength);
-    }
+	private LentHistoryPaginationDto generateLentHistoryPaginationDto(
+			List<LentHistory> lentHistories, int totalLength) {
+		List<LentHistoryDto> lentHistoryDto = lentHistories.stream()
+				.map(e -> lentMapper.toLentHistoryDto(e,
+						userExceptionHandler.getUser(e.getUserId()),
+						cabinetExceptionHandler.getCabinet(e.getCabinetId())))
+				.collect(Collectors.toList());
+		return new LentHistoryPaginationDto(lentHistoryDto, totalLength);
+	}
 
-    @Override
-    public void startLentCabinet(Long userId, Long cabinetId) {
-        lentService.startLentCabinet(userId, cabinetId);
-    }
+	@Override
+	public void startLentCabinet(Long userId, Long cabinetId) {
+		lentService.startLentCabinet(userId, cabinetId);
+	}
 
-    @Override
-    public void startLentClubCabinet(Long userId, Long cabinetId) {
-        lentService.startLentClubCabinet(userId, cabinetId);
-    }
+	@Override
+	public void startLentClubCabinet(Long userId, Long cabinetId) {
+		lentService.startLentClubCabinet(userId, cabinetId);
+	}
 
-    @Override
-    public void endLentCabinet(Long userId) {
-        lentService.endLentCabinet(userId);
-    }
+	@Override
+	public void endLentCabinet(Long userId) {
+		lentService.endLentCabinet(userId);
+	}
 
-    @Override
-    public void terminateLentCabinet(Long userId) {
-        lentService.terminateLentCabinet(userId);
-    }
+	@Override
+	public void terminateLentCabinet(Long userId) {
+		lentService.terminateLentCabinet(userId);
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
+++ b/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
@@ -17,8 +17,8 @@ public interface LentMapper {
 
 	LentDto toLentDto(String name, LentHistory lentHistory);
 
-	@Mapping(target = "userId", source = "lentHistory.userId")
-	@Mapping(target = "cabinetId", source = "cabinet.cabinetId")
+	@Mapping(target = "userId", source = "lentHistory.id")
+	@Mapping(target = "cabinetId", source = "cabinet.id")
 	@Mapping(target = "location", source = "cabinet.cabinetPlace.location")
 	LentHistoryDto toLentHistoryDto(LentHistory lentHistory, User user, Cabinet cabinet);
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/AdminUser.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/AdminUser.java
@@ -4,13 +4,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 /**
  * 관리자 엔티티 클래스입니다.
@@ -19,47 +17,31 @@ import lombok.NoArgsConstructor;
 @Table(name = "ADMIN_USER")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class AdminUser {
+public class AdminUser extends IdentityKeyEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ADMIN_USER_ID")
-    private Long adminUserId;
+	/**
+	 * OAuth 방식을 사용하기 때문에 비밀번호 없이 이메일만 저장합니다.
+	 */
+	@Column(name = "EMAIL", length = 128, unique = true, nullable = false)
+	private String email;
 
-    /**
-     * OAuth 방식을 사용하기 때문에 비밀번호 없이 이메일만 저장합니다.
-     */
-    @Column(name = "EMAIL", length = 128, unique = true, nullable = false)
-    private String email;
+	/**
+	 * {@link AdminRole}
+	 */
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "ROLE", length = 16, nullable = false)
+	private AdminRole role = AdminRole.NONE;
 
-    /**
-     * {@link AdminRole}
-     */
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "ROLE", length = 16, nullable = false)
-    private AdminRole role = AdminRole.NONE;
+	protected AdminUser(String email, AdminRole role) {
+		this.email = email;
+		this.role = role;
+	}
 
-    protected AdminUser(String email, AdminRole role) {
-        this.email = email;
-        this.role = role;
-    }
+	public static AdminUser of(String email, AdminRole role) {
+		return new AdminUser(email, role);
+	}
 
-    public static AdminUser of(String email, AdminRole role) {
-        return new AdminUser(email, role);
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        if (other == this) {
-            return true;
-        }
-        if (!(other instanceof AdminUser)) {
-            return false;
-        }
-        return (this.adminUserId.equals(((AdminUser) other).getAdminUserId()));
-    }
-
-    public void changeAdminRole(AdminRole role) {
-        this.role = role;
-    }
+	public void changeAdminRole(AdminRole role) {
+		this.role = role;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/BanHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/BanHistory.java
@@ -1,73 +1,53 @@
 package org.ftclub.cabinet.user.domain;
 
 import java.util.Date;
-import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 @Entity
 @Table(name = "BAN_HISTORY")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class BanHistory {
+public class BanHistory extends IdentityKeyEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "BAN_HISTORY_ID")
-    private long banHistoryId;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "BANNED_AT", nullable = false)
+	private Date bannedAt;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "BANNED_AT", nullable = false)
-    private Date bannedAt;
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(name = "UNBANNED_AT")
+	private Date unbannedAt;
 
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "UNBANNED_AT")
-    private Date unbannedAt;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "BAN_TYPE", length = 32, nullable = false)
+	private BanType banType;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "BAN_TYPE", length = 32, nullable = false)
-    private BanType banType;
+	@Column(name = "USER_ID", nullable = false)
+	private Long userId;
 
-    @Column(name = "USER_ID", nullable = false)
-    private Long userId;
+	protected BanHistory(Date bannedAt, Date unbannedAt, BanType banType,
+			Long userId) {
+		this.bannedAt = bannedAt;
+		this.unbannedAt = unbannedAt;
+		this.banType = banType;
+		this.userId = userId;
+	}
 
-    protected BanHistory(Date bannedAt, Date unbannedAt, BanType banType,
-            Long userId) {
-        this.bannedAt = bannedAt;
-        this.unbannedAt = unbannedAt;
-        this.banType = banType;
-        this.userId = userId;
-    }
+	public static BanHistory of(Date bannedAt, Date unbannedAt, BanType banType,
+			Long userId) {
+		return new BanHistory(bannedAt, unbannedAt, banType, userId);
+	}
 
-    public static BanHistory of(Date bannedAt, Date unbannedAt, BanType banType,
-            Long userId) {
-        return new BanHistory(bannedAt, unbannedAt, banType, userId);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        BanHistory banHistory = (BanHistory) o;
-        return Objects.equals(banHistoryId, banHistory.banHistoryId);
-    }
-
-    public boolean isBanEndedBefore(Date date) {
-        return date.before(unbannedAt);
-    }
+	public boolean isBanEndedBefore(Date date) {
+		return date.before(unbannedAt);
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -1,82 +1,62 @@
 package org.ftclub.cabinet.user.domain;
 
 import java.util.Date;
-import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.utils.entity.IdentityKeyEntity;
 
 @Entity
 @Table(name = "USER")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class User {
+public class User extends IdentityKeyEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "USER_ID")
-    private Long userId;
+	@Column(name = "NAME", length = 32, unique = true, nullable = false)
+	private String name;
 
-    @Column(name = "NAME", length = 32, unique = true, nullable = false)
-    private String name;
+	@Column(name = "EMAIL", unique = true)
+	private String email;
 
-    @Column(name = "EMAIL", unique = true)
-    private String email;
+	@Temporal(value = TemporalType.TIMESTAMP)
+	@Column(name = "BLACKHOLED_AT")
+	private Date blackholedAt = null;
 
-    @Temporal(value = TemporalType.TIMESTAMP)
-    @Column(name = "BLACKHOLED_AT")
-    private Date blackholedAt = null;
+	@Temporal(value = TemporalType.TIMESTAMP)
+	@Column(name = "DELETED_AT", length = 32)
+	private Date deletedAt = null;
 
-    @Temporal(value = TemporalType.TIMESTAMP)
-    @Column(name = "DELETED_AT", length = 32)
-    private Date deletedAt = null;
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "ROLE", length = 32, nullable = false)
+	private UserRole role;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "ROLE", length = 32, nullable = false)
-    private UserRole role;
+	protected User(String name, String email, Date blackholedAt, UserRole userRole) {
+		this.name = name;
+		this.email = email;
+		this.blackholedAt = blackholedAt;
+		this.role = userRole;
+	}
 
-    protected User(String name, String email, Date blackholedAt, UserRole userRole) {
-        this.name = name;
-        this.email = email;
-        this.blackholedAt = blackholedAt;
-        this.role = userRole;
-    }
+	public static User of(String name, String email, Date blackholedAt, UserRole userRole) {
+		return new User(name, email, blackholedAt, userRole);
+	}
 
-    public static User of(String name, String email, Date blackholedAt, UserRole userRole) {
-        return new User(name, email, blackholedAt, userRole);
-    }
+	public boolean isUserRole(UserRole role) {
+		return role.equals(this.role);
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        User user = (User) o;
-        return Objects.equals(userId, user.userId);
-    }
+	public void changeBlackholedAt(Date blackholedAt) {
+		this.blackholedAt = blackholedAt;
+	}
 
-    public boolean isUserRole(UserRole role) {
-        return role.equals(this.role);
-    }
-
-    public void changeBlackholedAt(Date blackholedAt) {
-        this.blackholedAt = blackholedAt;
-    }
-
-    public void setDeletedAt(Date deletedAt) {
-        this.deletedAt = deletedAt;
-    }
+	public void setDeletedAt(Date deletedAt) {
+		this.deletedAt = deletedAt;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/UserAspect.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/UserAspect.java
@@ -56,6 +56,6 @@ public class UserAspect {
 		User user = userExceptionHandlerService.getUserByName(name);
 		//To-Do: name을 기준으로 service에게 정보를 받고, 매핑한다.
 		// name과 email은 우선 구현했으나 수정이 필요함.
-		return new UserSessionDto(user.getUserId(), name, user.getEmail(), 1, 1, new Date(), true);
+		return new UserSessionDto(user.getId(), name, user.getEmail(), 1, 1, new Date(), true);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntity.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntity.java
@@ -1,0 +1,63 @@
+package org.ftclub.cabinet.utils.entity;
+
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
+import javax.persistence.Transient;
+import org.hibernate.proxy.HibernateProxy;
+import org.springframework.data.domain.Persistable;
+
+@MappedSuperclass
+abstract public class IdentityKeyEntity implements Persistable<Long> {
+
+	@Column(name = "ID")
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id = null;
+
+	@Transient
+	private Boolean isNew = true;
+
+	@Override
+	public Long getId() {
+		return id;
+	}
+	
+
+	@Override
+	public boolean isNew() {
+		return isNew;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getId() == null) {
+			return false;
+		}
+		if (!(o instanceof HibernateProxy)
+				&& this.getClass() != o.getClass()) {
+			return false;
+		}
+		Serializable oid = o instanceof HibernateProxy
+				? ((HibernateProxy) o).getHibernateLazyInitializer().getIdentifier() :
+				((IdentityKeyEntity) o).getId();
+		return getId() == oid;
+	}
+
+	@Override
+	public int hashCode() {
+		return id.hashCode();
+	}
+
+	@PostLoad
+	@PostPersist
+	protected void markNotNew() {
+		this.isNew = false;
+	}
+}

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetServiceTest.java
@@ -23,7 +23,7 @@ class CabinetServiceTest {
 	@Test
 	public void 사물함_가져오기() {
 		Cabinet cabinet = cabinetService.getCabinet(1L);
-		assertEquals(1L, cabinet.getCabinetId().longValue());
+		assertEquals(1L, cabinet.getId().longValue());
 	}
 
 	@Test

--- a/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryTest.java
@@ -63,7 +63,7 @@ class LentHistoryTest {
 		lentHistory.endLent(DateUtil.addDaysToDate(now, 6));
 		assertTrue(lentHistory.isSetEndedAt());
 		assertEquals(3, lentHistory.getDaysDiffEndedAndExpired());
-		lentRepository.findById(lentHistory.getLentHistoryId());
+		lentRepository.findById(lentHistory.getId());
 		assertTrue(lentHistory.isSetEndedAt());
 		assertEquals(3, lentHistory.getDaysDiffEndedAndExpired());
 	}

--- a/backend/src/test/java/org/ftclub/cabinet/lent/service/LentServiceImplTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/service/LentServiceImplTest.java
@@ -158,18 +158,18 @@ class LentServiceImplTest {
 	@DisplayName("사물함 대여 가능한 사용자는 available, limited_available 상태의 사물함을 빌릴 수 있습니다 ")
 	void generalLentSituation() {
 		// given
-		int lentCountBefore = lentRepository.countUserActiveLent(normalUser1.getUserId());
+		int lentCountBefore = lentRepository.countUserActiveLent(normalUser1.getId());
 		// when
-		lentService.startLentCabinet(normalUser1.getUserId(),
-				privateAvailableCabinet1.getCabinetId());
+		lentService.startLentCabinet(normalUser1.getId(),
+				privateAvailableCabinet1.getId());
 		// then
-		int lentCountAfter = lentRepository.countUserActiveLent(normalUser1.getUserId());
+		int lentCountAfter = lentRepository.countUserActiveLent(normalUser1.getId());
 		LentHistory lentHistory = lentRepository.findFirstByUserIdAndEndedAtIsNull(
-				normalUser1.getUserId()).orElseThrow(() -> new RuntimeException());
+				normalUser1.getId()).orElseThrow(() -> new RuntimeException());
 		Assertions.assertEquals(lentCountAfter, lentCountBefore + 1L);
 		Assertions.assertEquals(CabinetStatus.FULL, privateAvailableCabinet1.getStatus());
 		Assertions.assertNotNull(
-				lentRepository.findFirstByUserIdAndEndedAtIsNull(normalUser1.getUserId())
+				lentRepository.findFirstByUserIdAndEndedAtIsNull(normalUser1.getId())
 						.orElse(null));
 	}
 
@@ -177,8 +177,8 @@ class LentServiceImplTest {
 	@DisplayName("대여자는 또 다른 사물함을 빌릴 수 없습니다.")
 	void alreadyLentUserSituation() {
 		// given
-		Long userId = lentUser1.getUserId();
-		Long cabinetId = privateAvailableCabinet1.getCabinetId();
+		Long userId = lentUser1.getId();
+		Long cabinetId = privateAvailableCabinet1.getId();
 		// when
 		ServiceException serviceException = assertThrows(ServiceException.class,
 				() -> lentService.startLentCabinet(userId, cabinetId));
@@ -239,10 +239,10 @@ class LentServiceImplTest {
 	@DisplayName("유저가 available 상태의 shared cabinet을 렌트합니다. cabinet의 status, expired_at, ended_at 값이 적절히 변경돼야 합니다.")
 	void sharedCabinetProperStatus1() {
 		// given
-		Long userId1 = normalUser1.getUserId();
-		Long userId2 = normalUser2.getUserId();
-		Long userId3 = normalUser3.getUserId();
-		Long cabinetId = sharedAvailableCabinet1.getCabinetId();
+		Long userId1 = normalUser1.getId();
+		Long userId2 = normalUser2.getId();
+		Long userId3 = normalUser3.getId();
+		Long cabinetId = sharedAvailableCabinet1.getId();
 		Cabinet cabinet = sharedAvailableCabinet1;
 		// when
 		lentService.startLentCabinet(userId1, cabinetId);
@@ -273,12 +273,12 @@ class LentServiceImplTest {
 	@DisplayName("유저가 available 상태의 shared cabinet을 렌트합니다. cabinet의 status, expired_at, ended_at 값이 적절히 변경돼야 합니다.")
 	void sharedCabinetProperStatus2() {
 		// given
-		Long userId1 = normalUser1.getUserId();
-		Long userId2 = normalUser2.getUserId();
-		Long userId3 = normalUser3.getUserId();
-		Long userId4 = normalUser4.getUserId();
+		Long userId1 = normalUser1.getId();
+		Long userId2 = normalUser2.getId();
+		Long userId3 = normalUser3.getId();
+		Long userId4 = normalUser4.getId();
 
-		Long cabinetId = sharedAvailableCabinet0.getCabinetId();
+		Long cabinetId = sharedAvailableCabinet0.getId();
 		Cabinet cabinet = sharedAvailableCabinet0;
 		lentService.startLentCabinet(userId1, cabinetId);
 		lentService.startLentCabinet(userId2, cabinetId);

--- a/backend/src/test/java/org/ftclub/cabinet/mapper/CabinetMapperTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/mapper/CabinetMapperTest.java
@@ -23,71 +23,71 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class CabinetMapperTest {
 
-    @Autowired
-    CabinetMapper cabinetMapper;
+	@Autowired
+	CabinetMapper cabinetMapper;
 
-    @Test
-    void toCabinetDto() {
-        Location location = Location.of("testBuilding", 99, "testSection");
-        Cabinet cabinet = Cabinet.of(1, CabinetStatus.AVAILABLE, LentType.SHARE, 10, Grid.of(1, 2),
-                CabinetPlace.of(null, null, null));
-        CabinetDto cabinetDto = cabinetMapper.toCabinetDto(location, cabinet);
-        assertEquals(cabinet.getCabinetId(), cabinetDto.getCabinetId());
-        assertEquals(cabinet.getVisibleNum(), cabinetDto.getVisibleNum());
-        assertEquals(cabinet.getLentType(), cabinetDto.getLentType());
-        assertEquals(cabinet.getMaxUser(), cabinetDto.getMaxUser());
-        assertEquals(cabinet.getTitle(), cabinetDto.getTitle());
-        assertEquals(cabinet.getStatus(), cabinetDto.getStatus());
-        assertEquals(location, cabinetDto.getLocation());
-    }
+	@Test
+	void toCabinetDto() {
+		Location location = Location.of("testBuilding", 99, "testSection");
+		Cabinet cabinet = Cabinet.of(1, CabinetStatus.AVAILABLE, LentType.SHARE, 10, Grid.of(1, 2),
+				CabinetPlace.of(null, null, null));
+		CabinetDto cabinetDto = cabinetMapper.toCabinetDto(location, cabinet);
+		assertEquals(cabinet.getId(), cabinetDto.getCabinetId());
+		assertEquals(cabinet.getVisibleNum(), cabinetDto.getVisibleNum());
+		assertEquals(cabinet.getLentType(), cabinetDto.getLentType());
+		assertEquals(cabinet.getMaxUser(), cabinetDto.getMaxUser());
+		assertEquals(cabinet.getTitle(), cabinetDto.getTitle());
+		assertEquals(cabinet.getStatus(), cabinetDto.getStatus());
+		assertEquals(location, cabinetDto.getLocation());
+	}
 
-    @Test
-    void toBuildingFloorsDto() {
-        String targetBuilding = "targetBuilding";
-        List<Integer> floors = List.of(1, 2, 3, 4, 5);
+	@Test
+	void toBuildingFloorsDto() {
+		String targetBuilding = "targetBuilding";
+		List<Integer> floors = List.of(1, 2, 3, 4, 5);
 
-        BuildingFloorsDto buildingFloorsDto = cabinetMapper.toBuildingFloorsDto(targetBuilding,
-                floors);
-        assertEquals(targetBuilding, buildingFloorsDto.getBuilding());
-        assertArrayEquals(floors.toArray(), buildingFloorsDto.getFloors().toArray());
-    }
+		BuildingFloorsDto buildingFloorsDto = cabinetMapper.toBuildingFloorsDto(targetBuilding,
+				floors);
+		assertEquals(targetBuilding, buildingFloorsDto.getBuilding());
+		assertArrayEquals(floors.toArray(), buildingFloorsDto.getFloors().toArray());
+	}
 
-    @Test
-    void toCabinetInfoResponseDto() {
-        Location location = Location.of("buildingTest", 1, "testSection");
-        CabinetDto cabinetDto = new CabinetDto(2L, 3, LentType.SHARE, 4, "title",
-                CabinetStatus.AVAILABLE, location);
-        LentDto lentDto1 = new LentDto(5L, "testName1", 6L, new Date(), new Date());
-        LentDto lentDto2 = new LentDto(7L, "testName2", 8L, new Date(), new Date());
-        List<LentDto> lentDtos = List.of(lentDto1, lentDto2);
-        CabinetInfoResponseDto cabinetInfoResponseDto = cabinetMapper.toCabinetInfoResponseDto(
-                cabinetDto, lentDtos);
-        assertEquals(cabinetDto.getCabinetId(), cabinetInfoResponseDto.getCabinetId());
-        assertEquals(cabinetDto.getStatus(), cabinetInfoResponseDto.getStatus());
-        assertEquals(cabinetDto.getMaxUser(), cabinetInfoResponseDto.getMaxUser());
-        assertEquals(cabinetDto.getLocation(), cabinetInfoResponseDto.getLocation());
-        assertEquals(cabinetDto.getTitle(), cabinetInfoResponseDto.getTitle());
-        assertEquals(cabinetDto.getVisibleNum(), cabinetInfoResponseDto.getVisibleNum());
-        assertEquals(lentDtos, cabinetInfoResponseDto.getLents());
-    }
+	@Test
+	void toCabinetInfoResponseDto() {
+		Location location = Location.of("buildingTest", 1, "testSection");
+		CabinetDto cabinetDto = new CabinetDto(2L, 3, LentType.SHARE, 4, "title",
+				CabinetStatus.AVAILABLE, location);
+		LentDto lentDto1 = new LentDto(5L, "testName1", 6L, new Date(), new Date());
+		LentDto lentDto2 = new LentDto(7L, "testName2", 8L, new Date(), new Date());
+		List<LentDto> lentDtos = List.of(lentDto1, lentDto2);
+		CabinetInfoResponseDto cabinetInfoResponseDto = cabinetMapper.toCabinetInfoResponseDto(
+				cabinetDto, lentDtos);
+		assertEquals(cabinetDto.getCabinetId(), cabinetInfoResponseDto.getCabinetId());
+		assertEquals(cabinetDto.getStatus(), cabinetInfoResponseDto.getStatus());
+		assertEquals(cabinetDto.getMaxUser(), cabinetInfoResponseDto.getMaxUser());
+		assertEquals(cabinetDto.getLocation(), cabinetInfoResponseDto.getLocation());
+		assertEquals(cabinetDto.getTitle(), cabinetInfoResponseDto.getTitle());
+		assertEquals(cabinetDto.getVisibleNum(), cabinetInfoResponseDto.getVisibleNum());
+		assertEquals(lentDtos, cabinetInfoResponseDto.getLents());
+	}
 
-    @Test
-    void toCabinetsPerSectionResponseDto() {
-        String section = "testSection";
-        CabinetInfoResponseDto cabinetInfoResponseDto1 = new CabinetInfoResponseDto(1L, 2,
-                LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
-        CabinetInfoResponseDto cabinetInfoResponseDto2 = new CabinetInfoResponseDto(2L, 5,
-                LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
-        CabinetInfoResponseDto cabinetInfoResponseDto3 = new CabinetInfoResponseDto(3L, 6,
-                LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
-        CabinetInfoResponseDto cabinetInfoResponseDto4 = new CabinetInfoResponseDto(4L, 7,
-                LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
-        List<CabinetInfoResponseDto> cabinetInfoResponseDtos = List.of(cabinetInfoResponseDto1,
-                cabinetInfoResponseDto2, cabinetInfoResponseDto3, cabinetInfoResponseDto4);
-        CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto = cabinetMapper.toCabinetsPerSectionResponseDto(
-                section, cabinetInfoResponseDtos);
-        assertEquals(section, cabinetsPerSectionResponseDto.getSection());
-        assertArrayEquals(cabinetInfoResponseDtos.toArray(),
-                cabinetsPerSectionResponseDto.getCabinets().toArray(new CabinetInfoResponseDto[0]));
-    }
+	@Test
+	void toCabinetsPerSectionResponseDto() {
+		String section = "testSection";
+		CabinetInfoResponseDto cabinetInfoResponseDto1 = new CabinetInfoResponseDto(1L, 2,
+				LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
+		CabinetInfoResponseDto cabinetInfoResponseDto2 = new CabinetInfoResponseDto(2L, 5,
+				LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
+		CabinetInfoResponseDto cabinetInfoResponseDto3 = new CabinetInfoResponseDto(3L, 6,
+				LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
+		CabinetInfoResponseDto cabinetInfoResponseDto4 = new CabinetInfoResponseDto(4L, 7,
+				LentType.SHARE, 3, "title", CabinetStatus.AVAILABLE, null, null);
+		List<CabinetInfoResponseDto> cabinetInfoResponseDtos = List.of(cabinetInfoResponseDto1,
+				cabinetInfoResponseDto2, cabinetInfoResponseDto3, cabinetInfoResponseDto4);
+		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto = cabinetMapper.toCabinetsPerSectionResponseDto(
+				section, cabinetInfoResponseDtos);
+		assertEquals(section, cabinetsPerSectionResponseDto.getSection());
+		assertArrayEquals(cabinetInfoResponseDtos.toArray(),
+				cabinetsPerSectionResponseDto.getCabinets().toArray(new CabinetInfoResponseDto[0]));
+	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/mapper/LentMapperTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/mapper/LentMapperTest.java
@@ -29,7 +29,7 @@ class LentMapperTest {
 		LentHistory lentHistory = LentHistory.of(DateUtil.getNow(), DateUtil.getNow(), 19L, 99L);
 		String name = "someName";
 		LentDto lentDto = lentMapper.toLentDto("someName", lentHistory);
-		assertEquals(lentHistory.getLentHistoryId(), lentDto.getLentHistoryId());
+		assertEquals(lentHistory.getId(), lentDto.getLentHistoryId());
 		assertEquals(lentHistory.getUserId(), lentDto.getUserId());
 		assertEquals(name, lentDto.getName());
 		assertEquals(lentHistory.getExpiredAt(), lentDto.getExpiredAt());
@@ -44,7 +44,7 @@ class LentMapperTest {
 		Cabinet cabinet = Cabinet.of(1, CabinetStatus.AVAILABLE, LentType.SHARE, 10, Grid.of(1, 2),
 				CabinetPlace.of(location, null, null));
 		LentHistoryDto lentHistoryDto = lentMapper.toLentHistoryDto(lentHistory, user, cabinet);
-		assertEquals(cabinet.getCabinetId(), lentHistoryDto.getCabinetId());
+		assertEquals(cabinet.getId(), lentHistoryDto.getCabinetId());
 		assertEquals(lentHistory.getUserId(), lentHistoryDto.getUserId());
 		assertEquals(cabinet.getVisibleNum(), lentHistoryDto.getVisibleNum());
 		assertEquals(user.getName(), lentHistoryDto.getName());

--- a/backend/src/test/java/org/ftclub/cabinet/mapper/UserSessionMapperTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/mapper/UserSessionMapperTest.java
@@ -34,7 +34,7 @@ class UserSessionMapperTest {
 	void toUserProfileDto() {
 		User user = User.of("intraId", "user@email.com", new Date(), UserRole.USER);
 		UserProfileDto userProfileDto = userMapper.toUserProfileDto(user);
-		assertEquals(user.getUserId(), userProfileDto.getUserId());
+		assertEquals(user.getId(), userProfileDto.getUserId());
 		assertEquals(user.getName(), userProfileDto.getName());
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/user/repository/AdminUserRepositoryTestSession.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/repository/AdminUserRepositoryTestSession.java
@@ -25,7 +25,7 @@ public class AdminUserRepositoryTestSession {
 		AdminUser adminUser = adminUserRepository.getAdminUser(adminUserId);
 
 		assertNotNull(adminUser);
-		assertEquals(adminUserId, adminUser.getAdminUserId());
+		assertEquals(adminUserId, adminUser.getId());
 		assertEquals("admin0@gmail.com", adminUser.getEmail());
 	}
 

--- a/backend/src/test/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntityTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntityTest.java
@@ -1,0 +1,91 @@
+package org.ftclub.cabinet.utils.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+@EntityScan(basePackageClasses = IdentityKeyEntityTest.class)
+@ExtendWith(SpringExtension.class)
+@EnableAutoConfiguration
+@Transactional
+@AutoConfigureCache
+@AutoConfigureDataJpa
+@AutoConfigureTestDatabase
+@AutoConfigureTestEntityManager
+class IdentityKeyEntityTest {
+
+	@Entity
+	@Table(name = "TEST_ENTITY")
+	static class TestEntity extends IdentityKeyEntity {
+
+		public TestEntity() {
+		}
+	}
+
+	@Autowired
+	TestEntityManager em;
+
+	@Test
+	@DisplayName("id가 잘 들어가는지 확인")
+	void injectionIdTest() {
+		TestEntity entity1 = new TestEntity();
+		em.persist(entity1);
+		em.flush();
+		assertThat(entity1.getId()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("같은 엔티티 확인")
+	void sameEntity() {
+		TestEntity entity1 = new TestEntity();
+		em.persist(entity1);
+		em.flush();
+		TestEntity entity2 = em.find(TestEntity.class, entity1.getId());
+		assertThat(entity1).isEqualTo(entity2);
+	}
+
+	@Test
+	@DisplayName("다른 엔티티 확인")
+	void different() {
+		TestEntity entity1 = new TestEntity();
+		em.persist(entity1);
+		TestEntity entity2 = new TestEntity();
+		em.persist(entity2);
+		em.flush();
+		assertThat(entity1).isNotEqualTo(entity2);
+	}
+
+	@Test
+	@DisplayName("persist안된 객체 확인")
+	void notPersist() {
+		TestEntity entity1 = new TestEntity();
+		TestEntity entity2 = new TestEntity();
+		assertThat(entity1).isNotEqualTo(entity2);
+	}
+
+	@Test
+	@DisplayName("persist된 객체 비교")
+	void persistSame() {
+		TestEntity entity1 = new TestEntity();
+		em.persist(entity1);
+		em.flush();
+		TestEntity target1 = em.find(TestEntity.class, entity1.getId());
+		TestEntity target2 = em.find(TestEntity.class, entity1.getId());
+
+		assertThat(target1).isEqualTo(target2);
+	}
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

키 전략이 모두 같아 하나의 클래스에 모아서 관리해도 되겠다고 생각이 들었습니다.
equal과 hashcode를 한 곳에서 관리할 수 있고 Persistable를 통해 save할 때  효율성을 높일 수 있을 거 같습니다.

의견이 일치되면 그 때 머지 해주세요
backend/src/main/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntity.java
backend/src/test/java/org/ftclub/cabinet/utils/entity/IdentityKeyEntityTest.java
상기 두 파일만 보면 될 거 같습니다