### PR TITLE
[BE] Discord Webhook Messenger 추가

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordAlarmMessage.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordAlarmMessage.java
@@ -3,9 +3,13 @@ package org.ftclub.cabinet.alarm;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Builder
 @Getter
 public class DiscordAlarmMessage {
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private final String subject;
 	private final String packageName;
 	private final String httpMethod;
@@ -15,13 +19,14 @@ public class DiscordAlarmMessage {
 
 	@Override
 	public String toString() {
-		return "```java" +
+		return "```java\n" +
 				"Subject: \"" + subject + "\"\n" +
+				"Issued at: \"" + LocalDateTime.now().format(formatter) + "\"\n" +
 				"Package: \"" + packageName + "\"\n" +
 				"HTTP: \"" + httpMethod + "\"\n" +
 				"Method: \"" + methodName + "\"\n" +
 				"Parameters: \"" + parameters + "\"\n" +
-				"Return: \"" + returnValue + "\"\n" +
+				"Return: " + returnValue + "\n" +
 				"```";
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordAlarmMessage.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordAlarmMessage.java
@@ -1,0 +1,27 @@
+package org.ftclub.cabinet.alarm;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DiscordAlarmMessage {
+	private final String subject;
+	private final String packageName;
+	private final String httpMethod;
+	private final String methodName;
+	private final String parameters;
+	private final String returnValue;
+
+	@Override
+	public String toString() {
+		return "```java" +
+				"Subject: \"" + subject + "\"\n" +
+				"Package: \"" + packageName + "\"\n" +
+				"HTTP: \"" + httpMethod + "\"\n" +
+				"Method: \"" + methodName + "\"\n" +
+				"Parameters: \"" + parameters + "\"\n" +
+				"Return: \"" + returnValue + "\"\n" +
+				"```";
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordWebHookMessenger.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/DiscordWebHookMessenger.java
@@ -1,4 +1,4 @@
-package org.ftclub.cabinet.log;
+package org.ftclub.cabinet.alarm;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -16,9 +16,9 @@ public class DiscordWebHookMessenger {
 		this.discordWebHookUrl = discordWebHookUrl;
 	}
 
-	public void sendMessage(String message) {
+	public void sendMessage(DiscordAlarmMessage message) {
 		Map<String, String> body = new HashMap<>();
-		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message);
+		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message.toString());
 
 		WebClient.create().post()
 				.uri(discordWebHookUrl)

--- a/backend/src/main/java/org/ftclub/cabinet/log/DiscordWebHookMessenger.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/DiscordWebHookMessenger.java
@@ -4,8 +4,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Component
 public class DiscordWebHookMessenger {
+	private final static String DISCORD_WEBHOOK_MESSAGE_KEY = "content";
 	private final String discordWebHookUrl;
 
 	DiscordWebHookMessenger(@Value("${webhook.discord-admin}") String discordWebHookUrl) {
@@ -13,9 +17,12 @@ public class DiscordWebHookMessenger {
 	}
 
 	public void sendMessage(String message) {
+		Map<String, String> body = new HashMap<>();
+		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message);
+
 		WebClient.create().post()
 				.uri(discordWebHookUrl)
-				.bodyValue(message)
+				.bodyValue(body)
 				.retrieve()
 				.bodyToMono(String.class)
 				.block();

--- a/backend/src/main/java/org/ftclub/cabinet/log/DiscordWebHookMessenger.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/DiscordWebHookMessenger.java
@@ -1,0 +1,23 @@
+package org.ftclub.cabinet.log;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class DiscordWebHookMessenger {
+	private final String discordWebHookUrl;
+
+	DiscordWebHookMessenger(@Value("${webhook.discord-admin}") String discordWebHookUrl) {
+		this.discordWebHookUrl = discordWebHookUrl;
+	}
+
+	public void sendMessage(String message) {
+		WebClient.create().post()
+				.uri(discordWebHookUrl)
+				.bodyValue(message)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/log/LogParser.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/LogParser.java
@@ -1,0 +1,21 @@
+package org.ftclub.cabinet.log;
+
+import org.ftclub.cabinet.alarm.DiscordAlarmMessage;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogParser {
+	private static final String delimiter = "#";
+
+	public DiscordAlarmMessage parseToDiscordAlarmMessage(String log) {
+		String[] tokens = log.split(delimiter);
+		return DiscordAlarmMessage.builder()
+				.subject(tokens[0])
+				.packageName(tokens[1])
+				.httpMethod(tokens[2])
+				.methodName(tokens[3])
+				.parameters(tokens[4])
+				.returnValue(tokens[5])
+				.build();
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/log/WebHookTestController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/WebHookTestController.java
@@ -1,0 +1,19 @@
+package org.ftclub.cabinet.log;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WebHookTestController {
+	private final DiscordWebHookMessenger discordWebHookMessenger;
+
+	@PostMapping("/test/discord")
+	public void post(
+			@RequestBody String message
+	) {
+		discordWebHookMessenger.sendMessage(message);
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/log/WebHookTestController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/WebHookTestController.java
@@ -1,6 +1,8 @@
 package org.ftclub.cabinet.log;
 
 import lombok.RequiredArgsConstructor;
+import org.ftclub.cabinet.alarm.DiscordAlarmMessage;
+import org.ftclub.cabinet.alarm.DiscordWebHookMessenger;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,11 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class WebHookTestController {
 	private final DiscordWebHookMessenger discordWebHookMessenger;
+	private final LogParser logParser;
 
 	@PostMapping("/test/discord")
 	public void post(
-			@RequestBody String message
+			@RequestBody String log
 	) {
-		discordWebHookMessenger.sendMessage(message);
+		DiscordAlarmMessage discordAlarmMessage = logParser.parseToDiscordAlarmMessage(log);
+		discordWebHookMessenger.sendMessage(discordAlarmMessage);
 	}
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -76,4 +76,6 @@ spring:
           auth: true
           starttls:
             enable: true
-
+            
+webhook:
+  discord-admin: https://discord.com/api/webhooks/for-test

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -22,7 +22,11 @@ spring:
       ddl-auto: none
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     properties:
-      globally_quoted_identifiers: true
+      hibernate:
+        globally_quoted_identifiers: true
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        format_sql: true
+    defer-datasource-initialization: true
 
   cabinet:
     lent:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1384

- application profile에 webhook.discord-admin 부분이 추가되었습니다.
- 단순히 웹훅 url에 body("content" : "문구")를 전송하는 API입니다. 어드민의 경우 로깅이 진행되는데 그렇게 많은 호출이 일어나지 않을 것이라고 생각해서 단순한 POST로 사용했습니다.
