### PR TITLE
[FE] feat:mapBackGround_floorInfo 추가

### DIFF
--- a/frontend/src/assets/data/mapPositionData.ts
+++ b/frontend/src/assets/data/mapPositionData.ts
@@ -79,6 +79,14 @@ export const mapPostionData: IFloorSectionsInfo = {
       name: "Cluster 1 - Terrace2",
       type: "cabinet",
     },
+    {
+      colStart: 3,
+      colEnd: 4,
+      rowStart: 4,
+      rowEnd: 6,
+      name: "2F",
+      type: "floorInfo",
+    },
   ],
   "3": [
     {
@@ -145,6 +153,14 @@ export const mapPostionData: IFloorSectionsInfo = {
       name: "Cluster X - 1",
       type: "cabinet",
     },
+    {
+      colStart: 3,
+      colEnd: 4,
+      rowStart: 4,
+      rowEnd: 6,
+      name: "3F",
+      type: "floorInfo",
+    },
   ],
   "4": [
     {
@@ -187,6 +203,14 @@ export const mapPostionData: IFloorSectionsInfo = {
       name: `End of Cluster 3`,
       type: "cabinet",
     },
+    {
+      colStart: 3,
+      colEnd: 4,
+      rowStart: 4,
+      rowEnd: 6,
+      name: "4F",
+      type: "floorInfo",
+    },
   ],
   "5": [
     {
@@ -228,6 +252,14 @@ export const mapPostionData: IFloorSectionsInfo = {
       rowEnd: 9,
       name: "End of Cluster 5",
       type: "cabinet",
+    },
+    {
+      colStart: 3,
+      colEnd: 4,
+      rowStart: 4,
+      rowEnd: 6,
+      name: "5F",
+      type: "floorInfo",
     },
   ],
 };

--- a/frontend/src/components/MapInfo/MapItem/MapItem.tsx
+++ b/frontend/src/components/MapInfo/MapItem/MapItem.tsx
@@ -35,9 +35,9 @@ const ItemStyled = styled.div<{
   info: ISectionInfo;
 }>`
   padding: 3px;
-  font-size: 0.8rem;
+  font-size: ${({ info }) => (info.type === "floorInfo" ? "1.8rem" : "0.8rem")};
   cursor: pointer;
-  color: white;
+  color: ${({ info }) => (info.type === "floorInfo" ? "#bcb9b9" : "white")};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -48,7 +48,11 @@ const ItemStyled = styled.div<{
   grid-row-start: ${({ info }) => info.rowStart};
   grid-row-end: ${({ info }) => info.rowEnd};
   background: ${({ info }) =>
-    info.type === "cabinet" ? "#9747ff" : "#bcb9b9"};
+    info.type === "cabinet"
+      ? "#9747ff"
+      : info.type === "floorInfo"
+      ? "transparent"
+      : "#bcb9b9"};
   &:hover {
     opacity: ${({ info }) => (info.type === "cabinet" ? 0.9 : 1)};
   }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1204
![image](https://github.com/innovationacademy-kr/42cabi/assets/52481403/8d53f5d7-c42c-4c6c-b37b-02d95676ec0a)
사진과 같이 지도의 배경에 층의 정보도 나타나게 수정하였습니다.
