### PR TITLE
[FE] : fix lentLog layout 화면 높이에 따른 깨짐 수정

### DIFF
--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -439,7 +439,7 @@ export const axiosGetCabinetLentLog = async (
     const response = await instance.get(
       axiosGetCabinetLentLogURL + cabinetId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 10 },
+        params: { page: page, size: 7 },
       }
     );
     return response;
@@ -458,7 +458,7 @@ export const axiosGetUserLentLog = async (
     const response = await instance.get(
       axiosGetUserLentLogURL + userId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 10 },
+        params: { page: page, size: 7 },
       }
     );
     return response;

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -439,7 +439,7 @@ export const axiosGetCabinetLentLog = async (
     const response = await instance.get(
       axiosGetCabinetLentLogURL + cabinetId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 7 },
+        params: { page: page, size: 10 },
       }
     );
     return response;
@@ -458,7 +458,7 @@ export const axiosGetUserLentLog = async (
     const response = await instance.get(
       axiosGetUserLentLogURL + userId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 7 },
+        params: { page: page, size: 10 },
       }
     );
     return response;

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -439,7 +439,7 @@ export const axiosGetCabinetLentLog = async (
     const response = await instance.get(
       axiosGetCabinetLentLogURL + cabinetId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 10 },
+        params: { page: page, size: 8 },
       }
     );
     return response;
@@ -458,7 +458,7 @@ export const axiosGetUserLentLog = async (
     const response = await instance.get(
       axiosGetUserLentLogURL + userId.toString() + "/lent-histories",
       {
-        params: { page: page, size: 10 },
+        params: { page: page, size: 8 },
       }
     );
     return response;

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
@@ -19,6 +19,7 @@ const AdminCabinetLentLog = ({
           totalPage={totalPage}
           type="prev"
           onClick={onClickPrev}
+          className="logPageButton"
         >
           <ImgCenterStyled>
             <ImageStyled>
@@ -31,6 +32,7 @@ const AdminCabinetLentLog = ({
           totalPage={totalPage}
           type="next"
           onClick={onClickNext}
+          className="logPageButton"
         >
           <ImgCenterStyled>
             <ImageStyled>
@@ -60,6 +62,9 @@ const ButtonContainerStyled = styled.div`
   align-items: center;
   margin: 0 auto;
   overflow: hidden;
+  &:hover > .logPageButton {
+    opacity: 1;
+  }
 `;
 
 const PageButtonStyled = styled.div<{
@@ -72,7 +77,9 @@ const PageButtonStyled = styled.div<{
   height: 100%;
   border-radius: 10px;
   position: absolute;
-  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.7));
+  opacity: 0.5;
+  transition: opacity 0.5s;
+  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.5));
   display: ${({ page, totalPage, type }) => {
     if (type == "prev" && page == 0) return "none";
     if (type == "next" && (totalPage == 0 || page == totalPage - 1))

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
@@ -20,7 +20,11 @@ const AdminCabinetLentLog = ({
           type="prev"
           onClick={onClickPrev}
         >
-          이전
+          <ImgCenterStyled>
+            <ImageStyled>
+              <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
+            </ImageStyled>
+          </ImgCenterStyled>
         </PageButtonStyled>
         <PageButtonStyled
           page={page}
@@ -28,12 +32,35 @@ const AdminCabinetLentLog = ({
           type="next"
           onClick={onClickNext}
         >
-          다음
+          <ImgCenterStyled>
+            <ImageStyled>
+              <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
+            </ImageStyled>
+          </ImgCenterStyled>
         </PageButtonStyled>
       </ButtonContainerStyled>
     </AdminLentLogStyled>
   );
 };
+
+const AdminLentLogStyled = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+const ButtonContainerStyled = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+  overflow: hidden;
+`;
 
 const PageButtonStyled = styled.div<{
   page: number;
@@ -41,8 +68,14 @@ const PageButtonStyled = styled.div<{
   type: string;
 }>`
   cursor: pointer;
-  color: var(--main-color);
+  width: 40px;
+  height: 100%;
+  border-radius: 10px;
   position: absolute;
+  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.7));
+  /*&:hover {
+    background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.5));
+  }*/
   display: ${({ page, totalPage, type }) => {
     if (type == "prev" && page == 0) return "none";
     if (type == "next" && (totalPage == 0 || page == totalPage - 1))
@@ -56,22 +89,23 @@ const PageButtonStyled = styled.div<{
         `
       : css`
           right: 0;
+          transform: rotate(-180deg);
         `}
 `;
 
-const ButtonContainerStyled = styled.div`
-  position: relative;
-  width: 80%;
-  height: 50px;
+const ImgCenterStyled = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin: 0 auto;
-  margin-top: 25px;
+  justify-content: center;
+  height: 100%;
+  //padding-right: 15px;
 `;
 
-const AdminLentLogStyled = styled.div`
-  width: 100%;
+const ImageStyled = styled.div`
+  width: 40px;
+  margin-right: 4px;
+  filter: brightness(0%);
+  border-radius: 50%;
 `;
 
 export default AdminCabinetLentLog;

--- a/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminCabinetLentLog.tsx
@@ -73,9 +73,6 @@ const PageButtonStyled = styled.div<{
   border-radius: 10px;
   position: absolute;
   background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.7));
-  /*&:hover {
-    background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.5));
-  }*/
   display: ${({ page, totalPage, type }) => {
     if (type == "prev" && page == 0) return "none";
     if (type == "next" && (totalPage == 0 || page == totalPage - 1))
@@ -98,7 +95,6 @@ const ImgCenterStyled = styled.div`
   align-items: center;
   justify-content: center;
   height: 100%;
-  //padding-right: 15px;
 `;
 
 const ImageStyled = styled.div`

--- a/frontend/src/components/LentLog/AdminLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminLentLog.tsx
@@ -79,12 +79,12 @@ const AdminLentLogStyled = styled.div`
   top: 0;
   right: 0;
   min-width: 330px;
-  height: 100%;
-  padding: 40px 20px;
+  min-height: 100%;
+  padding: 40px 20px 10px 20px;
   z-index: 9;
   transform: translateX(120%);
   transition: transform 0.3s ease-in-out;
-  //box-shadow: 0 0 40px 0 var(--bg-shadow);
+  box-shadow: 0 0 40px 30px var(--bg-shadow);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/LentLog/AdminLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminLentLog.tsx
@@ -84,7 +84,7 @@ const AdminLentLogStyled = styled.div`
   z-index: 9;
   transform: translateX(120%);
   transition: transform 0.3s ease-in-out;
-  box-shadow: 0 0 40px 0 var(--bg-shadow);
+  //box-shadow: 0 0 40px 0 var(--bg-shadow);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/LentLog/AdminLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminLentLog.tsx
@@ -84,7 +84,7 @@ const AdminLentLogStyled = styled.div`
   z-index: 9;
   transform: translateX(120%);
   transition: transform 0.3s ease-in-out;
-  box-shadow: 0 0 40px 30px var(--bg-shadow);
+  box-shadow: 0 0 40px 0 var(--bg-shadow);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/src/components/LentLog/AdminUserLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminUserLentLog.tsx
@@ -19,6 +19,7 @@ const AdminUserLentLog = ({
           totalPage={totalPage}
           type="prev"
           onClick={onClickPrev}
+          className="logPageButton"
         >
           <ImgCenterStyled>
             <ImageStyled>
@@ -31,6 +32,7 @@ const AdminUserLentLog = ({
           totalPage={totalPage}
           type="next"
           onClick={onClickNext}
+          className="logPageButton"
         >
           <ImgCenterStyled>
             <ImageStyled>
@@ -59,6 +61,9 @@ const ButtonContainerStyled = styled.div`
   justify-content: space-between;
   align-items: center;
   margin: 0 auto;
+  &:hover > .logPageButton {
+    opacity: 1;
+  }
 `;
 
 const PageButtonStyled = styled.div<{
@@ -71,7 +76,9 @@ const PageButtonStyled = styled.div<{
   height: 100%;
   border-radius: 10px;
   position: absolute;
-  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.7));
+  opacity: 0.5;
+  transition: opacity 0.5s;
+  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.5));
   display: ${({ page, totalPage, type }) => {
     if (type == "prev" && page == 0) return "none";
     if (type == "next" && (totalPage == 0 || page == totalPage - 1))

--- a/frontend/src/components/LentLog/AdminUserLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminUserLentLog.tsx
@@ -20,7 +20,11 @@ const AdminUserLentLog = ({
           type="prev"
           onClick={onClickPrev}
         >
-          이전
+          <ImgCenterStyled>
+            <ImageStyled>
+              <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
+            </ImageStyled>
+          </ImgCenterStyled>
         </PageButtonStyled>
         <PageButtonStyled
           page={page}
@@ -28,12 +32,34 @@ const AdminUserLentLog = ({
           type="next"
           onClick={onClickNext}
         >
-          다음
+          <ImgCenterStyled>
+            <ImageStyled>
+              <img src="/src/assets/images/LeftSectionButton.svg" alt="" />
+            </ImageStyled>
+          </ImgCenterStyled>
         </PageButtonStyled>
       </ButtonContainerStyled>
     </AdminLentLogStyled>
   );
 };
+
+const AdminLentLogStyled = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+const ButtonContainerStyled = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+`;
 
 const PageButtonStyled = styled.div<{
   page: number;
@@ -41,8 +67,11 @@ const PageButtonStyled = styled.div<{
   type: string;
 }>`
   cursor: pointer;
-  color: var(--main-color);
+  width: 40px;
+  height: 100%;
+  border-radius: 10px;
   position: absolute;
+  background: linear-gradient(to left, transparent, rgba(0, 0, 0, 0.7));
   display: ${({ page, totalPage, type }) => {
     if (type == "prev" && page == 0) return "none";
     if (type == "next" && (totalPage == 0 || page == totalPage - 1))
@@ -56,22 +85,22 @@ const PageButtonStyled = styled.div<{
         `
       : css`
           right: 0;
+          transform: rotate(-180deg);
         `}
 `;
 
-const ButtonContainerStyled = styled.div`
-  position: relative;
-  width: 80%;
-  height: 50px;
+const ImgCenterStyled = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin: 0 auto;
-  margin-top: 25px;
+  justify-content: center;
+  height: 100%;
 `;
 
-const AdminLentLogStyled = styled.div`
-  width: 100%;
+const ImageStyled = styled.div`
+  width: 40px;
+  margin-right: 4px;
+  filter: brightness(0%);
+  border-radius: 50%;
 `;
 
 export default AdminUserLentLog;

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -56,7 +56,7 @@ const LogTableWrapperstyled = styled.div`
   max-width: 800px;
   border-radius: 10px;
   overflow: hidden;
-  margin: 0px auto;
+  margin: 0 auto;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 `;
 

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -56,7 +56,7 @@ const LogTableWrapperstyled = styled.div`
   max-width: 800px;
   border-radius: 10px;
   overflow: hidden;
-  margin: 0 auto;
+  //margin: 0px auto;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 `;
 

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -76,14 +76,13 @@ const TheadStyled = styled.thead`
 
 const TbodyStyled = styled.tbody`
   & > tr {
-    //font-size: 11px;
+    font-size: small;
     text-align: center;
     height: 50px;
   }
   & > tr > td {
     height: 50px;
     line-height: 50px;
-    //padding: 0 22px;
     width: 33.3%;
   }
   & > tr:nth-child(2n) {

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -56,7 +56,7 @@ const LogTableWrapperstyled = styled.div`
   max-width: 800px;
   border-radius: 10px;
   overflow: hidden;
-  //margin: 0px auto;
+  margin: 0px auto;
   box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
 `;
 

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -72,6 +72,12 @@ const TheadStyled = styled.thead`
   line-height: 50px;
   background-color: var(--main-color);
   color: var(--white);
+  & > tr > th:first-child {
+    padding-left: 20px;
+  }
+  & > tr > th:last-child {
+    padding-right: 20px;
+  }
 `;
 
 const TbodyStyled = styled.tbody`
@@ -87,6 +93,12 @@ const TbodyStyled = styled.tbody`
   }
   & > tr:nth-child(2n) {
     background: #f9f6ff;
+  }
+  & > tr > td:first-child {
+    padding-left: 20px;
+  }
+  & > tr > td:last-child {
+    padding-right: 20px;
   }
 `;
 

--- a/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -76,12 +76,14 @@ const TheadStyled = styled.thead`
 
 const TbodyStyled = styled.tbody`
   & > tr {
+    //font-size: 11px;
     text-align: center;
     height: 50px;
   }
   & > tr > td {
     height: 50px;
     line-height: 50px;
+    //padding: 0 22px;
     width: 33.3%;
   }
   & > tr:nth-child(2n) {

--- a/frontend/src/components/LentLog/LogTable/LogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/LogTable.tsx
@@ -71,6 +71,12 @@ const TheadStyled = styled.thead`
   line-height: 50px;
   background-color: var(--main-color);
   color: var(--white);
+  & > tr > th:first-child {
+    padding-left: 20px;
+  }
+  & > tr > th:last-child {
+    padding-right: 20px;
+  }
 `;
 
 const TbodyStyled = styled.tbody`
@@ -86,6 +92,12 @@ const TbodyStyled = styled.tbody`
   }
   & > tr:nth-child(2n) {
     background: #f9f6ff;
+  }
+  & > tr > td:first-child {
+    padding-left: 20px;
+  }
+  & > tr > td:last-child {
+    padding-right: 20px;
   }
 `;
 

--- a/frontend/src/components/LentLog/LogTable/LogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/LogTable.tsx
@@ -75,6 +75,7 @@ const TheadStyled = styled.thead`
 
 const TbodyStyled = styled.tbody`
   & > tr {
+    font-size: small;
     text-align: center;
     height: 50px;
   }

--- a/frontend/src/hooks/useMenu.ts
+++ b/frontend/src/hooks/useMenu.ts
@@ -104,6 +104,7 @@ const useMenu = () => {
   };
 
   const closeCabinet = () => {
+    closeLent();
     if (
       document.getElementById("cabinetDetailArea")?.classList.contains("on") ==
       true

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -98,7 +98,8 @@ const DetailInfoContainerStyled = styled.div<{ isFloat: boolean }>`
   position: relative;
   border-left: 1px solid var(--line-color);
   background-color: var(--white);
-  overflow-y: auto;
+  overflow-x: hidden;
+  height: 100%;
   ${(props) =>
     props.isFloat &&
     css`


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1129

- 10개씩 lentlog를 받아 오는 것을 8개로 수정하였습니다. (이렇게 받아오는 게 일반 화면에서 스크롤이 생기지 않아서 더 이쁨)
- min-height를 설정하여 화면의 높이가 줄었을 때 대여기록이 겹쳐지는 부분을 해결하였습니다.
- 클릭 시 closeLent가 적용되지 않고 있는 부분을 적용되도록 변경했습니다.
- 아래에 위치했던 버튼을 리스트 안으로 옮겼습니다.
- 
<img width="310" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/52481403/365716c4-68e3-4589-9035-2b16fe8f7b1b">

사진과 같이 다음 페이지가 있으면 그라데이션이 나타납니다.
