### PR TITLE
[FE] FIX: 어드민 사물함 검색 시 층 선택이 되도록 수정 #1155

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -294,9 +294,14 @@ export const axiosSearchByIntraId = async (intraId: string) => {
 };
 
 const axiosSearchByCabinetNumURL = "/api/admin/search/cabinet/visibleNum/";
-export const axiosSearchByCabinetNum = async (number: number) => {
+export const axiosSearchByCabinetNum = async (
+  number: number,
+  floor?: number
+) => {
   try {
-    const response = await instance.get(axiosSearchByCabinetNumURL + number);
+    const response = await instance.get(axiosSearchByCabinetNumURL + number, {
+      params: { floor: floor },
+    });
     return response;
   } catch (error) {
     throw error;

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -18,12 +18,14 @@ const SearchBar = () => {
   const [isFocus, setIsFocus] = useState<boolean>(true);
   const [targetIndex, setTargetIndex] = useState<number>(-1);
   const [searchValue, setSearchValue] = useState<string>("");
+  const [floor, setFloor] = useState<number>(0);
 
   const resetSearchState = () => {
     setSearchListById([]);
     setSearchListByNum([]);
     setTotalLength(0);
     setTargetIndex(-1);
+    setFloor(0);
     if (searchInput.current) {
       searchInput.current.value = "";
       setSearchValue("");
@@ -40,9 +42,12 @@ const SearchBar = () => {
         resetSearchState();
         return alert("두 글자 이상의 검색어를 입력해주세요.");
       } else {
+        let query = floor
+          ? `?q=${searchInput.current.value}&floor=${floor}`
+          : `?q=${searchInput.current.value}`;
         navigate({
           pathname: "search",
-          search: `?q=${searchInput.current.value}`,
+          search: query,
         });
         resetSearchState();
       }
@@ -119,6 +124,7 @@ const SearchBar = () => {
     if (isNaN(Number(searchInput.current!.value))) {
       return searchListById[targetIndex].intra_id;
     } else {
+      setFloor(searchListByNum[targetIndex].floor);
       return searchInput.current!.value;
     }
   };

--- a/frontend/src/components/TopNav/SearchBar/SearchListItem/SearchListItem.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchListItem/SearchListItem.tsx
@@ -23,9 +23,12 @@ const SearchListItem = (props: {
     <LiStyled
       className={targetIndex ? "active" : ""}
       onClick={() => {
+        let query = floor
+          ? `?q=${resultText}&floor=${floor}`
+          : `?q=${resultText}`;
         navigate({
           pathname: "search",
-          search: `?q=${resultText}`,
+          search: query,
         });
         resetSearchState();
       }}

--- a/frontend/src/pages/admin/SearchPage.tsx
+++ b/frontend/src/pages/admin/SearchPage.tsx
@@ -36,6 +36,7 @@ const SearchPage = () => {
   const [totalSearchList, setTotalSearchList] = useState(0);
   const currentPage = useRef(0);
   const searchValue = useRef("");
+  const searchFloor = useRef(0);
   const resetCurrentCabinetId = useResetRecoilState(currentCabinetIdState);
   const resetCurrentIntraId = useResetRecoilState(currentIntraIdState);
   const numberOfAdminWork = useRecoilValue(numberOfAdminWorkState);
@@ -48,6 +49,7 @@ const SearchPage = () => {
     setTotalSearchList(0);
     currentPage.current = 0;
     searchValue.current = searchParams.get("q") ?? "";
+    searchFloor.current = Number(searchParams.get("floor")) ?? 0;
     resetCurrentCabinetId();
     resetCurrentIntraId();
   };
@@ -68,7 +70,8 @@ const SearchPage = () => {
   // cabinet_num 검색
   const handleSearchByCabinetNum = async () => {
     const searchResult = await axiosSearchByCabinetNum(
-      Number(searchValue.current)
+      Number(searchValue.current),
+      searchFloor.current === 0 ? undefined : searchFloor.current
     );
     setSearchListByNum(searchResult.data.result);
     setTotalSearchList(searchResult.data.total_length);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> https://github.com/innovationacademy-kr/42cabi/issues/1155

이제 사물함 번호 검색 시 리스트에서 하나를 클릭하면 해당하는 사물함만 검색이 됩니다! 
