### PR TITLE
[FE] FIX: 대여기록 제목 클릭시 토글 검색 기능은 검색페이지에서만 가능하도록 수정

### DIFF
--- a/frontend/src/components/LentLog/AdminLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminLentLog.tsx
@@ -1,14 +1,20 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import AdminCabinetLentLogContainer from "@/components/LentLog/AdminCabinetLentLog.container";
 import AdminUserLentLogContainer from "@/components/LentLog/AdminUserLentLog.container";
 import useMenu from "@/hooks/useMenu";
 
-const AdminUserLentLog = ({ lentType }: { lentType: string }) => {
+const AdminLentLog = ({ lentType }: { lentType: string }) => {
   const { closeLent } = useMenu();
   const [togglelentType, setToggleLentType] = useState<string>(lentType);
+  const isSearchPage = window.location.pathname === "/admin/search";
+
+  useEffect(() => {
+    if (!isSearchPage) setToggleLentType("CABINET");
+  }, [isSearchPage]);
 
   const switchLentType = () => {
+    if (!isSearchPage) return;
     if (togglelentType === "USER") {
       setToggleLentType("CABINET");
     } else {
@@ -27,10 +33,12 @@ const AdminUserLentLog = ({ lentType }: { lentType: string }) => {
   return (
     <AdminLentLogStyled id="lentInfo">
       <TitleContainer>
-        <TitleStyled onClick={switchLentType}>
-          <ImageStyled>
-            <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
-          </ImageStyled>
+        <TitleStyled isClick={isSearchPage} onClick={switchLentType}>
+          {isSearchPage && (
+            <ImageStyled>
+              <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
+            </ImageStyled>
+          )}
           {getLentTypeText(togglelentType)} 대여 기록
         </TitleStyled>
         <GoBackButtonStyled onClick={closeLent}>뒤로가기</GoBackButtonStyled>
@@ -62,10 +70,14 @@ const TitleContainer = styled.div`
   margin-bottom: 30px;
 `;
 
-const TitleStyled = styled.h1`
+const TitleStyled = styled.h1<{ isClick: boolean }>`
   font-size: 1.5rem;
   font-weight: 700;
   display: flex;
+  cursor: ${(props) => (props.isClick ? "pointer" : "default")};
+  &:hover {
+    color: ${(props) => (props.isClick ? "var(--main-color)" : "")};
+  }
 `;
 
 const ImageStyled = styled.div`
@@ -94,4 +106,4 @@ const AdminLentLogStyled = styled.div`
   }
 `;
 
-export default AdminUserLentLog;
+export default AdminLentLog;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1227

대여기록 토글(사물함, 유저) 기능은 검색에서만 쓸 수 있으며, 타이틀을 클릭 시 바뀌도록 만들었습니다.
<img width="541" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/72684256/3c6e5bef-9b21-4723-bf80-e6e0e34d604f">


메인 페이지에서는 사물함 로그만 뜨도록 기능 제한을 뒀습니다.
<img width="593" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/72684256/fb18e4d9-f54a-4919-ab0a-162684d6f12f">



