### PR TITLE
[FE] BUG : admin_home에서 사용정지 유저 사용기록 나오지 않는 버그 수정 #1303

### DIFF
--- a/frontend/src/components/LentLog/AdminLentLog.tsx
+++ b/frontend/src/components/LentLog/AdminLentLog.tsx
@@ -10,7 +10,7 @@ const AdminLentLog = ({ lentType }: { lentType: string }) => {
   const isSearchPage = window.location.pathname === "/admin/search";
 
   useEffect(() => {
-    if (!isSearchPage) setToggleLentType("CABINET");
+    if (!isSearchPage && lentType === "CABINET") setToggleLentType("CABINET");
   }, [isSearchPage]);
 
   const switchLentType = () => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1303
- admin home에서 사용정지 유저의 대여기록을 누르면 사물함 대여기록이라 표시되면서 유저의 대여 기록이 보이지 않는 문제 해결
- 검색을 통한 결과가 아니면 CABINET기록만을 보여주고 있었어서 이 부분을 수정하였습니다.
- 코드 한 줄 수정이었지만 이거 찾기까지 좀 힘들었삼 ㅎ
