### PR TITLE
[FE] FIX: 대여 / 반납 시 버튼을 연속적으로 눌러 같은 요청을 반복적으로 보내지 못하도록 수정 #1315

### DIFF
--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -8,21 +8,21 @@ import {
   userState,
 } from "@/recoil/atoms";
 import Modal, { IModalContents } from "@/components/Modals/Modal";
-import {
-  SuccessResponseModal,
-  FailResponseModal,
-} from "@/components/Modals/ResponseModal/ResponseModal";
 import ModalPortal from "@/components/Modals/ModalPortal";
+import {
+  FailResponseModal,
+  SuccessResponseModal,
+} from "@/components/Modals/ResponseModal/ResponseModal";
+import { modalPropsMap } from "@/assets/data/maps";
 import checkIcon from "@/assets/images/checkIcon.svg";
 import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
-import { getExpireDateString } from "@/utils/dateUtils";
-import { modalPropsMap } from "@/assets/data/maps";
 import {
   axiosCabinetById,
   axiosLentId,
   axiosMyLentInfo,
 } from "@/api/axios/axios.custom";
+import { getExpireDateString } from "@/utils/dateUtils";
 
 const LentModal: React.FC<{
   lentType: string;
@@ -31,6 +31,7 @@ const LentModal: React.FC<{
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
   const [modalTitle, setModalTitle] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
   const [myInfo, setMyInfo] = useRecoilState(userState);
   const setMyLentInfo =
@@ -60,6 +61,7 @@ ${
 “메모 내용”은 공유 인원끼리 공유됩니다.
 귀중품 분실 및 메모 내용의 유출에 책임지지 않습니다.`;
   const tryLentRequest = async (e: React.MouseEvent) => {
+    setIsLoading(true);
     try {
       await axiosLentId(currentCabinetId);
       //userCabinetId 세팅
@@ -84,6 +86,7 @@ ${
       setModalTitle(error.response.data.message);
       setHasErrorOnResponse(true);
     } finally {
+      setIsLoading(false);
       setShowResponseModal(true);
     }
   };
@@ -96,6 +99,7 @@ ${
     proceedBtnText: modalPropsMap[CabinetStatus.AVAILABLE].confirmMessage,
     onClickProceed: tryLentRequest,
     closeModal: props.closeModal,
+    isLoading: isLoading,
   };
 
   return (

--- a/frontend/src/components/Modals/Modal.tsx
+++ b/frontend/src/components/Modals/Modal.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from "react";
 import styled, { css } from "styled-components";
+import AdminClubLogContainer from "@/components/Club/AdminClubLog.container";
 import Button from "@/components/Common/Button";
 import useMultiSelect from "@/hooks/useMultiSelect";
-import AdminClubLogContainer from "../Club/AdminClubLog.container";
 
 /**
  * @interface
@@ -17,6 +17,8 @@ import AdminClubLogContainer from "../Club/AdminClubLog.container";
  * @property {((e: React.MouseEvent) => Promise<void>) | null} onClickProceed : 확인 버튼의 동작함수
  * @property {string} cancleBtnText : 취소 버튼의 텍스트(기본값: 취소)
  * @property {React.MouseEventHandler} closeModal : 모달 닫는 함수
+ * @property {boolean} isClubLentModal : 동아리 (CLUB) 대여 모달인지 여부
+ * @property {boolean} isLoading : 로딩중 요청 버튼 비활성화 감지를 위한 변수
  */
 export interface IModalContents {
   type: string;
@@ -30,6 +32,7 @@ export interface IModalContents {
   cancleBtnText?: string;
   closeModal: React.MouseEventHandler;
   isClubLentModal?: boolean;
+  isLoading?: boolean;
 }
 
 const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
@@ -45,6 +48,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
     cancleBtnText,
     closeModal,
     isClubLentModal,
+    isLoading,
   } = props.modalContents;
   const { isMultiSelect, closeMultiSelectMode } = useMultiSelect();
 
@@ -59,9 +63,6 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
         }}
       />
       <ModalStyled onClick={type === "noBtn" ? closeModal : undefined}>
-        {/* {icon && (
-          <img src={icon} style={{ width: "70px", marginBottom: "20px" }} />
-        )} */}
         {icon && (
           <ModalIconImgStyled src={icon} iconScaleEffect={iconScaleEffect} />
         )}
@@ -84,6 +85,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
               }}
               text={proceedBtnText || "확인"}
               theme="fill"
+              disabled={isLoading}
             />
           </ButtonWrapperStyled>
         )}

--- a/frontend/src/components/Modals/Modal.tsx
+++ b/frontend/src/components/Modals/Modal.tsx
@@ -15,7 +15,7 @@ import useMultiSelect from "@/hooks/useMultiSelect";
  * @property {() => ReactElement} renderAdditionalComponent : 모달에 추가로 띄울 UI를 렌더해주는 함수
  * @property {string} proceedBtnText : 확인 버튼의 텍스트(기본값: 확인)
  * @property {((e: React.MouseEvent) => Promise<void>) | null} onClickProceed : 확인 버튼의 동작함수
- * @property {string} cancleBtnText : 취소 버튼의 텍스트(기본값: 취소)
+ * @property {string} cancelBtnText : 취소 버튼의 텍스트(기본값: 취소)
  * @property {React.MouseEventHandler} closeModal : 모달 닫는 함수
  * @property {boolean} isClubLentModal : 동아리 (CLUB) 대여 모달인지 여부
  * @property {boolean} isLoading : 로딩중 요청 버튼 비활성화 감지를 위한 변수
@@ -29,7 +29,7 @@ export interface IModalContents {
   renderAdditionalComponent?: () => ReactElement;
   proceedBtnText?: string;
   onClickProceed?: ((e: React.MouseEvent) => Promise<void>) | null;
-  cancleBtnText?: string;
+  cancelBtnText?: string;
   closeModal: React.MouseEventHandler;
   isClubLentModal?: boolean;
   isLoading?: boolean;
@@ -45,7 +45,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
     renderAdditionalComponent,
     proceedBtnText,
     onClickProceed,
-    cancleBtnText,
+    cancelBtnText,
     closeModal,
     isClubLentModal,
     isLoading,
@@ -76,7 +76,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
           <ButtonWrapperStyled>
             <Button
               onClick={closeModal}
-              text={cancleBtnText || "취소"}
+              text={cancelBtnText || "취소"}
               theme="line"
             />
             <Button

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordCheckModal.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from "react";
 import styled, { css } from "styled-components";
 import Button from "@/components/Common/Button";
-import useMultiSelect from "@/hooks/useMultiSelect";
 import { IModalContents } from "@/components/Modals/Modal";
+import useMultiSelect from "@/hooks/useMultiSelect";
 
 const PasswordCheckModal: React.FC<{
   modalContents: IModalContents;
@@ -17,7 +17,7 @@ const PasswordCheckModal: React.FC<{
     renderAdditionalComponent,
     proceedBtnText,
     onClickProceed,
-    cancleBtnText,
+    cancelBtnText,
     closeModal,
   } = modalContents;
   const { isMultiSelect, closeMultiSelectMode } = useMultiSelect();
@@ -44,7 +44,7 @@ const PasswordCheckModal: React.FC<{
         <ButtonWrapperStyled>
           <Button
             onClick={closeModal}
-            text={cancleBtnText || "취소"}
+            text={cancelBtnText || "취소"}
             theme="line"
           />
           <Button

--- a/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
+++ b/frontend/src/components/Modals/ReturnModal/ReturnModal.tsx
@@ -4,7 +4,6 @@ import {
   currentCabinetIdState,
   isCurrentSectionRenderState,
   myCabinetInfoState,
-  overdueCabinetListState,
   targetCabinetInfoState,
   userState,
 } from "@/recoil/atoms";
@@ -32,6 +31,7 @@ const ReturnModal: React.FC<{
   const [showResponseModal, setShowResponseModal] = useState<boolean>(false);
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
   const [modalTitle, setModalTitle] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
   const [myInfo, setMyInfo] = useRecoilState(userState);
   const [myLentInfo, setMyLentInfo] =
@@ -51,6 +51,7 @@ const ReturnModal: React.FC<{
   }
 지금 반납 하시겠습니까?`;
   const tryReturnRequest = async (e: React.MouseEvent) => {
+    setIsLoading(true);
     try {
       await axiosReturn();
       //userCabinetId 세팅
@@ -80,6 +81,7 @@ const ReturnModal: React.FC<{
       setHasErrorOnResponse(true);
       setModalTitle(error.response.data.message);
     } finally {
+      setIsLoading(false);
       setShowResponseModal(true);
     }
   };
@@ -93,6 +95,7 @@ const ReturnModal: React.FC<{
       modalPropsMap[additionalModalType.MODAL_RETURN].confirmMessage,
     onClickProceed: tryReturnRequest,
     closeModal: props.closeModal,
+    isLoading: isLoading,
   };
 
   return (


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/226e5ade-e961-47fb-ae0c-4fa4cbd5a81c)

- 이전에는 위 사진처럼 대여 / 반납 시 서버에서 응답이 오기 전에 버튼을 여러번 눌러 같은 요청을 반복적으로 보낼 수 있는 문제가 있었습니다. 이를 막기 위해 Modal 에서 isLoading 을 props 로 받게 하여 응답이 올 때까지 버튼을 disable 시켰습니다.

- Modal 컴포넌트 내의 IModalContents 에서 변수명에 오타가 있어 이를 수정하였습니다. (cancleBtnText -> cancelBtnText)

https://github.com/innovationacademy-kr/42cabi/issues/1315
