### PR TITLE
[FE] REFACTOR: main, adminMain 페이지 리팩토링#1137

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef } from "react";
-import styled from "styled-components";
-import { currentFloorSectionState } from "@/recoil/selectors";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import styled from "styled-components";
 import { currentSectionNameState } from "@/recoil/atoms";
 import { currentCabinetIdState, targetCabinetInfoState } from "@/recoil/atoms";
-import useMenu from "@/hooks/useMenu";
-import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
+import { currentFloorSectionState } from "@/recoil/selectors";
 import CabinetListContainer from "@/components/CabinetList/CabinetList.container";
+import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
+import useMenu from "@/hooks/useMenu";
 
 const MainPage = () => {
   const touchStartPosX = useRef(0);
@@ -34,24 +34,24 @@ const MainPage = () => {
     currentSectionNameState
   );
 
-  const currentSectionIdx = sectionList.findIndex(
+  const currentSectionIndex = sectionList.findIndex(
     (sectionName) => sectionName === currentSectionName
   );
 
   const moveToLeftSection = () => {
-    if (currentSectionIdx <= 0) {
+    if (currentSectionIndex <= 0) {
       setCurrentSectionName(sectionList[sectionList.length - 1]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx - 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex - 1]);
     }
     mainWrapperRef.current?.scrollTo(0, 0);
   };
 
   const moveToRightSection = () => {
-    if (currentSectionIdx >= sectionList.length - 1) {
+    if (currentSectionIndex >= sectionList.length - 1) {
       setCurrentSectionName(sectionList[0]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx + 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex + 1]);
     }
     mainWrapperRef.current?.scrollTo(0, 0);
   };
@@ -101,4 +101,5 @@ const CabinetListWrapperStyled = styled.div`
   align-items: center;
   padding-bottom: 30px;
 `;
+
 export default MainPage;

--- a/frontend/src/pages/admin/AdminMainPage.tsx
+++ b/frontend/src/pages/admin/AdminMainPage.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useRef } from "react";
-import styled from "styled-components";
-import { currentFloorSectionState } from "@/recoil/selectors";
 import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
+import styled from "styled-components";
 import {
   currentFloorNumberState,
   currentSectionNameState,
 } from "@/recoil/atoms";
 import { currentCabinetIdState, targetCabinetInfoState } from "@/recoil/atoms";
-import useMenu from "@/hooks/useMenu";
-import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
+import { currentFloorSectionState } from "@/recoil/selectors";
 import CabinetListContainer from "@/components/CabinetList/CabinetList.container";
-import useMultiSelect from "@/hooks/useMultiSelect";
 import MultiSelectButton from "@/components/Common/MultiSelectButton";
+import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
+import useMenu from "@/hooks/useMenu";
+import useMultiSelect from "@/hooks/useMultiSelect";
 
-const MainPage = () => {
+const AdminMainPage = () => {
   const touchStartPosX = useRef(0);
   const touchStartPosY = useRef(0);
   const mainWrapperRef = useRef<HTMLDivElement>(null);
@@ -43,28 +43,28 @@ const MainPage = () => {
   const [currentSectionName, setCurrentSectionName] = useRecoilState<string>(
     currentSectionNameState
   );
-  const currentSectionIdx = sectionList.findIndex(
+  const currentSectionIndex = sectionList.findIndex(
     (sectionName) => sectionName === currentSectionName
   );
 
   useEffect(() => {
     resetMultiSelectMode();
-  }, [currentSectionIdx, currentFloorNumber]);
+  }, [currentSectionIndex, currentFloorNumber]);
 
   const moveToLeftSection = () => {
-    if (currentSectionIdx <= 0) {
+    if (currentSectionIndex <= 0) {
       setCurrentSectionName(sectionList[sectionList.length - 1]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx - 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex - 1]);
     }
     mainWrapperRef.current?.scrollTo(0, 0);
   };
 
   const moveToRightSection = () => {
-    if (currentSectionIdx >= sectionList.length - 1) {
+    if (currentSectionIndex >= sectionList.length - 1) {
       setCurrentSectionName(sectionList[0]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx + 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex + 1]);
     }
     mainWrapperRef.current?.scrollTo(0, 0);
   };
@@ -93,13 +93,13 @@ const MainPage = () => {
       }}
     >
       <SectionPaginationContainer />
-      <div style={{ marginBottom: `${isMultiSelect ? "0px" : "4px"}` }}>
+      <MultiSelectButtonWrapperStyled isMultiSelect={isMultiSelect}>
         <MultiSelectButton
           theme={isMultiSelect ? "fill" : "line"}
           text="다중 선택 모드"
           onClick={toggleMultiSelectMode}
         />
-      </div>
+      </MultiSelectButtonWrapperStyled>
       <CabinetListWrapperStyled>
         <CabinetListContainer isAdmin={true} />
       </CabinetListWrapperStyled>
@@ -114,6 +114,10 @@ const WapperStyled = styled.div`
   user-select: none;
 `;
 
+const MultiSelectButtonWrapperStyled = styled.div<{ isMultiSelect: boolean }>`
+  margin-bottom: ${({ isMultiSelect }) => (isMultiSelect ? "0px" : "4px")};
+`;
+
 const CabinetListWrapperStyled = styled.div`
   display: flex;
   flex-direction: column;
@@ -121,4 +125,5 @@ const CabinetListWrapperStyled = styled.div`
   align-items: center;
   padding-bottom: 30px;
 `;
-export default MainPage;
+
+export default AdminMainPage;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- main, adminMain 페이지의 import 순서를 컨벤션에 맞게 처리해 주었습니다.
- currentSectionidx 변수명을 -> currentSectionIndex로 바꾸어 좀 더 명확하게 수정했습니다.
- AdminMainPage의 다중 선택 버튼을 감싸고 있던 div를 styled-component로 수정해주었습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1137
