### PR TITLE
[FE] BUG: AdminHomePage 에서 표가 모바일 환경에서 잘 보이게 조정과 변수명을 페이지명에 맞춰 변경 #1206

### DIFF
--- a/frontend/src/pages/admin/AdminHomePage.tsx
+++ b/frontend/src/pages/admin/AdminHomePage.tsx
@@ -203,7 +203,7 @@ const AdminInfoStyled = styled.div`
   @media screen and (max-width: 768px) {
     grid-template-columns: repeat(1, 1fr);
     grid-template-rows: repeat(6, 500px);
-    min-width: 500px;
+    min-width: 300px;
     overflow: scroll;
   }
 `;

--- a/frontend/src/pages/admin/AdminHomePage.tsx
+++ b/frontend/src/pages/admin/AdminHomePage.tsx
@@ -88,7 +88,7 @@ const AdminHomePage = () => {
     );
   }, []);
   return (
-    <AdminInfoStyled>
+    <AdminHomeStyled>
       <ContainerStyled>
         <H2styled>층별 이용 현황</H2styled>
         <BarChart data={cabinetNumbersPerFloor} />
@@ -132,7 +132,7 @@ const AdminHomePage = () => {
           ROW_COUNT={5}
         />
       </ContainerStyled>
-    </AdminInfoStyled>
+    </AdminHomeStyled>
   );
 };
 
@@ -184,7 +184,7 @@ const ContainerStyled = styled.div`
   }
 `;
 
-const AdminInfoStyled = styled.div`
+const AdminHomeStyled = styled.div`
   background: var(--white);
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- AdminHomeStyled 에서 min-width 프로퍼티를 대부분의 모바일 환경에서 짤리지 않게 보이게 300px 로 줄였습니다. 280px 이하에서는 표의 데이터가 잘 보이지 않는 문제가 있어 더 줄이지는 않았습니다.

- AdminInfoPage 가 AdminHomePage 로 이름이 바뀌어서 이에 맞춰 변수명을 수정했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1206
