### PR TITLE
[FE] FIX : IN_SESSION에서 상태 변경 시 올바른 상태 변경 가능#1371

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -313,8 +313,9 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       closeCabinet={closeCabinet}
       expireDate={setExpireDate(cabinetViewData?.expireDate)}
       isMine={
-        myCabinetInfo?.cabinetId === cabinetViewData?.cabinetId ||
-        myCabinetInfo?.cabinetId === 0
+        (myCabinetInfo?.cabinetId === cabinetViewData?.cabinetId ||
+          myCabinetInfo?.cabinetId === 0) &&
+        cabinetViewData?.status !== "AVAILABLE"
       }
       isAvailable={
         (cabinetViewData?.status === "AVAILABLE" ||

--- a/frontend/src/components/CabinetInfoArea/CountTime/CountTime.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CountTime/CountTime.container.tsx
@@ -47,11 +47,12 @@ const CountTimeContainer = ({ isMine }: { isMine: boolean }) => {
     if (!timeOver && countDown <= 0) {
       setTimeOver(true);
       try {
-        const { data } = await axiosCabinetById(targetCabinetInfo?.cabinetId);
+        const { data } = await axiosCabinetById(targetCabinetInfo.cabinetId);
         setTargetCabinetInfo(data);
-        setMyInfo({ ...myInfo, cabinetId: null });
         const { data: myLentInfo } = await axiosMyLentInfo();
         setMyLentInfo(myLentInfo);
+        if (myLentInfo.status == "FULL")
+          setMyInfo({ ...myInfo, cabinetId: targetCabinetInfo.cabinetId });
       } catch (error) {
         console.error("Error fetching data:", error);
       }

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -37,7 +37,8 @@ const CabinetListItem = (props: CabinetPreviewInfo): JSX.Element => {
     useState<boolean>(false);
   const { openCabinet, closeCabinet } = useMenu();
   const isMine = myCabinetInfo
-    ? myCabinetInfo.cabinetId === props.cabinetId
+    ? myCabinetInfo.cabinetId === props.cabinetId &&
+      props.status !== "AVAILABLE"
     : false;
 
   let cabinetLabelText = "";

--- a/frontend/src/components/Home/ServiceManual.tsx
+++ b/frontend/src/components/Home/ServiceManual.tsx
@@ -30,8 +30,9 @@ const ServiceManual = ({
             </span>{" "}
             대여할 수 있습니다.
             <br />
-            연체 시 연체되는 <span className="redColor">일 수만큼 페널티</span>
-            가 부과됩니다.
+            연체 시 연체되는{" "}
+            <span className="redColor">일의 제곱 수만큼 페널티</span>가<br />
+            부과됩니다.
           </p>
         </article>
         <article className="article">
@@ -43,23 +44,21 @@ const ServiceManual = ({
             1개의 사물함을 최대{" "}
             <span>{import.meta.env.VITE_SHARE_MAX_USER}인</span>이 사용합니다.
             <br />
-            <span>{import.meta.env.VITE_SHARE_LENT_PERIOD}일간</span> 대여할 수
-            있습니다.
+            대여한{" "}
+            <span>
+              인원수 * {import.meta.env.VITE_SHARE_LENT_PERIOD}일간
+            </span>{" "}
+            대여할 수 있습니다.
             <br />
             사물함 제목과 메모는 대여자들끼리 공유됩니다.
             <br />
-            대여 후{" "}
-            <span className="redColor">
-              {import.meta.env.VITE_SHARE_EARLY_RETURN_PERIOD}시간
-            </span>{" "}
-            내 반납 시,
+            대여 후 <span className="redColor">대여 만료기간</span> 내 반납 시,
             <br />
-            {import.meta.env.VITE_SHARE_EARLY_RETURN_PENALTY}시간 동안 공유
-            사물함 대여가
-            <span className="redColor"> 불가능</span>합니다.
-            <br />
-            연체 시 연체되는 <span className="redColor">일 수만큼 페널티</span>
-            가 부과됩니다.
+            <span className="redColor"> 잔여 기간의 절반</span>으로 대여기간이
+            감소됩니다. <br />
+            연체 시 연체되는{" "}
+            <span className="redColor">일의 제곱 수만큼 페널티</span>가<br />
+            부과됩니다.
           </p>
         </article>
         <article className="article">

--- a/frontend/src/components/Modals/InvitationCodeModal/InvitationCodeModal.container.tsx
+++ b/frontend/src/components/Modals/InvitationCodeModal/InvitationCodeModal.container.tsx
@@ -5,7 +5,6 @@ import {
   isCurrentSectionRenderState,
   myCabinetInfoState,
   targetCabinetInfoState,
-  userState,
 } from "@/recoil/atoms";
 import { IModalContents } from "@/components/Modals/Modal";
 import ModalPortal from "@/components/Modals/ModalPortal";
@@ -33,7 +32,6 @@ const InvitationCodeModalContainer: React.FC<{
   const currentCabinetId = useRecoilValue(currentCabinetIdState);
   const [modalTitle, setModalTitle] = useState<string>("");
   const [code, setCode] = useState("");
-  const [myInfo, setMyInfo] = useRecoilState(userState);
   const setTargetCabinetInfo = useSetRecoilState(targetCabinetInfoState);
   const setIsCurrentSectionRender = useSetRecoilState(
     isCurrentSectionRenderState
@@ -87,7 +85,6 @@ const InvitationCodeModalContainer: React.FC<{
   const tryLentRequest = async () => {
     try {
       await axiosLentShareId(currentCabinetId, code);
-      setMyInfo({ ...myInfo, cabinetId: currentCabinetId });
       setIsCurrentSectionRender(true);
       setModalTitle("공유 사물함 대기열에 입장하였습니다");
       try {

--- a/frontend/src/components/Modals/LentModal/LentModal.tsx
+++ b/frontend/src/components/Modals/LentModal/LentModal.tsx
@@ -62,7 +62,8 @@ const LentModal: React.FC<{
         await axiosLentShareId(currentCabinetId, "0");
       else await axiosLentId(currentCabinetId);
       //userCabinetId 세팅
-      setMyInfo({ ...myInfo, cabinetId: currentCabinetId });
+      if (props.lentType != "SHARE")
+        setMyInfo({ ...myInfo, cabinetId: currentCabinetId });
       setIsCurrentSectionRender(true);
       if (props.lentType == "SHARE")
         setModalTitle("공유 사물함 대기열에 입장하였습니다");

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -12,13 +12,23 @@ import {
   currentFloorNumberState,
   currentSectionNameState,
 } from "@/recoil/atoms";
-import { currentCabinetIdState, targetCabinetInfoState } from "@/recoil/atoms";
+import {
+  currentCabinetIdState,
+  myCabinetInfoState,
+  targetCabinetInfoState,
+  userState,
+} from "@/recoil/atoms";
 import { currentFloorSectionState } from "@/recoil/selectors";
 import CabinetListContainer from "@/components/CabinetList/CabinetList.container";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
 import SectionPaginationContainer from "@/components/SectionPagination/SectionPagination.container";
 import { CabinetInfoByBuildingFloorDto } from "@/types/dto/cabinet.dto";
-import { axiosCabinetByBuildingFloor } from "@/api/axios/axios.custom";
+import { MyCabinetInfoResponseDto } from "@/types/dto/cabinet.dto";
+import { UserDto } from "@/types/dto/user.dto";
+import {
+  axiosCabinetByBuildingFloor,
+  axiosMyLentInfo,
+} from "@/api/axios/axios.custom";
 import useMenu from "@/hooks/useMenu";
 
 const MainPage = () => {
@@ -58,9 +68,23 @@ const MainPage = () => {
     CabinetInfoByBuildingFloorDto[]
   >(currentFloorCabinetState);
   const setCurrentSection = useSetRecoilState<string>(currentSectionNameState);
+  const myInfo = useRecoilValue<UserDto>(userState);
+  const [myCabinetInfo, setMyLentInfo] =
+    useRecoilState<MyCabinetInfoResponseDto>(myCabinetInfoState);
 
   const refreshCabinetList = async () => {
     setIsLoading(true);
+    if (
+      myInfo.cabinetId !== myCabinetInfo.cabinetId &&
+      myCabinetInfo.cabinetId
+    ) {
+      try {
+        const { data: myLentInfo } = await axiosMyLentInfo();
+        setMyLentInfo(myLentInfo);
+      } catch (error) {
+        throw error;
+      }
+    }
     try {
       await axiosCabinetByBuildingFloor(currentBuilding, currentFloor)
         .then((response) => {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1371
- In_session에서 사물함 상세 정보를 바라보지 않고 세션 시간이 지났을 시 자체 새로고침을 눌러서 정보 변경이 바로 가능하게 변경하였습니다.
- In_session인 경우에는 userState의 cabinetId를 업데이트 하지 않고 null로 두어서 대여가 성공한 경우에만 업데이트를 통해 userState의 cabinetId와 myCabinetInfoState의 cabinetId가 다른 경우에만 새로고침 버튼에서 층 정보와 lent/me를 같이 요청해서 정보의 변경이 바르게 이루어지도록 수정하였습니다.
- 따라서 공유 사물함을 대여할 시(아직 대여 완료가 안되었을 때)는 userState를 업데이트 하지 않습니다.
