### PR TITLE
[FE] FEAT 이전 사용자 보여주기 

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -327,6 +327,7 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       userModal={userModal}
       openModal={openModal}
       closeModal={closeModal}
+      previousUserName={myCabinetInfo.previousUserName}
     />
   );
 };

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useState } from "react";
 import styled, { css, keyframes } from "styled-components";
 import {
   ICurrentModalStateInfo,
@@ -35,6 +36,7 @@ const CabinetInfoArea: React.FC<{
   userModal: ICurrentModalStateInfo;
   openModal: (modalName: TModalState) => void;
   closeModal: (modalName: TModalState) => void;
+  previousUserName: string | null;
 }> = ({
   selectedCabinetInfo,
   closeCabinet,
@@ -45,7 +47,13 @@ const CabinetInfoArea: React.FC<{
   userModal,
   openModal,
   closeModal,
+  previousUserName,
 }) => {
+  const [showPreviousUser, setShowPreviousUser] = useState(false);
+
+  const handleLinkTextClick = () => {
+    setShowPreviousUser(!showPreviousUser);
+  };
   return selectedCabinetInfo === null ? (
     <NotSelectedStyled>
       <CabiLogoStyled src={cabiLogo} />
@@ -86,7 +94,6 @@ const CabinetInfoArea: React.FC<{
                 }}
                 text="대기열 취소"
                 theme="fill"
-                //disabled={timeOver}
               />
               <ButtonContainer
                 onClick={closeCabinet}
@@ -114,6 +121,22 @@ const CabinetInfoArea: React.FC<{
                 text="닫기"
                 theme="grayLine"
               />
+              <LinkTextStyled onClick={handleLinkTextClick}>
+                {showPreviousUser ? (
+                  previousUserName
+                ) : (
+                  <>
+                    <ImageStyled
+                      src="/src/assets/images/happyCcabi.png"
+                      alt=""
+                    />
+                    <HoverTextStyled>
+                      이전 <br />
+                      대여자
+                    </HoverTextStyled>
+                  </>
+                )}
+              </LinkTextStyled>
             </>
           )
         ) : (
@@ -249,6 +272,39 @@ const CabinetDetailAreaStyled = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
+`;
+
+const LinkTextStyled = styled.div`
+  position: absolute;
+  bottom: 3%;
+  right: 7%;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 0.875rem;
+  color: var(--gray-color);
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const HoverTextStyled = styled.div`
+  width: 50px;
+  display: none;
+  position: absolute;
+  bottom: 35px;
+  right: -10px;
+  color: var(--gray-color);
+  text-align: center;
+  line-height: 1.2;
+`;
+
+const ImageStyled = styled.img`
+  width: 30px;
+  height: 30px;
+
+  &:hover + ${HoverTextStyled} {
+    display: block;
+  }
 `;
 
 const CabiLogoStyled = styled.img`

--- a/frontend/src/types/dto/cabinet.dto.ts
+++ b/frontend/src/types/dto/cabinet.dto.ts
@@ -36,7 +36,7 @@ export interface CabinetInfo {
   lents: LentDto[];
   statusNote: string | null;
   sessionExpiredAt?: Date;
-  previousUserName: string | null;
+  previousUserName?: string | null;
 }
 
 export interface CabinetPreview {

--- a/frontend/src/types/dto/cabinet.dto.ts
+++ b/frontend/src/types/dto/cabinet.dto.ts
@@ -7,6 +7,7 @@ import CabinetType from "@/types/enum/cabinet.type.enum";
 export interface MyCabinetInfoResponseDto extends CabinetInfo {
   memo: string; // 사물함 비밀번호와 관련된 메모
   shareCode: number;
+  previousUserName: string;
 }
 
 export interface CabinetBuildingFloorDto {
@@ -35,6 +36,7 @@ export interface CabinetInfo {
   lents: LentDto[];
   statusNote: string | null;
   sessionExpiredAt?: Date;
+  previousUserName: string | null;
 }
 
 export interface CabinetPreview {

--- a/frontend/src/types/dto/cabinet.dto.ts
+++ b/frontend/src/types/dto/cabinet.dto.ts
@@ -36,7 +36,6 @@ export interface CabinetInfo {
   lents: LentDto[];
   statusNote: string | null;
   sessionExpiredAt?: Date;
-  previousUserName?: string | null;
 }
 
 export interface CabinetPreview {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/
- 현재 나의 사물함을 이전에 사용한 유저를 보여주는 기능 추가
<img width="325" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/52481403/8fcabfea-a544-46b1-8791-fd0d57a6f1cd">
<img width="328" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/52481403/d76e4e26-9fac-45dd-94a9-2f1417a095c4">
<img width="320" alt="image" src="https://github.com/innovationacademy-kr/42cabi/assets/52481403/86b016e5-0233-4fac-ab98-6eeef9aeeba6">

- 호버하면 "이전 사용자"라는 문구가 나타나고 클릭 시 이름이 보이도록 하였습니다.
