### PR TITLE
[BE] FIX : 대소비교 수정 & 메소드 이름 수정 in lentRepository

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -141,13 +141,13 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
 			"WHERE lh.startedAt <= :endDate AND lh.startedAt >= :startDate")
-	Integer countLentByLentTimeBetween(@Param("startDate") LocalDateTime startDate,
+	Integer countLentByTimeDuration(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
 			"WHERE lh.endedAt <= :endDate AND lh.endedAt >= :startDate")
-	Integer countReturnByReturnTimeBetween(@Param("startDate") LocalDateTime startDate,
+	Integer countReturnByTimeDuration(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 
 	@Query("SELECT count(lh) " +

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -140,14 +140,14 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
-			"WHERE lh.startedAt > :endDate AND lh.startedAt < :startDate")
+			"WHERE lh.startedAt <= :endDate AND lh.startedAt >= :startDate")
 	Integer countLentByLentTimeBetween(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
-			"WHERE :endDate < lh.endedAt AND lh.endedAt < :startDate")
-	Integer countLentByReturnTimeBetween(@Param("startDate") LocalDateTime startDate,
+			"WHERE lh.endedAt <= :endDate AND lh.endedAt >= :startDate")
+	Integer countReturnByReturnTimeBetween(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 
 	@Query("SELECT count(lh) " +

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -140,13 +140,13 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
-			"WHERE lh.startedAt <= :endDate AND lh.startedAt >= :startDate")
+			"WHERE lh.startedAt < :endDate AND lh.startedAt >= :startDate")
 	Integer countLentByTimeDuration(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 
 	@Query("SELECT count(lh) " +
 			"FROM LentHistory lh " +
-			"WHERE lh.endedAt <= :endDate AND lh.endedAt >= :startDate")
+			"WHERE lh.endedAt < :endDate AND lh.endedAt >= :startDate")
 	Integer countReturnByTimeDuration(@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate);
 

--- a/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
@@ -67,7 +67,7 @@ public class StatisticsFacadeServiceImpl implements StatisticsFacadeService {
 	public LentsStatisticsResponseDto getCountOnLentAndReturn(LocalDateTime startDate, LocalDateTime endDate) {
 		log.info("Called getCountOnLentAndReturn");
 		Integer lentStartCount = lentRepository.countLentByLentTimeBetween(startDate, endDate);
-		Integer lentEndCount = lentRepository.countLentByReturnTimeBetween(startDate, endDate);
+		Integer lentEndCount = lentRepository.countReturnByReturnTimeBetween(startDate, endDate);
 		return new LentsStatisticsResponseDto(startDate, endDate, lentStartCount, lentEndCount);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
@@ -66,8 +66,8 @@ public class StatisticsFacadeServiceImpl implements StatisticsFacadeService {
 	@Override
 	public LentsStatisticsResponseDto getCountOnLentAndReturn(LocalDateTime startDate, LocalDateTime endDate) {
 		log.info("Called getCountOnLentAndReturn");
-		Integer lentStartCount = lentRepository.countLentByLentTimeBetween(startDate, endDate);
-		Integer lentEndCount = lentRepository.countReturnByReturnTimeBetween(startDate, endDate);
+		Integer lentStartCount = lentRepository.countLentByTimeDuration(startDate, endDate);
+		Integer lentEndCount = lentRepository.countReturnByTimeDuration(startDate, endDate);
 		return new LentsStatisticsResponseDto(startDate, endDate, lentStartCount, lentEndCount);
 	}
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

statisticsFacadeServiceImpl에서 사용하는 lentRepository의 countLentByLentTimeBetween과 countLentByReturnTimeBetween의 query문에서 대소비교가 잘못되어 있어서 수정하였습니다.

추가적으로, countLentByReturnTimeBetween은 일정 기간 동안의 반납 개수를 반환하는 메소드라서 이름을countReturnByReturnTimeBetween라고 하는게 조금 더 적절할 것 같아서 수정하였습니다.

https://github.com/innovationacademy-kr/42cabi/issues/
