### PR TITLE
[BE] FIX: 메일 발신자 이름이 42CABI로 표시되도록 수정

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/config/GmailProperties.java
+++ b/backend/src/main/java/org/ftclub/cabinet/config/GmailProperties.java
@@ -17,6 +17,9 @@ public class GmailProperties {
 	@Value("${spring.mail.port}")
 	private int mailServerPort;
 
+	@Value("${spring.mail.display-sender-name}")
+	private String displaySenderName;
+
 	@Value("${spring.mail.username}")
 	private String username;
 

--- a/backend/src/main/java/org/ftclub/cabinet/utils/mail/EmailSender.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/mail/EmailSender.java
@@ -31,7 +31,7 @@ public class EmailSender {
 		MimeMessage message = javaMailSender.createMimeMessage();
 		MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
-		helper.setFrom(gmailProperties.getUsername());
+		helper.setFrom(gmailProperties.getDisplaySenderName() + " <" + gmailProperties.getUsername() + ">");
 		helper.setTo(to);
 		helper.setSubject(subject);
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -56,6 +56,7 @@ spring:
       no-risk-of-blackhole: 0 42 1 1 * * # 매월 1일 1시 42분 0초
 
   mail:
+    display-sender-name: "42CABI"
     soonoverdue:
       term: -1
       subject: "42CABI 사물함 연체 예정 알림"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

<img width="677" alt="스크린샷 2023-09-02 오후 2 37 23" src="https://github.com/innovationacademy-kr/42cabi/assets/83565255/d471762c-d3b8-49f0-83f6-5a000103ed5a">

`MimeMessageHelper.setFrom()`의 인자로 `42CABI <이메일@example.com>` 문자열을 넣어 메일 발송 시, 발송자 이름을 `42CABI`로 표시되도록 수정 했습니다.
