### PR TITLE
[FE] FIX: 반납시간이 NULL 일 시 "-" 출력되게 수정 #1266

### DIFF
--- a/frontend/src/components/LentLog/LogTable/LogTable.tsx
+++ b/frontend/src/components/LentLog/LogTable/LogTable.tsx
@@ -33,8 +33,14 @@ const LogTable = ({ lentHistory }: { lentHistory: LentLogResponseType }) => {
                   <td title={new Date(startedAt).toLocaleString("ko-KR")}>
                     {new Date(startedAt).toLocaleString("ko-KR", dateOptions)}
                   </td>
-                  <td title={new Date(endedAt).toLocaleString("ko-KR")}>
-                    {new Date(endedAt).toLocaleString("ko-KR", dateOptions)}
+                  <td
+                    title={
+                      endedAt ? new Date(endedAt).toLocaleString("ko-KR") : "-"
+                    }
+                  >
+                    {endedAt
+                      ? new Date(endedAt).toLocaleString("ko-KR", dateOptions)
+                      : "-"}
                   </td>
                 </tr>
               )


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

- 반납 시간이 NULL 일 경우에 유닉스 초기 시간 대신 "-" 출력

https://github.com/innovationacademy-kr/42cabi/issues/1266
