### PR TITLE
[BE] 사물함 대여 시 직전 사물함 유저 기록 조회 로직 추가 #1368

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/dto/MyCabinetResponseDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/MyCabinetResponseDto.java
@@ -30,4 +30,5 @@ public class MyCabinetResponseDto {
 	// 공유사물함에 필요한 정보
 	private final String shareCode;
 	private final LocalDateTime sessionExpiredAt;
+	private final String previousUserName;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
@@ -34,6 +34,7 @@ public enum ExceptionStatus {
 	INCORRECT_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
 	ALL_BANNED_USER(HttpStatus.BAD_REQUEST, "ALL 밴 상태의 유저입니다."),
 	SHARE_BANNED_USER(HttpStatus.BAD_REQUEST, "초대코드를 3회 이상 틀린 유저입니다."),
+	LENT_PENDING(HttpStatus.BAD_REQUEST, "오픈 예정인 사물함입니다."),
 	WRONG_SHARE_CODE(HttpStatus.BAD_REQUEST, "초대코드가 유효하지 않습니다."),
 	NOT_FOUND_BAN_HISTORY(HttpStatus.NOT_FOUND, "현재 정지 상태인 유저가 아닙니다."),
 	BLACKHOLED_USER(HttpStatus.BAD_REQUEST, "블랙홀 상태의 유저입니다."),

--- a/backend/src/main/java/org/ftclub/cabinet/lent/controller/LentController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/controller/LentController.java
@@ -113,8 +113,6 @@ public class LentController {
 			@UserSession UserSessionDto user) {
 		log.info("Called getMyLentInfo user: {}", user);
 		MyCabinetResponseDto myCabinetResponseDto = lentFacadeService.getMyLentInfo(user);
-		System.out.println("myCabinetResponseDto.getPreviousUserName() = "
-				+ myCabinetResponseDto.getPreviousUserName());
 		if (myCabinetResponseDto == null) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 		}

--- a/backend/src/main/java/org/ftclub/cabinet/lent/controller/LentController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/controller/LentController.java
@@ -113,6 +113,8 @@ public class LentController {
 			@UserSession UserSessionDto user) {
 		log.info("Called getMyLentInfo user: {}", user);
 		MyCabinetResponseDto myCabinetResponseDto = lentFacadeService.getMyLentInfo(user);
+		System.out.println("myCabinetResponseDto.getPreviousUserName() = "
+				+ myCabinetResponseDto.getPreviousUserName());
 		if (myCabinetResponseDto == null) {
 			return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 		}

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
@@ -2,6 +2,7 @@ package org.ftclub.cabinet.lent.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
@@ -237,5 +238,10 @@ public class LentOptionalFetcher {
 	public List<LentHistory> findAllActiveLentHistoriesByUserId(Long userId) {
 		log.debug("Called findAllActiveLentHistoriesByUserId: {}", userId);
 		return lentRepository.findAllActiveLentHistoriesByUserId(userId);
+	}
+
+	public Optional<LentHistory> findPreviousLentHistoryByCabinetId(Long cabinetId) {
+		log.debug("Called findPreviousLentUserNameByCabinetId: {}", cabinetId);
+		return lentRepository.findFirstByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(cabinetId);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
@@ -28,14 +28,17 @@ public class LentRedis {
 	private final HashOperations<String, String, String> valueHashOperations;
 	private final ValueOperations<String, String> valueOperations;
 	private final RedisTemplate<String, String> shadowKeyRedisTemplate;
+	private final ValueOperations<String, String> previousUserRedisTemplate;
 
 	@Autowired
 	public LentRedis(RedisTemplate<String, Object> valueHashRedisTemplate,
 			RedisTemplate<String, String> valueRedisTemplate,
-			RedisTemplate<String, String> shadowKeyRedisTemplate) {
+			RedisTemplate<String, String> shadowKeyRedisTemplate,
+			RedisTemplate<String, String> previousUserRedisTemplate) {
 		this.valueOperations = valueRedisTemplate.opsForValue();
 		this.valueHashOperations = valueHashRedisTemplate.opsForHash();
 		this.shadowKeyRedisTemplate = shadowKeyRedisTemplate;
+		this.previousUserRedisTemplate = previousUserRedisTemplate.opsForValue();
 	}
 
 	/**
@@ -162,5 +165,15 @@ public class LentRedis {
 							TimeUnit.SECONDS).longValue());
 		}
 		return null;
+	}
+
+	public void setPreviousUser(String cabinetId, String userName) {
+		log.debug("Called setPreviousUser: {}, {}", cabinetId, userName);
+		previousUserRedisTemplate.set(cabinetId, userName);
+	}
+
+	public String getPreviousUser(String cabinetId) {
+		log.debug("Called getPreviousUser: {}", cabinetId);
+		return previousUserRedisTemplate.get(cabinetId);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
@@ -173,7 +173,7 @@ public class LentRedis {
 		previousUserRedisTemplate.set(cabinetId + PREVIOUS_USER_SUFFIX, userName);
 	}
 
-	public String getPreviousUser(String cabinetId) {
+	public String getPreviousUserName(String cabinetId) {
 		log.debug("Called getPreviousUser: {}", cabinetId);
 		return previousUserRedisTemplate.get(cabinetId + PREVIOUS_USER_SUFFIX);
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRedis.java
@@ -24,6 +24,7 @@ public class LentRedis {
 	private static final String USER_ENTERED = "entered";
 	private static final String SHADOW_KEY_SUFFIX = ":shadow";
 	private static final String VALUE_KEY_SUFFIX = ":user";
+	private static final String PREVIOUS_USER_SUFFIX = ":previousUser";
 
 	private final HashOperations<String, String, String> valueHashOperations;
 	private final ValueOperations<String, String> valueOperations;
@@ -169,11 +170,11 @@ public class LentRedis {
 
 	public void setPreviousUser(String cabinetId, String userName) {
 		log.debug("Called setPreviousUser: {}, {}", cabinetId, userName);
-		previousUserRedisTemplate.set(cabinetId, userName);
+		previousUserRedisTemplate.set(cabinetId + PREVIOUS_USER_SUFFIX, userName);
 	}
 
 	public String getPreviousUser(String cabinetId) {
 		log.debug("Called getPreviousUser: {}", cabinetId);
-		return previousUserRedisTemplate.get(cabinetId);
+		return previousUserRedisTemplate.get(cabinetId + PREVIOUS_USER_SUFFIX);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -77,6 +77,14 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 */
 	List<LentHistory> findByCabinetId(@Param("cabinetId") Long cabinetId, Pageable pageable);
 
+	/***
+	 * 사물함을 기준으로 가장 최근에 반납한 {@link LentHistory} 를 가져옵니다.
+	 * @param cabinetId 찾으려는 cabinet id
+	 * @return 반납한 {@link LentHistory}의 {@link Optional}
+	 */
+	Optional<LentHistory> findFirstByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(
+			@Param("cabinetId") Long cabinetId);
+
 	/**
 	 * 유저가 빌리고 있는 사물함의 개수를 가져옵니다.
 	 *
@@ -195,4 +203,5 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 			+ "IN (SELECT lh2.cabinetId "
 			+ "FROM LentHistory lh2 WHERE lh2.userId = :userId AND lh2.endedAt IS NULL)")
 	List<LentHistory> findAllActiveLentHistoriesByUserId(@Param("userId") Long userId);
+
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
@@ -158,7 +158,7 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 		}
 		List<LentDto> lentDtoList = getLentDtoList(myCabinet.getCabinetId());
 		return cabinetMapper.toMyCabinetResponseDto(myCabinet, lentDtoList,
-				null, null);
+				null, null, lentRedis.getPreviousUser(myCabinet.getCabinetId().toString()));
 	}
 
 	@Override
@@ -176,7 +176,7 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 		List<LentDto> lentDtoList = getLentDtoListFromRedis(cabinetId);
 		return cabinetMapper.toMyCabinetResponseDto(cabinet, lentDtoList,
 				lentRedis.getShareCode(cabinetId),
-				lentRedis.getSessionExpiredAtInRedis(cabinetId));
+				lentRedis.getSessionExpiredAtInRedis(cabinetId), null);
 	}
 
 

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
@@ -1,6 +1,7 @@
 package org.ftclub.cabinet.lent.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import lombok.AllArgsConstructor;
@@ -156,9 +157,19 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 		if (myCabinet == null) { // 대여 기록이 없거나 대여 대기 중인 경우
 			return getMyLentInfoFromRedis(user);
 		}
-		List<LentDto> lentDtoList = getLentDtoList(myCabinet.getCabinetId());
+		Long cabinetId = myCabinet.getCabinetId();
+		List<LentDto> lentDtoList = getLentDtoList(cabinetId);
+		String previousUserName = lentRedis.getPreviousUserName(
+				myCabinet.getCabinetId().toString());
+		if (previousUserName == null) {
+			Optional<LentHistory> previousLentHistory = lentOptionalFetcher.findPreviousLentHistoryByCabinetId(
+					cabinetId);
+			if (previousLentHistory.isPresent()) {
+				previousUserName = previousLentHistory.get().getUser().getName();
+			}
+		}
 		return cabinetMapper.toMyCabinetResponseDto(myCabinet, lentDtoList,
-				null, null, lentRedis.getPreviousUser(myCabinet.getCabinetId().toString()));
+				null, null, previousUserName);
 	}
 
 	@Override

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentServiceImpl.java
@@ -154,6 +154,8 @@ public class LentServiceImpl implements LentService {
 				e.setExpiredAt(expiredAt);
 			});
 		}
+		lentRedis.setPreviousUser(cabinet.getCabinetId().toString(),
+				lentHistory.getUser().getName());
 	}
 
 	@Override

--- a/backend/src/main/java/org/ftclub/cabinet/mapper/CabinetMapper.java
+++ b/backend/src/main/java/org/ftclub/cabinet/mapper/CabinetMapper.java
@@ -87,7 +87,6 @@ public interface CabinetMapper {
 
 	@Mapping(target = "location", source = "cabinet.cabinetPlace.location")
 	@Mapping(target = "shareCode", source = "sessionShareCode")
-	@Mapping(target = "sessionExpiredAt", source = "sessionExpiredAt")
 	MyCabinetResponseDto toMyCabinetResponseDto(Cabinet cabinet, List<LentDto> lents,
 			String sessionShareCode, LocalDateTime sessionExpiredAt, String previousUserName);
 

--- a/backend/src/main/java/org/ftclub/cabinet/mapper/CabinetMapper.java
+++ b/backend/src/main/java/org/ftclub/cabinet/mapper/CabinetMapper.java
@@ -89,7 +89,7 @@ public interface CabinetMapper {
 	@Mapping(target = "shareCode", source = "sessionShareCode")
 	@Mapping(target = "sessionExpiredAt", source = "sessionExpiredAt")
 	MyCabinetResponseDto toMyCabinetResponseDto(Cabinet cabinet, List<LentDto> lents,
-			String sessionShareCode, LocalDateTime sessionExpiredAt);
+			String sessionShareCode, LocalDateTime sessionExpiredAt, String previousUserName);
 
 	CabinetPreviewDto toCabinetPreviewDto(Cabinet cabinet, Integer userCount, String name);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
사물함 대여 시 해당 사물함을 마지막으로 대여한 이전 사용자의 userName을 보여주는 로직을 추가하였습니다.

접근 방식
- 사물함 반납 시 해당 사물함의 cabinetId와 반납 유저의 userName을 key:value 형태로 redis에 저장합니다.
- 유저가 사물함을 대여 할 시에 redis에서 cabinetId로 해당 사물함을 이용한 마지막 유저의 userName을 가져옵니다.

>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/#1368
