### PR TITLE
[FE] FIX: 지도 클릭 후 층 이동시 localStorage 의 CurrentSection 이 업데이트 되지 않아 해당 층에 없는 Section 을 보여주던 문제 수정 #1269

### DIFF
--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
@@ -56,19 +56,22 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
     axiosCabinetByBuildingFloor(currentBuilding, currentFloor)
       .then((response) => {
         setCurrentFloorData(response.data);
-        if (isMount || isCurrentSectionRender) {
-          const recoilPersist = localStorage.getItem("recoil-persist");
-          let recoilPersistObj;
-          if (recoilPersist) recoilPersistObj = JSON.parse(recoilPersist);
-          setCurrentSection(
-            Object.keys(recoilPersistObj).includes("CurrentSection")
-              ? recoilPersistObj.CurrentSection
-              : response.data[0].section
-          );
-          setIsCurrentSectionRender(false);
-        } else {
-          setCurrentSection(response.data[0].section);
+        const sections = response.data.map(
+          (data: CabinetInfoByBuildingFloorDto) => data.section
+        );
+        let currentSectionFromPersist = undefined;
+        const recoilPersist = localStorage.getItem("recoil-persist");
+        if (recoilPersist) {
+          const recoilPersistObj = JSON.parse(recoilPersist);
+          if (Object.keys(recoilPersistObj).includes("CurrentSection")) {
+            currentSectionFromPersist = recoilPersistObj.CurrentSection;
+          }
         }
+        currentSectionFromPersist &&
+        sections.includes(currentSectionFromPersist)
+          ? setCurrentSection(currentSectionFromPersist)
+          : setCurrentSection(response.data[0].section);
+        setIsCurrentSectionRender(false);
       })
       .catch((error) => {
         console.error(error);

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
@@ -12,7 +12,6 @@ import {
   currentFloorNumberState,
   currentMapFloorState,
   currentSectionNameState,
-  isCurrentSectionRenderState,
   numberOfAdminWorkState,
   userState,
 } from "@/recoil/atoms";
@@ -22,7 +21,6 @@ import { CabinetInfoByBuildingFloorDto } from "@/types/dto/cabinet.dto";
 import { UserDto } from "@/types/dto/user.dto";
 import { axiosCabinetByBuildingFloor } from "@/api/axios/axios.custom";
 import { removeCookie } from "@/api/react_cookie/cookies";
-import useIsMount from "@/hooks/useIsMount";
 import useMenu from "@/hooks/useMenu";
 
 const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
@@ -43,10 +41,6 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
   const numberOfAdminWork = useRecoilValue<number>(numberOfAdminWorkState);
   const navigator = useNavigate();
   const { pathname } = useLocation();
-  const isMount = useIsMount();
-  const [isCurrentSectionRender, setIsCurrentSectionRender] = useRecoilState(
-    isCurrentSectionRenderState
-  );
 
   useEffect(() => {
     if (currentFloor === undefined) {
@@ -71,7 +65,6 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
         sections.includes(currentSectionFromPersist)
           ? setCurrentSection(currentSectionFromPersist)
           : setCurrentSection(response.data[0].section);
-        setIsCurrentSectionRender(false);
       })
       .catch((error) => {
         console.error(error);

--- a/frontend/src/components/MapInfo/MapItem/MapItem.tsx
+++ b/frontend/src/components/MapInfo/MapItem/MapItem.tsx
@@ -17,26 +17,31 @@ const MapItem: React.FC<{
   const setCurrentFloor = useSetRecoilState(currentFloorNumberState);
   const floors = useRecoilValue<Array<number>>(currentBuildingFloorState);
   const { closeMap } = useMenu();
-  const onClick = () => {
+  const onClick = (info: ISectionInfo) => {
+    if (info.type === "floorInfo") return;
     if (pathname !== "main") navigate("main");
     setCurrentFloor(floor ? floor : floors[0]);
     selectSection(info.name);
     closeMap();
   };
   return (
-    <ItemStyled className="cabiButton" onClick={onClick} info={info}>
+    <ItemStyled
+      className="cabiButton"
+      onClick={() => onClick(info)}
+      info={info}
+    >
       {info.name}
     </ItemStyled>
   );
 };
 
 const ItemStyled = styled.div<{
-  onClick: React.MouseEventHandler;
+  onClick: Function;
   info: ISectionInfo;
 }>`
   padding: 3px;
   font-size: ${({ info }) => (info.type === "floorInfo" ? "1.8rem" : "0.8rem")};
-  cursor: pointer;
+  cursor: ${({ info }) => (info.type === "floorInfo" ? "default" : "pointer")};
   color: ${({ info }) => (info.type === "floorInfo" ? "#bcb9b9" : "white")};
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 기존에는 LocalStorage 에 CurrentFloor 과 CurrentSection 을 저장하여 층 이동과 섹션 이동을 감지하고 있어 지도에서 Section 을 변경하고 다른 층을 누르면 CurrentFloor 만 업데이트 되고, CurrentSection 이 이미 LocalStorage 에 존재하므로 Section 을 업데이트 하지 않는 문제가 있었습니다.

- 변경된 로직에서는 층을 변경할 경우 localStorage 의 CurrentSection 과 response data 의 Section 을 비교해, CurrentSection 이 response data 에 존재하면 (e.g. Oasis) 그 Section 으로 이동하고, 아닐 시 그 층의 첫 Section 을 보여줍니다.

- 지도에서 지도 중앙의 층을 클릭할 경우 (e.g. 2F, 3F 등) 존재하지 않는 섹션 (2F, 3F 등) 으로 이동하여 빈 화면이 나타나는 문제를 발견하여 추가로 수정하였습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1269