### PR TITLE
[FE] REFACTOR: SectionPagination 및 CabinetInfoArea 리팩토링

### DIFF
--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -4,6 +4,7 @@ import {
   IAdminCurrentModalStateInfo,
   IMultiSelectTargetInfo,
   ISelectedCabinetInfo,
+  TAdminModalState,
 } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import ButtonContainer from "@/components/Common/Button";
 import AdminReturnModal from "@/components/Modals/ReturnModal/AdminReturnModal";
@@ -26,7 +27,7 @@ const AdminCabinetInfoArea: React.FC<{
   multiSelectTargetInfo: IMultiSelectTargetInfo | null;
   openLent: React.MouseEventHandler;
   adminModal: IAdminCurrentModalStateInfo;
-  currentlyOpenedModal: (moadlName: string, toggle: boolean) => void;
+  currentlyOpenedModal: (moadlName: TAdminModalState, toggle: boolean) => void;
   checkMultiReturn: (selectedCabinets: CabinetInfo[]) => boolean;
   checkMultiStatus: (selectedCabinets: CabinetInfo[]) => boolean;
 }> = ({

--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -1,29 +1,20 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
+import { ISelectedCabinetInfo } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
+import { IMultiSelectTargetInfo } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import ButtonContainer from "@/components/Common/Button";
-import CabinetStatus from "@/types/enum/cabinet.status.enum";
-import CabinetType from "@/types/enum/cabinet.type.enum";
-import cabiLogo from "@/assets/images/logo.svg";
+import AdminReturnModal from "@/components/Modals/ReturnModal/AdminReturnModal";
+import StatusModalContainer from "@/components/Modals/StatusModal/StatusModal.container";
 import {
   cabinetIconSrcMap,
   cabinetLabelColorMap,
   cabinetStatusColorMap,
 } from "@/assets/data/maps";
+import cabiLogo from "@/assets/images/logo.svg";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import CabinetType from "@/types/enum/cabinet.type.enum";
 import useMultiSelect from "@/hooks/useMultiSelect";
-import AdminReturnModal from "../Modals/ReturnModal/AdminReturnModal";
-import StatusModalContainer from "@/components/Modals/StatusModal/StatusModal.container";
-import { ISelectedCabinetInfo } from "@/components/CabinetInfoArea/CabinetInfoArea";
-
-export interface IMultiSelectTargetInfo {
-  targetCabinetInfoList: CabinetInfo[];
-  typeCounts: {
-    AVAILABLE: number;
-    EXPIRED: number;
-    SET_EXPIRE_FULL: number;
-    BROKEN: number;
-  };
-}
 
 const AdminCabinetInfoArea: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
@@ -41,7 +32,6 @@ const AdminCabinetInfoArea: React.FC<{
   const [showAdminReturnModal, setShowAdminReturnModal] =
     useState<boolean>(false);
   const [showStatusModal, setShowStatusModal] = useState<boolean>(false);
-
   const { resetMultiSelectMode, isSameStatus, isSameType } = useMultiSelect();
 
   const isLented: boolean = selectedCabinetInfo?.userNameList.at(0) !== "-";
@@ -204,8 +194,6 @@ const AdminCabinetInfoArea: React.FC<{
   );
 };
 
-export default AdminCabinetInfoArea;
-
 const NotSelectedStyled = styled.div`
   height: 100%;
   display: flex;
@@ -323,3 +311,5 @@ const MultiCabinetIconStyled = styled.div<{ status: CabinetStatus }>`
   color: ${({ status }) =>
     status === CabinetStatus.SET_EXPIRE_FULL ? "black" : "white"};
 `;
+
+export default AdminCabinetInfoArea;

--- a/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/AdminCabinetInfoArea.tsx
@@ -27,18 +27,22 @@ const AdminCabinetInfoArea: React.FC<{
   multiSelectTargetInfo: IMultiSelectTargetInfo | null;
   openLent: React.MouseEventHandler;
   adminModal: IAdminCurrentModalStateInfo;
-  currentlyOpenedModal: (moadlName: TAdminModalState, toggle: boolean) => void;
+  openModal: (moadlName: TAdminModalState) => void;
+  closeModal: (moadlName: TAdminModalState) => void;
   checkMultiReturn: (selectedCabinets: CabinetInfo[]) => boolean;
   checkMultiStatus: (selectedCabinets: CabinetInfo[]) => boolean;
+  expireDate: string | null;
 }> = ({
   selectedCabinetInfo,
   closeCabinet,
   multiSelectTargetInfo,
   openLent,
   adminModal,
-  currentlyOpenedModal,
+  openModal,
+  closeModal,
   checkMultiReturn,
   checkMultiStatus,
+  expireDate,
 }) => {
   const { targetCabinetInfoList, typeCounts } = multiSelectTargetInfo ?? {};
   const { resetMultiSelectMode } = useMultiSelect();
@@ -84,13 +88,13 @@ const AdminCabinetInfoArea: React.FC<{
         </MultiCabinetIconWrapperStyled>
         <CabinetInfoButtonsContainerStyled>
           <ButtonContainer
-            onClick={() => currentlyOpenedModal("returnModal", true)}
+            onClick={() => openModal("returnModal")}
             text="일괄 반납"
             theme="fill"
             disabled={!checkMultiReturn(targetCabinetInfoList!)}
           />
           <ButtonContainer
-            onClick={() => currentlyOpenedModal("statusModal", true)}
+            onClick={() => openModal("statusModal")}
             text="상태관리"
             theme="line"
             disabled={!checkMultiStatus(targetCabinetInfoList!)}
@@ -105,14 +109,10 @@ const AdminCabinetInfoArea: React.FC<{
           />
         </CabinetInfoButtonsContainerStyled>
         {adminModal.returnModal && (
-          <AdminReturnModal
-            closeModal={() => currentlyOpenedModal("returnModal", false)}
-          />
+          <AdminReturnModal closeModal={() => closeModal("returnModal")} />
         )}
         {adminModal.statusModal && (
-          <StatusModalContainer
-            onClose={() => currentlyOpenedModal("statusModal", false)}
-          />
+          <StatusModalContainer onClose={() => closeModal("statusModal")} />
         )}
       </CabinetDetailAreaStyled>
     );
@@ -139,7 +139,7 @@ const AdminCabinetInfoArea: React.FC<{
       </TextStyled>
       <CabinetInfoButtonsContainerStyled>
         <ButtonContainer
-          onClick={() => currentlyOpenedModal("returnModal", true)}
+          onClick={() => openModal("returnModal")}
           text="반납"
           theme="fill"
           disabled={
@@ -147,7 +147,7 @@ const AdminCabinetInfoArea: React.FC<{
           }
         />
         <ButtonContainer
-          onClick={() => currentlyOpenedModal("statusModal", true)}
+          onClick={() => openModal("statusModal")}
           text="상태 관리"
           theme="line"
         />
@@ -159,20 +159,16 @@ const AdminCabinetInfoArea: React.FC<{
         {selectedCabinetInfo!.detailMessage}
       </CabinetLentDateInfoStyled>
       <CabinetLentDateInfoStyled textColor="var(--black)">
-        {selectedCabinetInfo!.expireDate
-          ? `${selectedCabinetInfo!.expireDate.toString().substring(0, 10)}`
-          : null}
+        {expireDate}
       </CabinetLentDateInfoStyled>
       {adminModal.returnModal && (
         <AdminReturnModal
           lentType={selectedCabinetInfo!.lentType}
-          closeModal={() => currentlyOpenedModal("returnModal", false)}
+          closeModal={() => closeModal("returnModal")}
         />
       )}
       {adminModal.statusModal && (
-        <StatusModalContainer
-          onClose={() => currentlyOpenedModal("statusModal", false)}
-        />
+        <StatusModalContainer onClose={() => closeModal("statusModal")} />
       )}
     </CabinetDetailAreaStyled>
   );

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -44,8 +44,8 @@ export interface ICurrentModalStateInfo {
 }
 
 export interface IAdminCurrentModalStateInfo {
-  returnModal: false;
-  statusModal: false;
+  returnModal: boolean;
+  statusModal: boolean;
 }
 
 interface ICount {

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -1,21 +1,56 @@
 import { useRecoilValue } from "recoil";
 import { myCabinetInfoState, targetCabinetInfoState } from "@/recoil/atoms";
-import CabinetInfoArea, {
-  ISelectedCabinetInfo,
-} from "@/components/CabinetInfoArea/CabinetInfoArea";
+import AdminCabinetInfoArea from "@/components/CabinetInfoArea/AdminCabinetInfoArea";
+import CabinetInfoArea from "@/components/CabinetInfoArea/CabinetInfoArea";
+import AdminCabinetLentLogContainer from "@/components/LentLog/AdminCabinetLentLog.container";
 import { CabinetInfo, MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import CabinetType from "@/types/enum/cabinet.type.enum";
 import useMenu from "@/hooks/useMenu";
 import useMultiSelect from "@/hooks/useMultiSelect";
-import AdminCabinetInfoArea, {
-  IMultiSelectTargetInfo,
-} from "@/components/CabinetInfoArea/AdminCabinetInfoArea";
-import AdminCabinetLentLogContainer from "@/components/LentLog/AdminCabinetLentLog.container";
+
+export interface ISelectedCabinetInfo {
+  floor: number;
+  section: string;
+  cabinetId: number;
+  cabinetNum: number;
+  status: CabinetStatus;
+  lentType: CabinetType;
+  userNameList: string;
+  expireDate?: Date;
+  detailMessage: string | null;
+  detailMessageColor: string;
+  isAdmin: boolean;
+  isLented: boolean;
+}
+
+export interface IMultiSelectTargetInfo {
+  targetCabinetInfoList: CabinetInfo[];
+  typeCounts: {
+    AVAILABLE: number;
+    EXPIRED: number;
+    SET_EXPIRE_FULL: number;
+    BROKEN: number;
+  };
+}
+
+interface ICount {
+  AVAILABLE: number;
+  SET_EXPIRE_FULL: number;
+  EXPIRED: number;
+  BROKEN: number;
+}
 
 const calExpiredTime = (expireTime: Date) =>
   Math.floor(
     (expireTime.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
   );
+
+const setExpireDate = (date: Date | undefined) => {
+  if (!date) return null;
+  if (date.toString().slice(0, 4) === "9999") return null;
+  return date.toString().slice(0, 10);
+};
 
 const getCalcualtedTimeString = (expireTime: Date) => {
   const remainTime = calExpiredTime(expireTime);
@@ -98,13 +133,6 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       }
     : null;
 
-  interface ICount {
-    AVAILABLE: number;
-    SET_EXPIRE_FULL: number;
-    EXPIRED: number;
-    BROKEN: number;
-  }
-
   const countTypes = (cabinetList: CabinetInfo[]) =>
     cabinetList.reduce(
       (result, cabinet): ICount => {
@@ -139,6 +167,12 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       selectedCabinetInfo={cabinetViewData}
       myCabinetId={myCabinetInfo?.cabinet_id}
       closeCabinet={closeCabinet}
+      expireDate={setExpireDate(cabinetViewData?.expireDate)}
+      isMine={myCabinetInfo?.cabinet_id === cabinetViewData?.cabinetId}
+      isAvailable={
+        cabinetViewData?.status === "AVAILABLE" ||
+        cabinetViewData?.status === "SET_EXPIRE_AVAILABLE"
+      }
     />
   );
 };

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -187,20 +187,31 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       }
     : null;
 
-  const currentlyOpenedModal = (modalName: TModalState, toggle: boolean) => {
+  const openModal = (modalName: TModalState) => {
     setUserModal({
       ...userModal,
-      [modalName]: toggle,
+      [modalName]: true,
     });
   };
 
-  const currentlyOpenedAdminModal = (
-    modalName: TAdminModalState,
-    toggle: boolean
-  ) => {
+  const closeModal = (modalName: TModalState) => {
+    setUserModal({
+      ...userModal,
+      [modalName]: false,
+    });
+  };
+
+  const openAdminModal = (modalName: TAdminModalState) => {
     setAdminModal({
       ...adminModal,
-      [modalName]: toggle,
+      [modalName]: true,
+    });
+  };
+
+  const closeAdminModal = (modalName: TAdminModalState) => {
+    setAdminModal({
+      ...adminModal,
+      [modalName]: false,
     });
   };
 
@@ -230,9 +241,11 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
         multiSelectTargetInfo={multiSelectInfo}
         openLent={toggleLent}
         adminModal={adminModal}
-        currentlyOpenedModal={currentlyOpenedAdminModal}
+        openModal={openAdminModal}
+        closeModal={closeAdminModal}
         checkMultiReturn={checkMultiReturn}
         checkMultiStatus={checkMultiStatus}
+        expireDate={setExpireDate(cabinetViewData?.expireDate)}
       />
       {cabinetViewData && <AdminCabinetLentLogContainer />}
     </>
@@ -247,7 +260,8 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
         cabinetViewData?.status === "SET_EXPIRE_AVAILABLE"
       }
       userModal={userModal}
-      currentlyOpenedModal={currentlyOpenedModal}
+      openModal={openModal}
+      closeModal={closeModal}
     />
   );
 };

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -55,6 +55,15 @@ interface ICount {
   BROKEN: number;
 }
 
+export type TModalState =
+  | "lentModal"
+  | "unavailableModal"
+  | "returnModal"
+  | "memoModal"
+  | "passwordCheckModal";
+
+export type TAdminModalState = "returnModal" | "statusModal";
+
 const calExpiredTime = (expireTime: Date) =>
   Math.floor(
     (expireTime.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
@@ -178,14 +187,17 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       }
     : null;
 
-  const currentlyOpenedModal = (modalName: string, toggle: boolean) => {
+  const currentlyOpenedModal = (modalName: TModalState, toggle: boolean) => {
     setUserModal({
       ...userModal,
       [modalName]: toggle,
     });
   };
 
-  const currentlyOpenedAdminModal = (modalName: string, toggle: boolean) => {
+  const currentlyOpenedAdminModal = (
+    modalName: TAdminModalState,
+    toggle: boolean
+  ) => {
     setAdminModal({
       ...adminModal,
       [modalName]: toggle,

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import styled, { css } from "styled-components";
-import { ISelectedCabinetInfo } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
+import {
+  ICurrentModalStateInfo,
+  ISelectedCabinetInfo,
+} from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import ButtonContainer from "@/components/Common/Button";
 import LentModal from "@/components/Modals/LentModal/LentModal";
 import MemoModalContainer from "@/components/Modals/MemoModal/MemoModal.container";
@@ -19,59 +22,21 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 
 const CabinetInfoArea: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
-  myCabinetId?: number;
   closeCabinet: () => void;
   expireDate: string | null;
   isMine: boolean;
   isAvailable: boolean;
+  userModal: ICurrentModalStateInfo;
+  currentlyOpenedModal: (modalName: string, toggle: boolean) => void;
 }> = ({
   selectedCabinetInfo,
-  myCabinetId,
   closeCabinet,
   expireDate,
   isMine,
   isAvailable,
+  userModal,
+  currentlyOpenedModal,
 }) => {
-  const [showUnavailableModal, setShowUnavailableModal] =
-    useState<boolean>(false);
-  const [showLentModal, setShowLentModal] = useState<boolean>(false);
-  const [showReturnModal, setShowReturnModal] = useState<boolean>(false);
-  const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
-  const [showPasswordCheckModal, setPasswordCheckModal] =
-    useState<boolean>(false);
-
-  const handleOpenLentModal = () => {
-    if (myCabinetId) return handleOpenUnavailableModal();
-    setShowLentModal(true);
-  };
-  const handleCloseLentModal = () => {
-    setShowLentModal(false);
-  };
-  const handleOpenReturnModal = () => {
-    setShowReturnModal(true);
-  };
-  const handleCloseReturnModal = () => {
-    setShowReturnModal(false);
-  };
-  const handleOpenMemoModal = () => {
-    setShowMemoModal(true);
-  };
-  const handleCloseMemoModal = () => {
-    setShowMemoModal(false);
-  };
-  const handleOpenUnavailableModal = () => {
-    setShowUnavailableModal(true);
-  };
-  const handleCloseUnavailableModal = () => {
-    setShowUnavailableModal(false);
-  };
-  const handleOpenPasswordCheckModal = () => {
-    setPasswordCheckModal(true);
-  };
-  const handleClosePasswordCheckModal = () => {
-    setPasswordCheckModal(false);
-  };
-
   return selectedCabinetInfo === null ? (
     <NotSelectedStyled>
       <CabiLogoStyled src={cabiLogo} />
@@ -102,12 +67,12 @@ const CabinetInfoArea: React.FC<{
         {isMine ? (
           <>
             <ButtonContainer
-              onClick={handleOpenReturnModal}
+              onClick={() => currentlyOpenedModal("returnModal", true)}
               text="반납"
               theme="fill"
             />
             <ButtonContainer
-              onClick={handleOpenMemoModal}
+              onClick={() => currentlyOpenedModal("memoModal", true)}
               text="메모관리"
               theme="line"
             />
@@ -120,7 +85,7 @@ const CabinetInfoArea: React.FC<{
         ) : (
           <>
             <ButtonContainer
-              onClick={handleOpenLentModal}
+              onClick={() => currentlyOpenedModal("lentModal", true)}
               text="대여"
               theme="fill"
               disabled={!isAvailable}
@@ -137,28 +102,36 @@ const CabinetInfoArea: React.FC<{
       <CabinetLentDateInfoStyled textColor="var(--black)">
         {expireDate}
       </CabinetLentDateInfoStyled>
-      {showUnavailableModal && (
+      {userModal.unavailableModal && (
         <UnavailableModal
           status={additionalModalType.MODAL_UNAVAILABLE_ALREADY_LENT}
-          closeModal={handleCloseUnavailableModal}
+          closeModal={() => currentlyOpenedModal("unavailableModal", false)}
         />
       )}
-      {showLentModal && (
+      {userModal.lentModal && (
         <LentModal
           lentType={selectedCabinetInfo!.lentType}
-          closeModal={handleCloseLentModal}
+          closeModal={() => currentlyOpenedModal("lentModal", false)}
         />
       )}
-      {showReturnModal && (
+      {userModal.returnModal && (
         <ReturnModal
           lentType={selectedCabinetInfo!.lentType}
-          handleOpenPasswordCheckModal={handleOpenPasswordCheckModal}
-          closeModal={handleCloseReturnModal}
+          handleOpenPasswordCheckModal={() =>
+            currentlyOpenedModal("passwordCheckModal", true)
+          }
+          closeModal={() => currentlyOpenedModal("returnModal", false)}
         />
       )}
-      {showMemoModal && <MemoModalContainer onClose={handleCloseMemoModal} />}
-      {showPasswordCheckModal && (
-        <PasswordCheckModalContainer onClose={handleClosePasswordCheckModal} />
+      {userModal.memoModal && (
+        <MemoModalContainer
+          onClose={() => currentlyOpenedModal("memoModal", false)}
+        />
+      )}
+      {userModal.passwordCheckModal && (
+        <PasswordCheckModalContainer
+          onClose={() => currentlyOpenedModal("passwordCheckModal", false)}
+        />
       )}
     </CabinetDetailAreaStyled>
   );

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -3,6 +3,7 @@ import styled, { css } from "styled-components";
 import {
   ICurrentModalStateInfo,
   ISelectedCabinetInfo,
+  TModalState,
 } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import ButtonContainer from "@/components/Common/Button";
 import LentModal from "@/components/Modals/LentModal/LentModal";
@@ -27,7 +28,7 @@ const CabinetInfoArea: React.FC<{
   isMine: boolean;
   isAvailable: boolean;
   userModal: ICurrentModalStateInfo;
-  currentlyOpenedModal: (modalName: string, toggle: boolean) => void;
+  currentlyOpenedModal: (modalName: TModalState, toggle: boolean) => void;
 }> = ({
   selectedCabinetInfo,
   closeCabinet,

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -28,7 +28,8 @@ const CabinetInfoArea: React.FC<{
   isMine: boolean;
   isAvailable: boolean;
   userModal: ICurrentModalStateInfo;
-  currentlyOpenedModal: (modalName: TModalState, toggle: boolean) => void;
+  openModal: (modalName: TModalState) => void;
+  closeModal: (modalName: TModalState) => void;
 }> = ({
   selectedCabinetInfo,
   closeCabinet,
@@ -36,7 +37,8 @@ const CabinetInfoArea: React.FC<{
   isMine,
   isAvailable,
   userModal,
-  currentlyOpenedModal,
+  openModal,
+  closeModal,
 }) => {
   return selectedCabinetInfo === null ? (
     <NotSelectedStyled>
@@ -68,12 +70,12 @@ const CabinetInfoArea: React.FC<{
         {isMine ? (
           <>
             <ButtonContainer
-              onClick={() => currentlyOpenedModal("returnModal", true)}
+              onClick={() => openModal("returnModal")}
               text="반납"
               theme="fill"
             />
             <ButtonContainer
-              onClick={() => currentlyOpenedModal("memoModal", true)}
+              onClick={() => openModal("memoModal")}
               text="메모관리"
               theme="line"
             />
@@ -86,7 +88,7 @@ const CabinetInfoArea: React.FC<{
         ) : (
           <>
             <ButtonContainer
-              onClick={() => currentlyOpenedModal("lentModal", true)}
+              onClick={() => openModal("lentModal")}
               text="대여"
               theme="fill"
               disabled={!isAvailable}
@@ -106,32 +108,28 @@ const CabinetInfoArea: React.FC<{
       {userModal.unavailableModal && (
         <UnavailableModal
           status={additionalModalType.MODAL_UNAVAILABLE_ALREADY_LENT}
-          closeModal={() => currentlyOpenedModal("unavailableModal", false)}
+          closeModal={() => closeModal("unavailableModal")}
         />
       )}
       {userModal.lentModal && (
         <LentModal
           lentType={selectedCabinetInfo!.lentType}
-          closeModal={() => currentlyOpenedModal("lentModal", false)}
+          closeModal={() => closeModal("lentModal")}
         />
       )}
       {userModal.returnModal && (
         <ReturnModal
           lentType={selectedCabinetInfo!.lentType}
-          handleOpenPasswordCheckModal={() =>
-            currentlyOpenedModal("passwordCheckModal", true)
-          }
-          closeModal={() => currentlyOpenedModal("returnModal", false)}
+          handleOpenPasswordCheckModal={() => openModal("passwordCheckModal")}
+          closeModal={() => closeModal("returnModal")}
         />
       )}
       {userModal.memoModal && (
-        <MemoModalContainer
-          onClose={() => currentlyOpenedModal("memoModal", false)}
-        />
+        <MemoModalContainer onClose={() => closeModal("memoModal")} />
       )}
       {userModal.passwordCheckModal && (
         <PasswordCheckModalContainer
-          onClose={() => currentlyOpenedModal("passwordCheckModal", false)}
+          onClose={() => closeModal("passwordCheckModal")}
         />
       )}
     </CabinetDetailAreaStyled>

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
+import { ISelectedCabinetInfo } from "@/components/CabinetInfoArea/CabinetInfoArea.container";
 import ButtonContainer from "@/components/Common/Button";
-import CabinetStatus from "@/types/enum/cabinet.status.enum";
-import CabinetType from "@/types/enum/cabinet.type.enum";
-import cabiLogo from "@/assets/images/logo.svg";
-import MemoModalContainer from "@/components/Modals/MemoModal/MemoModal.container";
 import LentModal from "@/components/Modals/LentModal/LentModal";
+import MemoModalContainer from "@/components/Modals/MemoModal/MemoModal.container";
+import PasswordCheckModalContainer from "@/components/Modals/PasswordCheckModal/PasswordCheckModal.container";
 import ReturnModal from "@/components/Modals/ReturnModal/ReturnModal";
 import UnavailableModal from "@/components/Modals/UnavailableModal/UnavailableModal";
 import {
@@ -14,34 +13,25 @@ import {
   cabinetLabelColorMap,
   cabinetStatusColorMap,
 } from "@/assets/data/maps";
-import PasswordCheckModalContainer from "../Modals/PasswordCheckModal/PasswordCheckModal.container";
-
-export interface ISelectedCabinetInfo {
-  floor: number;
-  section: string;
-  cabinetId: number;
-  cabinetNum: number;
-  status: CabinetStatus;
-  lentType: CabinetType;
-  userNameList: string;
-  expireDate?: Date;
-  detailMessage: string | null;
-  detailMessageColor: string;
-  isAdmin: boolean;
-  isLented: boolean;
-}
-
-const setExprieDate = (date: Date | undefined) => {
-  if (!date) return null;
-  if (date.toString().slice(0, 4) === "9999") return null;
-  return date.toString().slice(0, 10);
-};
+import cabiLogo from "@/assets/images/logo.svg";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
+import CabinetType from "@/types/enum/cabinet.type.enum";
 
 const CabinetInfoArea: React.FC<{
   selectedCabinetInfo: ISelectedCabinetInfo | null;
   myCabinetId?: number;
   closeCabinet: () => void;
-}> = ({ selectedCabinetInfo, myCabinetId, closeCabinet }) => {
+  expireDate: string | null;
+  isMine: boolean;
+  isAvailable: boolean;
+}> = ({
+  selectedCabinetInfo,
+  myCabinetId,
+  closeCabinet,
+  expireDate,
+  isMine,
+  isAvailable,
+}) => {
   const [showUnavailableModal, setShowUnavailableModal] =
     useState<boolean>(false);
   const [showLentModal, setShowLentModal] = useState<boolean>(false);
@@ -49,14 +39,6 @@ const CabinetInfoArea: React.FC<{
   const [showMemoModal, setShowMemoModal] = useState<boolean>(false);
   const [showPasswordCheckModal, setPasswordCheckModal] =
     useState<boolean>(false);
-  const isMine: boolean = myCabinetId
-    ? selectedCabinetInfo?.cabinetId === myCabinetId
-    : false;
-  const isAvailable: boolean =
-    selectedCabinetInfo?.status === "AVAILABLE" ||
-    selectedCabinetInfo?.status === "SET_EXPIRE_AVAILABLE"
-      ? true
-      : false;
 
   const handleOpenLentModal = () => {
     if (myCabinetId) return handleOpenUnavailableModal();
@@ -90,19 +72,15 @@ const CabinetInfoArea: React.FC<{
     setPasswordCheckModal(false);
   };
 
-  if (!selectedCabinetInfo)
-    //아무 사물함도 선택하지 않았을 때
-    return (
-      <NotSelectedStyled>
-        <CabiLogoStyled src={cabiLogo} />
-        <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
-          사물함를 <br />
-          선택해주세요
-        </TextStyled>
-      </NotSelectedStyled>
-    );
-  // 단일 선택 시 보이는 cabinetInfoArea
-  return (
+  return selectedCabinetInfo === null ? (
+    <NotSelectedStyled>
+      <CabiLogoStyled src={cabiLogo} />
+      <TextStyled fontSize="1.125rem" fontColor="var(--gray-color)">
+        사물함를 <br />
+        선택해주세요
+      </TextStyled>
+    </NotSelectedStyled>
+  ) : (
     <CabinetDetailAreaStyled>
       <TextStyled fontSize="1rem" fontColor="var(--gray-color)">
         {selectedCabinetInfo!.floor + "F - " + selectedCabinetInfo!.section}
@@ -145,7 +123,7 @@ const CabinetInfoArea: React.FC<{
               onClick={handleOpenLentModal}
               text="대여"
               theme="fill"
-              disabled={isAvailable ? false : true}
+              disabled={!isAvailable}
             />
             <ButtonContainer onClick={closeCabinet} text="취소" theme="line" />
           </>
@@ -157,7 +135,7 @@ const CabinetInfoArea: React.FC<{
         {selectedCabinetInfo!.detailMessage}
       </CabinetLentDateInfoStyled>
       <CabinetLentDateInfoStyled textColor="var(--black)">
-        {setExprieDate(selectedCabinetInfo!.expireDate)}
+        {expireDate}
       </CabinetLentDateInfoStyled>
       {showUnavailableModal && (
         <UnavailableModal
@@ -185,8 +163,6 @@ const CabinetInfoArea: React.FC<{
     </CabinetDetailAreaStyled>
   );
 };
-
-export default CabinetInfoArea;
 
 const NotSelectedStyled = styled.div`
   height: 100%;
@@ -273,21 +249,4 @@ const CabinetLentDateInfoStyled = styled.div<{ textColor: string }>`
   text-align: center;
 `;
 
-const MultiCabinetIconWrapperStyled = styled.div`
-  display: grid;
-  grid-template-columns: 40px 40px;
-  width: 90px;
-  height: 90px;
-  margin-top: 15px;
-  grid-gap: 10px;
-`;
-
-const MultiCabinetIconStyled = styled.div<{ status: CabinetStatus }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: ${({ status }) => cabinetStatusColorMap[status]};
-  border-radius: 5px;
-  color: ${({ status }) =>
-    status === CabinetStatus.SET_EXPIRE_FULL ? "black" : "white"};
-`;
+export default CabinetInfoArea;

--- a/frontend/src/components/SectionPagination/SectionPagination.container.tsx
+++ b/frontend/src/components/SectionPagination/SectionPagination.container.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useRecoilValue, useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import {
   currentFloorNumberState,
   currentSectionNameState,
@@ -13,32 +13,32 @@ const SectionPaginationContainer = (): JSX.Element => {
   const [currentSectionName, setCurrentSectionName] = useRecoilState<string>(
     currentSectionNameState
   );
-  const currentSectionIdx = sectionList.findIndex(
+  const currentSectionIndex = sectionList.findIndex(
     (sectionName) => sectionName === currentSectionName
   );
   const currentPositionName = floor?.toString() + "층 - " + currentSectionName;
 
-  const changeSectionOnClickIdxButton = (idx: number) => {
+  const changeSectionOnClickIndexButton = (index: number) => {
     if (sectionList === undefined) return;
 
-    const targetSectionName = sectionList.at(idx);
+    const targetSectionName = sectionList.at(index);
     if (targetSectionName === undefined) return;
     setCurrentSectionName(targetSectionName);
   };
 
   const moveToLeftSection = () => {
-    if (currentSectionIdx <= 0) {
+    if (currentSectionIndex <= 0) {
       setCurrentSectionName(sectionList[sectionList.length - 1]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx - 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex - 1]);
     }
   };
 
   const moveToRightSection = () => {
-    if (currentSectionIdx >= sectionList.length - 1) {
+    if (currentSectionIndex >= sectionList.length - 1) {
       setCurrentSectionName(sectionList[0]);
     } else {
-      setCurrentSectionName(sectionList[currentSectionIdx + 1]);
+      setCurrentSectionName(sectionList[currentSectionIndex + 1]);
     }
   };
 
@@ -54,7 +54,7 @@ const SectionPaginationContainer = (): JSX.Element => {
           currentSectionName={currentSectionName}
           currentPositionName={currentPositionName}
           sectionList={sectionList}
-          changeSectionOnClickIdxButton={changeSectionOnClickIdxButton}
+          changeSectionOnClickIndexButton={changeSectionOnClickIndexButton}
           moveToLeftSection={moveToLeftSection}
           moveToRightSection={moveToRightSection}
         />

--- a/frontend/src/components/SectionPagination/SectionPagination.tsx
+++ b/frontend/src/components/SectionPagination/SectionPagination.tsx
@@ -5,7 +5,7 @@ const SectionPagination: React.FC<{
   currentSectionName: string;
   currentPositionName: string;
   sectionList: Array<string>;
-  changeSectionOnClickIdxButton: (idx: number) => void;
+  changeSectionOnClickIndexButton: (index: number) => void;
   moveToLeftSection: React.MouseEventHandler;
   moveToRightSection: React.MouseEventHandler;
 }> = (props) => {
@@ -13,15 +13,16 @@ const SectionPagination: React.FC<{
     currentSectionName,
     currentPositionName,
     sectionList,
-    changeSectionOnClickIdxButton,
+    changeSectionOnClickIndexButton,
     moveToLeftSection,
     moveToRightSection,
   } = props;
-  const paginationIdxBar = sectionList.map((sectionName, idx) => (
+
+  const paginationIndexBar = sectionList.map((sectionName, index) => (
     <IndexRectangleStyled
       key={sectionName}
-      bgColor={sectionName === currentSectionName ? "#9747FF" : "#D9D9D9"}
-      onClick={() => changeSectionOnClickIdxButton(idx)}
+      filledColor={sectionName === currentSectionName ? "#9747FF" : "#D9D9D9"}
+      onClick={() => changeSectionOnClickIndexButton(index)}
       className="cabiButton"
     />
   ));
@@ -37,17 +38,15 @@ const SectionPagination: React.FC<{
         <SectionNameTextStyled>{currentPositionName}</SectionNameTextStyled>
         <MoveSectionButtonStyled
           src={LeftSectionButton}
-          needRotate
+          arrowReversed={true}
           onClick={moveToRightSection}
           className="cabiButton"
         />
       </SectionBarStyled>
-      <SectionIndexStyled>{paginationIdxBar}</SectionIndexStyled>
+      <SectionIndexStyled>{paginationIndexBar}</SectionIndexStyled>
     </SectionPaginationStyled>
   );
 };
-
-export default SectionPagination;
 
 const SectionPaginationStyled = styled.div`
   min-width: 360px;
@@ -70,18 +69,18 @@ const SectionBarStyled = styled.div`
   align-items: center;
 `;
 
-const MoveSectionButtonStyled = styled.img<{ needRotate?: boolean }>`
+const MoveSectionButtonStyled = styled.img<{ arrowReversed?: boolean }>`
   width: 24px;
   height: 24px;
   margin: 0px 15px;
   opacity: 70%;
   cursor: pointer;
-  transform: rotate(${(props) => (props.needRotate ? "180deg" : "0")});
+  transform: rotate(${(props) => (props.arrowReversed ? "180deg" : "0")});
   transition: all 0.2s;
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       opacity: 100%;
-      transform: rotate(${(props) => (props.needRotate ? "180deg" : "0")})
+      transform: rotate(${(props) => (props.arrowReversed ? "180deg" : "0")})
         scale(1.3);
     }
   }
@@ -100,12 +99,12 @@ const SectionIndexStyled = styled.div`
   justify-content: center;
 `;
 
-const IndexRectangleStyled = styled.div<{ bgColor: string }>`
+const IndexRectangleStyled = styled.div<{ filledColor: string }>`
   width: 15px;
   height: 8px;
   border-radius: 2px;
   margin: 0px 3px;
-  background: ${(props) => props.bgColor};
+  background: ${(props) => props.filledColor};
   cursor: pointer;
   transition: all 0.2s;
   @media (hover: hover) and (pointer: fine) {
@@ -115,3 +114,5 @@ const IndexRectangleStyled = styled.div<{ bgColor: string }>`
     }
   }
 `;
+
+export default SectionPagination;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
- SectionPagination 및 CabinetInfoArea의 import 순서를 수정했습니다.
- 변수명을 좀 더 명확하게 수정했습니다.
- CabinetInfoArea, AdminCabinetInfoArea 와 CabinetInfoAreaContainer의 기능 분리 작업을 진행했습니다. 기존 아키텍쳐 컨벤션에 맞게 혼재되어 있던 로직과 스타일드 컴포넌트를 분리해 주었습니다.
- 이전 yooh님이 올려 주신 코드를 참고하여 모달이 오픈되는 상태를 좀 더 분명하게 명시해 주었습니다.
-논의해보고 싶은 점: 현재 Container 코드가 너무 길어 AdminCabinetInfoAreaContainer를 따로 빼는 것이 좋을지. interface 분리에 대한 컨벤션 논의

-모달 오픈 함수를 좀 더 명학하게 사용하기 위해 open과close로 분리했습니다.

- 모달 type 추가
https://github.com/innovationacademy-kr/42cabi/issues/1137
