### PR TITLE
[FE] CabinetInfoArea 연장권 위치 수정 및 에러 수정 #1362

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -163,18 +163,18 @@ const CabinetInfoArea: React.FC<{
       </CabinetLentDateInfoStyled>
       <CabinetInfoButtonsContainerStyled>
         {isExtensible &&
-        isMine &&
-        selectedCabinetInfo!.lentType === "PRIVATE" ? (
-          <ButtonContainer
-            onClick={() => {
-              openModal("extendModal");
-            }}
-            text={"연장권 사용하기"}
-            theme="line"
-            iconSrc="/src/assets/images/extensionTicket.svg"
-            iconAlt="연장권 아이콘"
-          />
-        ) : null}
+          isMine &&
+          selectedCabinetInfo.status !== "IN_SESSION" && (
+            <ButtonContainer
+              onClick={() => {
+                openModal("extendModal");
+              }}
+              text={"연장권 사용하기"}
+              theme="line"
+              iconSrc="/src/assets/images/extensionTicket.svg"
+              iconAlt="연장권 아이콘"
+            />
+          )}
       </CabinetInfoButtonsContainerStyled>
       {userModal.unavailableModal && (
         <UnavailableModal

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -118,7 +118,7 @@ const CabinetInfoArea: React.FC<{
           )
         ) : (
           <>
-            {isMine && (
+            {selectedCabinetInfo!.cabinetId !== 0 && (
               <>
                 <ButtonContainer
                   onClick={() =>

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -118,19 +118,29 @@ const CabinetInfoArea: React.FC<{
           )
         ) : (
           <>
-            <ButtonContainer
-              onClick={() =>
-                openModal(
-                  selectedCabinetInfo.status == "IN_SESSION"
-                    ? "invitationCodeModal"
-                    : "lentModal"
-                )
-              }
-              text="대여"
-              theme="fill"
-              disabled={!isAvailable || selectedCabinetInfo.lentType === "CLUB"}
-            />
-            <ButtonContainer onClick={closeCabinet} text="닫기" theme="line" />
+            {isMine && (
+              <>
+                <ButtonContainer
+                  onClick={() =>
+                    openModal(
+                      selectedCabinetInfo.status == "IN_SESSION"
+                        ? "invitationCodeModal"
+                        : "lentModal"
+                    )
+                  }
+                  text="대여"
+                  theme="fill"
+                  disabled={
+                    !isAvailable || selectedCabinetInfo.lentType === "CLUB"
+                  }
+                />
+                <ButtonContainer
+                  onClick={closeCabinet}
+                  text="닫기"
+                  theme="line"
+                />
+              </>
+            )}
             {isExtensible &&
             selectedCabinetInfo!.cabinetId === 0 &&
             selectedCabinetInfo!.lentType === "PRIVATE" ? (

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -113,10 +113,12 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
           disable={true}
         />
       )}
-      <TopNavButton
-        onClick={clickMyCabinet}
-        imgSrc="/src/assets/images/myCabinetIcon.svg"
-      />
+      {!isAdmin && (
+        <TopNavButton
+          onClick={clickMyCabinet}
+          imgSrc="/src/assets/images/myCabinetIcon.svg"
+        />
+      )}
       <TopNavButton onClick={toggleMap} imgSrc="/src/assets/images/map.svg" />
     </NaviButtonsStyled>
   );


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/3e5712b0-8cdb-4fc4-a611-af590cd52e64)

- CabinetInfoArea 에서 연장권 정보를 확인할 수 있게 수정하면서 사물함을 대여중이 아닐 때에도 CabinetInfoArea 모달을 우측 상단 아이콘을 이용해 볼 수 있었는데, Admin 에서도 CabinetInfoArea 모달을 열 수 있는 이슈가 있어 열 수 없도록 수정하였습니다.

![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/4ee7c563-dba0-4cd8-a2a8-8de89e81f914)
![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/3c0ed151-e52a-4eb8-9cc1-8035e3f58655)

- 현재 개인사물함에서만 연장권 사용이 가능한데, 공유사물함에서도 연장권 사용을 가능하게 변경했습니다.

<img width="637" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/14016311/ce4d9604-c3c9-4be8-854f-a8def2896a0c">

- 대여중인 사물함이 없을 때 개인사물함정보 모달에서 ‘대여’ 및 '닫기' 를 보이지 않게 수정하고 연장권 정보만 확인할 수 있게 변경했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1362