### PR TITLE
[BE] FIX: 대여, 반납 비관적 락으로 변경

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/Cabinet.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/domain/Cabinet.java
@@ -17,6 +17,8 @@ import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.exception.ExceptionStatus;
+import org.ftclub.cabinet.exception.ServiceException;
 
 /**
  * 사물함 엔티티
@@ -31,15 +33,6 @@ public class Cabinet {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "CABINET_ID")
 	private Long cabinetId;
-
-	/**
-	 * 사물함의 상태가 변경될 때 증가하는 버전입니다.
-	 * <p>
-	 * 동시성 문제 해결을 위한 낙관적 락을 위해 사용됩니다.
-	 */
-	@Version
-	@Getter(AccessLevel.NONE)
-	private Long version = 1L;
 
 	/**
 	 * 실물로 표시되는 번호입니다.
@@ -193,6 +186,10 @@ public class Cabinet {
 	 * @param userCount 현재 사용자 수
 	 */
 	public void specifyStatusByUserCount(Integer userCount) {
+		if (this.status.equals(CabinetStatus.BROKEN)) {
+			// To-Do: 도메인 익셉션으로 변경 필요
+			throw new ServiceException(ExceptionStatus.UNCHANGEABLE_CABINET);
+		}
 		if (userCount.equals(0)) {
 			this.status = CabinetStatus.AVAILABLE;
 			return;

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
@@ -2,6 +2,7 @@ package org.ftclub.cabinet.cabinet.repository;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
 import org.ftclub.cabinet.cabinet.domain.CabinetPlace;
 import org.ftclub.cabinet.cabinet.domain.CabinetStatus;
@@ -10,12 +11,20 @@ import org.ftclub.cabinet.cabinet.domain.Location;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CabinetRepository extends JpaRepository<Cabinet, Long> {
+
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT c "
+			+ "FROM Cabinet c "
+			+ "WHERE c.cabinetId = :cabinetId")
+	Optional<Cabinet> findByIdForUpdate(@Param("cabinetId") Long cabinetId);
 
 	@Query("SELECT DISTINCT p.location.floor "
 			+ "FROM Cabinet c "

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetExceptionHandlerService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetExceptionHandlerService.java
@@ -21,6 +21,20 @@ public class CabinetExceptionHandlerService {
 	private final CabinetRepository cabinetRepository;
 
 	/**
+	 * 사물함 ID로 변경 사항이 예정된 사물함을 찾습니다.
+	 *
+	 * X Lock을 획득한 상태로 가져옵니다.
+	 *
+	 * @param cabinetId 사물함 ID
+	 * @return 사물함 엔티티
+	 * @throws ServiceException 사물함을 찾을 수 없는 경우
+	 */
+	public Cabinet getCabinetForUpdate(Long cabinetId) {
+		return cabinetRepository.findByIdForUpdate(cabinetId)
+				.orElseThrow(() -> new ServiceException(ExceptionStatus.NOT_FOUND_CABINET));
+	}
+
+	/**
 	 * 사물함 ID로 사물함을 찾습니다.
 	 *
 	 * @param cabinetId 사물함 ID

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetService.java
@@ -24,14 +24,6 @@ public interface CabinetService {
 	void updateStatus(Long cabinetId, CabinetStatus status);
 
 	/**
-	 * 대여 시작/종료 이후의 사용자 수에 따라 사물함의 상태를 변경합니다.
-	 *
-	 * @param cabinetId 사물함 ID
-	 * @param userCount 사용자 수
-	 */
-	void updateStatusByUserCount(Long cabinetId, Integer userCount);
-
-	/**
 	 * 사물함의 메모를 업데이트합니다.
 	 *
 	 * @param cabinetId 사물함 ID

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetServiceImpl.java
@@ -41,18 +41,6 @@ public class CabinetServiceImpl implements CabinetService {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void updateStatusByUserCount(Long cabinetId, Integer userCount) {
-		Cabinet cabinet = cabinetExceptionHandlerService.getCabinet(cabinetId);
-		if (!cabinet.isStatusUpdatableByUserCount(userCount)) {
-			throw new ServiceException(ExceptionStatus.UNCHANGEABLE_CABINET);
-		}
-		cabinet.specifyStatusByUserCount(userCount);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
 	public void updateMemo(Long cabinetId, String memo) {
 		Cabinet cabinet = cabinetExceptionHandlerService.getCabinet(cabinetId);
 		cabinet.writeMemo(memo);

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentServiceImpl.java
@@ -35,7 +35,7 @@ public class LentServiceImpl implements LentService {
 	@Override
 	public void startLentCabinet(Long userId, Long cabinetId) {
 		Date now = new Date();
-		Cabinet cabinet = cabinetExceptionHandler.getCabinet(cabinetId);
+		Cabinet cabinet = cabinetExceptionHandler.getCabinetForUpdate(cabinetId);
 		User user = userExceptionHandler.getUser(userId);
 		int userActiveLentCount = lentRepository.countUserActiveLent(userId);
 		List<BanHistory> userActiveBanList = banHistoryRepository.findUserActiveBanList(userId,
@@ -75,7 +75,7 @@ public class LentServiceImpl implements LentService {
 	@Override
 	public void endLentCabinet(Long userId) {
 		LentHistory lentHistory = returnCabinet(userId);
-		Cabinet cabinet = cabinetExceptionHandler.getCabinet(lentHistory.getCabinetId());
+		Cabinet cabinet = cabinetExceptionHandler.getCabinetForUpdate(lentHistory.getCabinetId());
 		// cabinetType도 인자로 전달하면 좋을 거 같습니다 (공유사물함 3일이내 반납 페널티)
 		userService.banUser(userId, cabinet.getLentType(), lentHistory.getStartedAt(),
 				lentHistory.getEndedAt(), lentHistory.getExpiredAt());
@@ -90,9 +90,10 @@ public class LentServiceImpl implements LentService {
 		Date now = new Date();
 		userExceptionHandler.getUser(userId);
 		LentHistory lentHistory = lentExceptionHandler.getActiveLentHistoryWithUserId(userId);
+		Cabinet cabinet = cabinetExceptionHandler.getCabinetForUpdate(lentHistory.getCabinetId());
 		int activeLentCount = lentRepository.countCabinetActiveLent(lentHistory.getCabinetId());
 		lentHistory.endLent(now);
-		cabinetService.updateStatusByUserCount(lentHistory.getCabinetId(), activeLentCount - 1);
+		cabinet.specifyStatusByUserCount(activeLentCount - 1);
 		return lentHistory;
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetServiceTest.java
@@ -40,9 +40,10 @@ class CabinetServiceTest {
 	@Test
 	public void 불가능한_사물함_유저수_상태_업데이트() {
 		Long brokenId = 1L;
+		Cabinet cabinet = cabinetService.getCabinet(brokenId);
 
 		assertThrows(ServiceException.class, () -> {
-			cabinetService.updateStatusByUserCount(brokenId, 0);
+			cabinet.specifyStatusByUserCount(0);
 		});
 	}
 
@@ -52,38 +53,45 @@ class CabinetServiceTest {
 		Long overdueId = 6L;
 		Long availableId = 8L;
 		Long limitedAvailableId = 16L;
+		Cabinet fullCabinet = cabinetService.getCabinet(fullId);
+		Cabinet overdueCabinet = cabinetService.getCabinet(overdueId);
+		Cabinet availableCabinet = cabinetService.getCabinet(availableId);
+		Cabinet limitedAvailableCabinet = cabinetService.getCabinet(limitedAvailableId);
 
-		cabinetService.updateStatusByUserCount(fullId, 2);
-		cabinetService.updateStatusByUserCount(overdueId, 0);
-		cabinetService.updateStatusByUserCount(availableId, 3);
-		cabinetService.updateStatusByUserCount(limitedAvailableId, 0);
+
+		fullCabinet.specifyStatusByUserCount(2);
+		overdueCabinet.specifyStatusByUserCount(0);
+		availableCabinet.specifyStatusByUserCount(3);
+		limitedAvailableCabinet.specifyStatusByUserCount(0);
 
 		// 3 -> 2
 		assertEquals(CabinetStatus.LIMITED_AVAILABLE,
-				cabinetService.getCabinet(fullId).getStatus());
+				fullCabinet.getStatus());
 		// 0, 1, 2 -> 0
 		assertEquals(CabinetStatus.AVAILABLE,
-				cabinetService.getCabinet(overdueId).getStatus());
+				overdueCabinet.getStatus());
 		// 0, 1, 2 -> 3
 		assertEquals(CabinetStatus.FULL,
-				cabinetService.getCabinet(availableId).getStatus());
+				availableCabinet.getStatus());
 		// 1 -> 0
 		assertEquals(CabinetStatus.AVAILABLE,
-				cabinetService.getCabinet(limitedAvailableId).getStatus());
+				limitedAvailableCabinet.getStatus());
 	}
 
 	@Test
 	public void 개인_사물함_유저수_상태_업데이트() {
 		Long fullId = 3L;
 		Long availableId = 7L;
+		Cabinet fullCabinet = cabinetService.getCabinet(fullId);
+		Cabinet availableCabinet = cabinetService.getCabinet(availableId);
 
-		cabinetService.updateStatusByUserCount(fullId, 0);
-		cabinetService.updateStatusByUserCount(availableId, 1);
+		fullCabinet.specifyStatusByUserCount(0);
+		availableCabinet.specifyStatusByUserCount(1);
 
 		// 1 -> 0
-		assertEquals(CabinetStatus.AVAILABLE, cabinetService.getCabinet(fullId).getStatus());
+		assertEquals(CabinetStatus.AVAILABLE, fullCabinet.getStatus());
 		// 0 -> 1
-		assertEquals(CabinetStatus.FULL, cabinetService.getCabinet(availableId).getStatus());
+		assertEquals(CabinetStatus.FULL, availableCabinet.getStatus());
 	}
 
 	@Test


### PR DESCRIPTION
…아닌 도메인에서 사용하게끔 변경

<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1178

참조 글 : https://cabi.oopy.io/6f64bbb2-5d1d-4015-8997-29d0aca17400
앞으로의 변경사항을 고려하고, 회의를 통해서 비관적 락으로 설정하기로 결정했습니다.

비관적 락으로 변경할 수 있게끔 version 컬럼을 삭제하고, @Lock을 이용해 X Lock을 획득해서 엔티티를 가져오는 ForUpdate 메서드를 생성했습니다.

추가적으로, lentService에서 불필요하게 사용하는 cabinetService의 specifyCabinetStatusByUserCount를 도메인 메서드로 사용하게끔 변경하였습니다.

변경사항에 맞추어 테스트를 변경했습니다.
