### PR TITLE
[FE] FEAT: 공유 대여 빈납과 연장권 사용시 띄울 모달 추가 #1317

### DIFF
--- a/frontend/src/assets/data/maps.ts
+++ b/frontend/src/assets/data/maps.ts
@@ -12,6 +12,7 @@ export enum additionalModalType {
   MODAL_ADMIN_CLUB_EDIT = "MODAL_ADMIN_CLUB_EDIT",
   MODAL_ADMIN_CLUB_DELETE = "MODAL_ADMIN_CLUB_DELETE",
   MODAL_OVERDUE_PENALTY = "MODAL_OVERDUE_PENALTY",
+  MODAL_EXTENSION = "MODAL_EXTENSION",
 }
 
 export const cabinetIconSrcMap = {
@@ -135,6 +136,11 @@ export const modalPropsMap = {
     type: "confirm",
     title: "초대 코드",
     confirmMessage: "대여하기",
+  },
+  MODAL_EXTENSION: {
+    type: "confirm",
+    title: "연장권 사용",
+    confirmMessage: "연장하기",
   },
 };
 

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useRecoilValue } from "recoil";
-import { myCabinetInfoState, targetCabinetInfoState } from "@/recoil/atoms";
+import {
+  myCabinetInfoState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
 import AdminCabinetInfoArea from "@/components/CabinetInfoArea/AdminCabinetInfoArea";
 import CabinetInfoArea from "@/components/CabinetInfoArea/CabinetInfoArea";
 import AdminLentLog from "@/components/LentLog/AdminLentLog";
@@ -9,6 +13,7 @@ import {
   CabinetPreviewInfo,
   MyCabinetInfoResponseDto,
 } from "@/types/dto/cabinet.dto";
+import { UserDto, UserInfo } from "@/types/dto/user.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import useMenu from "@/hooks/useMenu";
@@ -47,6 +52,7 @@ export interface ICurrentModalStateInfo {
   memoModal: boolean;
   passwordCheckModal: boolean;
   invitationCodeModal: boolean;
+  extendModal: boolean;
 }
 
 export interface IAdminCurrentModalStateInfo {
@@ -68,7 +74,8 @@ export type TModalState =
   | "returnModal"
   | "memoModal"
   | "passwordCheckModal"
-  | "invitationCodeModal";
+  | "invitationCodeModal"
+  | "extendModal";
 
 export type TAdminModalState = "returnModal" | "statusModal" | "clubLentModal";
 
@@ -159,6 +166,7 @@ const loadSharedWrongCodeCounts = () => {
 
 const CabinetInfoAreaContainer = (): JSX.Element => {
   const targetCabinetInfo = useRecoilValue(targetCabinetInfoState);
+  const myInfo = useRecoilValue<UserDto>(userState);
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);
   const { closeCabinet, toggleLent } = useMenu();
@@ -172,6 +180,7 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
     memoModal: false,
     passwordCheckModal: false,
     invitationCodeModal: false,
+    extendModal: false,
   });
   const [adminModal, setAdminModal] = useState<IAdminCurrentModalStateInfo>({
     returnModal: false,
@@ -231,6 +240,12 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       cabinetViewData.lentsLength >= 1
     ) {
       modalName = "invitationCodeModal";
+    } else if (
+      modalName === "extendModal" &&
+      cabinetViewData?.lentsLength &&
+      cabinetViewData.lentsLength >= 1
+    ) {
+      modalName = "extendModal";
     }
     setUserModal({
       ...userModal,
@@ -305,6 +320,8 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
         cabinetViewData?.status === "AVAILABLE" ||
         cabinetViewData?.status === "LIMITED_AVAILABLE"
       }
+      isExtendable={true}
+      // isExtendable={myInfo.extendable} // TODO: 연장권 구현 후 수정
       userModal={userModal}
       openModal={openModal}
       closeModal={closeModal}

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -20,6 +20,7 @@ import {
 import cabiLogo from "@/assets/images/logo.svg";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import CabinetType from "@/types/enum/cabinet.type.enum";
+import ExtendModal from "../Modals/ExtendModal/ExtendModal";
 import InvitationCodeModalContainer from "../Modals/InvitationCodeModal/InvitationCodeModal.container";
 
 const CabinetInfoArea: React.FC<{
@@ -28,6 +29,7 @@ const CabinetInfoArea: React.FC<{
   expireDate: string | null;
   isMine: boolean;
   isAvailable: boolean;
+  isExtendable: boolean;
   userModal: ICurrentModalStateInfo;
   openModal: (modalName: TModalState) => void;
   closeModal: (modalName: TModalState) => void;
@@ -38,6 +40,7 @@ const CabinetInfoArea: React.FC<{
   expireDate,
   isMine,
   isAvailable,
+  isExtendable,
   userModal,
   openModal,
   closeModal,
@@ -72,6 +75,15 @@ const CabinetInfoArea: React.FC<{
       <CabinetInfoButtonsContainerStyled>
         {isMine ? (
           <>
+            {selectedCabinetInfo!.lentType === "PRIVATE" && isExtendable ? (
+              <ButtonContainer
+                onClick={() => {
+                  openModal("extendModal");
+                }}
+                text="연장권 사용"
+                theme="line"
+              />
+            ) : null}
             <ButtonContainer
               onClick={() => {
                 openModal("returnModal");
@@ -161,6 +173,12 @@ const CabinetInfoArea: React.FC<{
           cabinetId={selectedCabinetInfo?.cabinetId}
         />
       )}
+      {userModal.extendModal && (
+        <ExtendModal
+          onClose={() => closeModal("extendModal")}
+          cabinetId={selectedCabinetInfo?.cabinetId}
+        />
+      )}
     </CabinetDetailAreaStyled>
   );
 };
@@ -236,7 +254,7 @@ const CabinetInfoButtonsContainerStyled = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  max-height: 210px;
+  max-height: 255px;
   margin: 3vh 0;
   width: 100%;
 `;

--- a/frontend/src/components/Modals/ExtendModal/ExtendModal.tsx
+++ b/frontend/src/components/Modals/ExtendModal/ExtendModal.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  currentCabinetIdState,
+  isCurrentSectionRenderState,
+  myCabinetInfoState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
+import Modal, { IModalContents } from "@/components/Modals/Modal";
+import ModalPortal from "@/components/Modals/ModalPortal";
+import {
+  FailResponseModal,
+  SuccessResponseModal,
+} from "@/components/Modals/ResponseModal/ResponseModal";
+import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
+import checkIcon from "@/assets/images/checkIcon.svg";
+import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
+import {
+  axiosCabinetById,
+  axiosMyLentInfo, // axiosExtend,
+} from "@/api/axios/axios.custom";
+import { getExtendedDateString } from "@/utils/dateUtils";
+
+const ExtendModal: React.FC<{
+  onClose: () => void;
+  cabinetId: Number;
+}> = (props) => {
+  const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
+  const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
+  const [modalTitle, setModalTitle] = useState<string>("");
+  const currentCabinetId = useRecoilValue(currentCabinetIdState);
+  const [myInfo, setMyInfo] = useRecoilState(userState);
+  const [myLentInfo, setMyLentInfo] =
+    useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
+  const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
+  const setIsCurrentSectionRender = useSetRecoilState(
+    isCurrentSectionRenderState
+  );
+  const formattedExtendedDate = getExtendedDateString(
+    myLentInfo.lents ? myLentInfo.lents[0].expiredAt : undefined
+  );
+  const extendDetail = `사물함 연장권 사용 시,
+대여 기간이 <strong>${formattedExtendedDate} 23:59</strong>으로
+연장됩니다.
+연장권 사용은 취소할 수 없습니다.
+연장권을 사용하시겠습니까?`;
+  const tryExtendRequest = async (e: React.MouseEvent) => {
+    try {
+      // await axiosExtend(); // TODO: 연장권 api 생성 후 연결해야 함
+      setMyInfo({ ...myInfo, cabinetId: currentCabinetId });
+      setIsCurrentSectionRender(true);
+      setModalTitle("연장되었습니다");
+      try {
+        const { data } = await axiosCabinetById(currentCabinetId);
+        setTargetCabinetInfo(data);
+      } catch (error) {
+        throw error;
+      }
+      try {
+        const { data: myLentInfo } = await axiosMyLentInfo();
+        setMyLentInfo(myLentInfo);
+      } catch (error) {
+        throw error;
+      }
+    } catch (error: any) {
+      setHasErrorOnResponse(true);
+      setModalTitle(error.response.data.message);
+    } finally {
+      setShowResponseModal(true);
+    }
+  };
+
+  const extendModalContents: IModalContents = {
+    type: "hasProceedBtn",
+    icon: checkIcon,
+    title: modalPropsMap[additionalModalType.MODAL_EXTENSION].title,
+    detail: extendDetail,
+    proceedBtnText:
+      modalPropsMap[additionalModalType.MODAL_EXTENSION].confirmMessage,
+    onClickProceed: tryExtendRequest,
+    closeModal: props.onClose,
+  };
+
+  return (
+    <ModalPortal>
+      {!showResponseModal && <Modal modalContents={extendModalContents} />}
+      {showResponseModal &&
+        (hasErrorOnResponse ? (
+          <FailResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.onClose}
+          />
+        ) : (
+          <SuccessResponseModal
+            modalTitle={modalTitle}
+            closeModal={props.onClose}
+          />
+        ))}
+    </ModalPortal>
+  );
+};
+
+export default ExtendModal;

--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -45,10 +45,10 @@ const LentModal: React.FC<{
   const formattedExpireDate = getExpireDateString(props.lentType);
   const privateLentDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
     귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
-  const shareLentDetail = `대여 후 ${
+  const shareLentDetail = `<strong>대여 후 ${
     10
     // import.meta.env.VITE_SHARE_LENT_COUNTDOWN // TODO: .env 에 등록하기
-  }분 이내에
+  }분 이내에</strong>
   공유 인원 (2인~4인) 이 충족되지 않으면,
   공유 사물함의 대여가 취소됩니다.
   “메모 내용”은 공유 인원끼리 공유됩니다.

--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -8,21 +8,21 @@ import {
   userState,
 } from "@/recoil/atoms";
 import Modal, { IModalContents } from "@/components/Modals/Modal";
-import {
-  SuccessResponseModal,
-  FailResponseModal,
-} from "@/components/Modals/ResponseModal/ResponseModal";
 import ModalPortal from "@/components/Modals/ModalPortal";
+import {
+  FailResponseModal,
+  SuccessResponseModal,
+} from "@/components/Modals/ResponseModal/ResponseModal";
+import { modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
-import { getExpireDateString } from "@/utils/dateUtils";
-import { modalPropsMap } from "@/assets/data/maps";
 import {
   axiosCabinetById,
   axiosLentId,
   axiosMyLentInfo,
 } from "@/api/axios/axios.custom";
+import { getExpireDateString } from "@/utils/dateUtils";
 
 const LentModal: React.FC<{
   lentType: string;
@@ -45,20 +45,14 @@ const LentModal: React.FC<{
   const formattedExpireDate = getExpireDateString(props.lentType);
   const privateLentDetail = `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.
     귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
-  const shareLentDetail = `${
-    targetCabinetInfo.lents.length > 0 &&
-    targetCabinetInfo.lents[0].expiredAt !== null
-      ? `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
-      : ""
-  }
-대여 후 ${
-    import.meta.env.VITE_SHARE_EARLY_RETURN_PERIOD
-  }시간 이내 취소(반납) 시,
-${
-  import.meta.env.VITE_SHARE_EARLY_RETURN_PENALTY
-}시간의 대여 불가 패널티가 적용됩니다.
-“메모 내용”은 공유 인원끼리 공유됩니다.
-귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
+  const shareLentDetail = `대여 후 ${
+    10
+    // import.meta.env.VITE_SHARE_LENT_COUNTDOWN // TODO: .env 에 등록하기
+  }분 이내에
+  공유 인원 (2인~4인) 이 충족되지 않으면,
+  공유 사물함의 대여가 취소됩니다.
+  “메모 내용”은 공유 인원끼리 공유됩니다.
+  귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
   const tryLentRequest = async (e: React.MouseEvent) => {
     try {
       await axiosLentId(currentCabinetId);

--- a/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
@@ -4,7 +4,6 @@ import {
   currentCabinetIdState,
   isCurrentSectionRenderState,
   myCabinetInfoState,
-  overdueCabinetListState,
   targetCabinetInfoState,
   userState,
 } from "@/recoil/atoms";
@@ -47,9 +46,13 @@ const ReturnModal: React.FC<{
   const returnDetail = `${
     myLentInfo && myLentInfo.lents[0].expiredAt === null
       ? ""
+      : myLentInfo.lentType === "SHARE"
+      ? `대여기간 이내 취소(반납) 시,
+대여 기간이 <strong>${formattedExpireDate} 23:59</strong>으로
+변경되는 패널티가 발생합니다.`
       : `대여기간은 <strong>${formattedExpireDate} 23:59</strong>까지 입니다.`
   }
-지금 반납 하시겠습니까?`;
+  지금 반납 하시겠습니까?`;
   const tryReturnRequest = async (e: React.MouseEvent) => {
     try {
       await axiosReturn();

--- a/frontend/src/recoil/atoms.ts
+++ b/frontend/src/recoil/atoms.ts
@@ -10,8 +10,8 @@ import {
   CabinetPreviewInfo,
   MyCabinetInfoResponseDto,
 } from "@/types/dto/cabinet.dto";
-import { UserDto, UserInfo } from "@/types/dto/user.dto";
 import { ClubUserDto } from "@/types/dto/lent.dto";
+import { UserDto, UserInfo } from "@/types/dto/user.dto";
 
 const { persistAtom } = recoilPersist();
 
@@ -21,6 +21,7 @@ export const userState = atom<UserDto>({
     cabinetId: null,
     userId: null,
     name: "default",
+    extendable: false,
   },
 });
 

--- a/frontend/src/types/dto/user.dto.ts
+++ b/frontend/src/types/dto/user.dto.ts
@@ -6,6 +6,7 @@ export interface UserDto {
   // TODO:
   // mock 데이터와 충돌 생겨서 옵셔널 필드로 바꿨습니다. 추후 수정 필요합니다.
   cabinetId: number | null; // 캐비닛 고유 ID
+  extendable: boolean;
 }
 
 export interface UserInfo {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -25,6 +25,24 @@ export const getExpireDateString = (
   return formatDate(expireDate);
 };
 
+export const getExtendedDateString = (existExpireDate?: Date) => {
+  let expireDate = existExpireDate ? new Date(existExpireDate) : new Date();
+  const addDays: string = import.meta.env.VITE_PRIVATE_LENT_PERIOD;
+  expireDate.setDate(expireDate.getDate() + parseInt(addDays) + 28); // TODO: env 에 import.meta.env.VITE_EXTENDED_LENT_PERIOD 추가
+  const padTo2Digits = (num: number) => {
+    return num.toString().padStart(2, "0");
+  };
+  const formatDate = (date: Date) => {
+    return [
+      date.getFullYear(),
+      padTo2Digits(date.getMonth() + 1),
+      padTo2Digits(date.getDate()),
+    ].join("/");
+  };
+
+  return formatDate(expireDate);
+};
+
 export const getTotalPage = (totalLength: number, size: number) => {
   return Math.ceil(totalLength / size);
 };


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/bd41a6a3-6199-4f99-919f-5f9a3f05c2fd)

<img width="955" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/14016311/aebf53b8-04d2-4074-b90c-2765e8b387b9">

- 공유 사물함의 대여 / 반납 시 사용할 모달을 새로운 정책에 맞춰 수정하였습니다.

- 연장권 사용 버튼과 모달을 추가하고, 연장권 사용 시 기한이 언제까지 연장되는지 계산하는 함수인 getExtendedDateString() 을 추가하였습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1317
