### PR TITLE
[FE] FIX: SearchBarList에서 사용하는 API를 cabinets-simple API로 변경 #1238

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -229,6 +229,18 @@ export const axiosSearchByCabinetNum = async (number: number) => {
   }
 };
 
+const axiosSearchByCabinetNumSimpleURL = "/v4/admin/search/cabinets-simple";
+export const axiosSearchByCabinetNumSimple = async (number: number) => {
+  try {
+    const response = await instance.get(axiosSearchByCabinetNumSimpleURL, {
+      params: { visibleNum: number },
+    });
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const axiosSearchDetailByIntraIdURL = "/v4/admin/search/users";
 export const axiosSearchDetailByIntraId = async (
   intraId: string,

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -21,35 +21,6 @@ export const axiosMyInfo = async (): Promise<any> => {
     throw error;
   }
 };
-/*
-const axiosUpdateCabinetMemoURL = "/v4/lent/me/memo";
-export const axiosUpdateCabinetMemo = async (
-  cabinet_memo: object
-): Promise<any> => {
-  try {
-    const response = await instance.patch(
-      axiosUpdateCabinetMemoURL,
-      cabinet_memo
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosUpdateCabinetTitleURL = "/v4/lent/me/cabinet-title";
-export const axiosUpdateCabinetTitle = async (
-  cabinet_title: any
-): Promise<any> => {
-  try {
-    const response = await instance.patch(axiosUpdateCabinetTitleURL, {
-      cabinetTitle: cabinet_title.title,
-    });
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}; */
 
 // V3 API
 const axiosBuildingFloorURL = "/v4/cabinets/buildings/floors";
@@ -192,17 +163,6 @@ export const axiosAdminCabinetInfoByCabinetId = async (
   }
 };
 
-/*
-const axiosAdminReturnURL = "/v4/admin/return-cabinets/";
-export const axiosAdminReturn = async (cabinetId: number): Promise<any> => {
-  try {
-    const response = await instance.patch(axiosAdminReturnURL + cabinetId);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
- */
 const axiosReturnByUserIdURL = "/v4/admin/return-users/";
 export const axiosReturnByUserId = async (userId: number): Promise<any> => {
   try {
@@ -226,24 +186,6 @@ export const axiosBundleReturn = async (
     throw error;
   }
 };
-/*
-const axiosUpdateCabinetTypeURL = "/v4/admin/cabinets/lent-types/";
-export const axiosUpdateCabinetType = async (
-  cabinetId: number,
-  lentType: CabinetType
-) => {
-  try {
-    const response = await instance.patch(
-      `${axiosUpdateCabinetTypeURL}${lentType}`,
-      {
-        cabinetIds: [cabinetId],
-      }
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}; */
 
 const axiosUpdateCabinetsURL = "/v4/admin/cabinets/";
 export const axiosUpdateCabinets = async (
@@ -262,61 +204,6 @@ export const axiosUpdateCabinets = async (
     throw error;
   }
 };
-/*
-const axiosBundleUpdateCabinetTypeURL = "/v4/admin/cabinets/lent-types/";
-export const axiosBundleUpdateCabinetType = async (
-  cabinetIdList: number[],
-  cabinetType: CabinetType
-): Promise<any> => {
-  try {
-    const response = await instance.patch(
-      `${axiosBundleUpdateCabinetTypeURL}${cabinetType}`,
-      {
-        cabinetIds: cabinetIdList,
-      }
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
- */
-/*
-const axiosUpdateCabinetStatusURL = "/v4/admin/cabinets/status/";
-export const axiosUpdateCabinetStatus = async (
-  cabinetId: number,
-  status: CabinetStatus
-): Promise<any> => {
-  try {
-    const response = await instance.patch(
-      `${axiosUpdateCabinetStatusURL}${status}`,
-      {
-        cabinetIds: [cabinetId],
-      }
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}; */
-/*
-const axiosBundleUpdateCabinetStatusURL = "/v4/admin/cabinets/status/";
-export const axiosBundleUpdateCabinetStatus = async (
-  cabinetIdList: number[],
-  cabinetStatus: CabinetStatus
-): Promise<any> => {
-  try {
-    const response = await instance.patch(
-      `${axiosBundleUpdateCabinetStatusURL}${cabinetStatus}`,
-      {
-        cabinetIds: cabinetIdList,
-      }
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}; */
 
 const axiosSearchByIntraIdURL = "/v4/admin/search/users-simple";
 export const axiosSearchByIntraId = async (intraId: string) => {

--- a/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBar.tsx
@@ -2,9 +2,9 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import SearchBarList from "@/components/TopNav/SearchBar/SearchBarList/SearchBarList";
-import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import { CabinetSimple } from "@/types/dto/cabinet.dto";
 import {
-  axiosSearchByCabinetNum,
+  axiosSearchByCabinetNumSimple,
   axiosSearchByIntraId,
 } from "@/api/axios/axios.custom";
 import useOutsideClick from "@/hooks/useOutsideClick";
@@ -14,7 +14,7 @@ const SearchBar = () => {
   const searchWrap = useRef<HTMLDivElement>(null);
   const searchInput = useRef<HTMLInputElement>(null);
   const [searchListById, setSearchListById] = useState<any[]>([]);
-  const [searchListByNum, setSearchListByNum] = useState<CabinetInfo[]>([]);
+  const [searchListByNum, setSearchListByNum] = useState<CabinetSimple[]>([]);
   const [totalLength, setTotalLength] = useState<number>(0);
   const [isFocus, setIsFocus] = useState<boolean>(true);
   const [targetIndex, setTargetIndex] = useState<number>(-1);
@@ -97,10 +97,10 @@ const SearchBar = () => {
           setSearchListByNum([]);
           setTotalLength(0);
         } else {
-          const searchResult = await axiosSearchByCabinetNum(
+          const searchResult = await axiosSearchByCabinetNumSimple(
             Number(searchValue)
           );
-          const searchResultData: CabinetInfo[] = searchResult.data.result;
+          const searchResultData: CabinetSimple[] = searchResult.data.result;
           searchResultData.sort((a, b) => a.floor - b.floor);
           setSearchListById([]);
           setSearchListByNum(searchResultData);

--- a/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
+++ b/frontend/src/components/TopNav/SearchBar/SearchBarList/SearchBarList.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import SearchListItem from "@/components/TopNav/SearchBar/SearchListItem/SearchListItem";
-import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import { CabinetSimple } from "@/types/dto/cabinet.dto";
 
 interface ISearchListByIntraId {
   name: string;
@@ -16,7 +16,7 @@ const SearchBarList = ({
   targetIndex,
 }: {
   searchListById: ISearchListByIntraId[];
-  searchListByNum: CabinetInfo[];
+  searchListByNum: CabinetSimple[];
   resetSearchState: () => void;
   searchWord?: string;
   totalLength: number;

--- a/frontend/src/types/dto/cabinet.dto.ts
+++ b/frontend/src/types/dto/cabinet.dto.ts
@@ -13,6 +13,14 @@ export interface CabinetBuildingFloorDto {
   floors: Array<number>;
 }
 
+export interface CabinetSimple {
+  cabinetId: number;
+  building: string;
+  floor: number;
+  section: string;
+  visibleNum: number;
+}
+
 export interface CabinetInfo {
   building: string;
   floor: number;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1238

### 변경사항
- `cabinets-simple API`가 새로 만들어진 것에 따라 기존의 `cabinets?visibleNum=` 으로 사용하던 API를 수정했습니다.
- 응답으로 오는 data 객체의 프로퍼티가 변경되어 새로운 DTO인 CabinetSimple을 추가했습니다.
- 기존의 사용하던 API 중 이제는 사용하지 않는 API들을 삭제 조치하였습니다.