### PR TITLE
[FE] fix: 현재 위치한 층과 동일한 맵 띄우기 #1133

### DIFF
--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
@@ -10,6 +10,7 @@ import {
   currentFloorCabinetState,
   currentFloorNumberState,
   currentLocationNameState,
+  currentMapFloorState,
   currentSectionNameState,
   isCurrentSectionRenderState,
   numberOfAdminWorkState,
@@ -19,8 +20,8 @@ import { currentLocationFloorState } from "@/recoil/selectors";
 import LeftMainNav from "@/components/LeftNav/LeftMainNav/LeftMainNav";
 import { CabinetInfoByLocationFloorDto } from "@/types/dto/cabinet.dto";
 import { UserDto } from "@/types/dto/user.dto";
-import { removeCookie } from "@/api/react_cookie/cookies";
 import { axiosCabinetByLocationFloor } from "@/api/axios/axios.custom";
+import { removeCookie } from "@/api/react_cookie/cookies";
 import useIsMount from "@/hooks/useIsMount";
 import useMenu from "@/hooks/useMenu";
 
@@ -29,6 +30,7 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
   const [currentFloor, setCurrentFloor] = useRecoilState<number>(
     currentFloorNumberState
   );
+  const setCurrentMapFloor = useSetRecoilState<number>(currentMapFloorState);
   const currentLocation = useRecoilValue<string>(currentLocationNameState);
   const myInfo = useRecoilValue<UserDto>(userState);
   const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
@@ -47,7 +49,10 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
   );
 
   useEffect(() => {
-    if (currentFloor === undefined) return;
+    if (currentFloor === undefined) {
+      setCurrentMapFloor(floors[0]);
+      return;
+    }
     axiosCabinetByLocationFloor(currentLocation, currentFloor)
       .then((response) => {
         setCurrentFloorData(response.data);
@@ -72,6 +77,7 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
 
   const onClickFloorButton = (floor: number) => {
     setCurrentFloor(floor);
+    setCurrentMapFloor(floor);
     if (!pathname.includes("main")) {
       if (floor === currentFloor) {
         axiosCabinetByLocationFloor(currentLocation, currentFloor).then(

--- a/frontend/src/components/MapInfo/MapInfo.container.tsx
+++ b/frontend/src/components/MapInfo/MapInfo.container.tsx
@@ -1,5 +1,6 @@
-import React, { useRef, useState } from "react";
-import { useRecoilValue } from "recoil";
+import React, { useEffect, useRef } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { currentFloorNumberState, currentMapFloorState } from "@/recoil/atoms";
 import { currentLocationFloorState } from "@/recoil/selectors";
 import MapInfo from "@/components/MapInfo/MapInfo";
 import useMenu from "@/hooks/useMenu";
@@ -7,9 +8,19 @@ import useMenu from "@/hooks/useMenu";
 const MapInfoContainer = () => {
   const { closeMap } = useMenu();
   const floorInfo = useRecoilValue(currentLocationFloorState);
-  const [floor, setFloor] = useState(floorInfo[0]);
+  const [currentMapFloor, setCurrentMapFloor] =
+    useRecoilState<number>(currentMapFloorState);
+  const [currentFloor] = useRecoilState<number>(currentFloorNumberState);
   const touchXpos = useRef(0);
   const touchYpos = useRef(0);
+
+  useEffect(() => {
+    if (currentMapFloor === undefined) {
+      if (currentFloor === undefined) setCurrentMapFloor(floorInfo[0]);
+      else setCurrentMapFloor(currentFloor);
+      return;
+    }
+  }, [currentMapFloor]);
 
   const touchStart = (e: React.TouchEvent) => {
     touchXpos.current = e.changedTouches[0].clientX;
@@ -19,9 +30,9 @@ const MapInfoContainer = () => {
   const touchEnd = (e: React.TouchEvent) => {
     const offsetX = Math.round(e.changedTouches[0].clientX - touchXpos.current);
     const offsetY = Math.round(e.changedTouches[0].clientY - touchYpos.current);
-    let index = floorInfo.indexOf(floor);
+    let index = floorInfo.indexOf(currentMapFloor);
     index = swipeMap(offsetX, offsetY, index);
-    setFloor(floorInfo[index]);
+    setCurrentMapFloor(floorInfo[index]);
   };
 
   const swipeMap = (offsetX: number, offsetY: number, index: number) => {
@@ -37,8 +48,8 @@ const MapInfoContainer = () => {
     <MapInfo
       touchStart={touchStart}
       touchEnd={touchEnd}
-      floor={floor}
-      setFloor={setFloor}
+      floor={currentMapFloor}
+      setFloor={setCurrentMapFloor}
       floorInfo={floorInfo}
       closeMap={closeMap}
     />

--- a/frontend/src/recoil/atoms.ts
+++ b/frontend/src/recoil/atoms.ts
@@ -1,15 +1,15 @@
-import { recoilPersist } from "recoil-persist";
-import { UserDto, UserInfo } from "@/types/dto/user.dto";
-import {
-  CabinetInfo,
-  CabinetInfoByLocationFloorDto,
-  MyCabinetInfoResponseDto,
-  CabinetLocationFloorDto,
-} from "@/types/dto/cabinet.dto";
 import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
 import { staticColNumData } from "@/assets/data/sectionColNumData";
 import { ILocationColNum } from "@/assets/data/sectionColNumData";
 import { ITableData } from "@/types/dto/admin.dto";
+import {
+  CabinetInfo,
+  CabinetInfoByLocationFloorDto,
+  CabinetLocationFloorDto,
+  MyCabinetInfoResponseDto,
+} from "@/types/dto/cabinet.dto";
+import { UserDto, UserInfo } from "@/types/dto/user.dto";
 
 const { persistAtom } = recoilPersist();
 
@@ -58,6 +58,11 @@ export const currentFloorNumberState = atom<number>({
   key: "CurrentFloor",
   default: undefined,
   effects_UNSTABLE: [persistAtom],
+});
+
+export const currentMapFloorState = atom<number>({
+  key: "CurrentMapFloor",
+  default: undefined,
 });
 
 export const currentSectionNameState = atom<string>({


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1133
- 위치한 층이 변화하더라도 2층 또는 사용자가 이전에 봤던 층의 지도가 뜬다는 기존의 사항을 변경했습니다.
- currentMapFloorState라는 recoil 전역 상태관리를 사용하여 층이 변화할 때 맵도 변화하도록 수정하였습니다.
- 어떠한 층에 위치한 상태에서 새로고침을 하면 currentFloor가 undefined되어서 이에 대한 예외처리를 useEffect로 처리하였습니다.