### PR TITLE
[BE] HOTFIX : 사물함 expiredAt이 만료일 23시59분59초가 되도록 수정 및 연체일이 하루 적게 나오는 로직 수정

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
@@ -1,5 +1,17 @@
 package org.ftclub.cabinet.lent.domain;
 
+import static javax.persistence.FetchType.LAZY;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,11 +24,6 @@ import org.ftclub.cabinet.user.domain.User;
 import org.ftclub.cabinet.utils.DateUtil;
 import org.ftclub.cabinet.utils.ExceptionUtil;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-
-import static javax.persistence.FetchType.LAZY;
-
 /**
  * lent의 기록을 관리하기 위한 data mapper
  */
@@ -28,215 +35,215 @@ import static javax.persistence.FetchType.LAZY;
 @Log4j2
 public class LentHistory {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "LENT_HISTORY_ID")
-    private Long lentHistoryId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "LENT_HISTORY_ID")
+	private Long lentHistoryId;
 
-    /**
-     * 낙관적 락을 위한 version
-     */
-    @Version
-    @Getter(AccessLevel.NONE)
-    private Long version = 1L;
+	/**
+	 * 낙관적 락을 위한 version
+	 */
+	@Version
+	@Getter(AccessLevel.NONE)
+	private Long version = 1L;
 
-    /**
-     * 대여 시작일
-     */
-    @Column(name = "STARTED_AT", nullable = false)
-    private LocalDateTime startedAt;
+	/**
+	 * 대여 시작일
+	 */
+	@Column(name = "STARTED_AT", nullable = false)
+	private LocalDateTime startedAt;
 
-    /**
-     * 연체 시작일
-     */
-    @Column(name = "EXPIRED_AT")
-    private LocalDateTime expiredAt = null;
+	/**
+	 * 연체 시작일
+	 */
+	@Column(name = "EXPIRED_AT")
+	private LocalDateTime expiredAt = null;
 
-    /**
-     * 반납일
-     */
-    @Column(name = "ENDED_AT")
-    private LocalDateTime endedAt = null;
+	/**
+	 * 반납일
+	 */
+	@Column(name = "ENDED_AT")
+	private LocalDateTime endedAt = null;
 
-    /**
-     * 대여하는 유저
-     */
-    @Column(name = "USER_ID", nullable = false)
-    private Long userId;
+	/**
+	 * 대여하는 유저
+	 */
+	@Column(name = "USER_ID", nullable = false)
+	private Long userId;
 
-    /**
-     * 대여하는 캐비넷
-     */
-    @Column(name = "CABINET_ID", nullable = false)
-    private Long cabinetId;
+	/**
+	 * 대여하는 캐비넷
+	 */
+	@Column(name = "CABINET_ID", nullable = false)
+	private Long cabinetId;
 
-    @JoinColumn(name = "USER_ID", insertable = false, updatable = false)
-    @ManyToOne(fetch = LAZY)
-    private User user;
+	@JoinColumn(name = "USER_ID", insertable = false, updatable = false)
+	@ManyToOne(fetch = LAZY)
+	private User user;
 
-    @JoinColumn(name = "CABINET_ID", insertable = false, updatable = false)
-    @ManyToOne(fetch = LAZY)
-    private Cabinet cabinet;
+	@JoinColumn(name = "CABINET_ID", insertable = false, updatable = false)
+	@ManyToOne(fetch = LAZY)
+	private Cabinet cabinet;
 
-    protected LentHistory(LocalDateTime startedAt, LocalDateTime expiredAt, Long userId,
-                          Long cabinetId) {
-        this.startedAt = startedAt;
-        this.expiredAt = expiredAt;
-        this.userId = userId;
-        this.cabinetId = cabinetId;
-    }
+	protected LentHistory(LocalDateTime startedAt, LocalDateTime expiredAt, Long userId,
+			Long cabinetId) {
+		this.startedAt = startedAt;
+		this.expiredAt = expiredAt;
+		this.userId = userId;
+		this.cabinetId = cabinetId;
+	}
 
-    /**
-     * @param startedAt 대여 시작일
-     * @param expiredAt 연체 시작일
-     * @param userId    대여하는 user id
-     * @param cabinetId 대여하는 cabinet id
-     * @return 인자 정보를 담고있는 {@link LentHistory}
-     */
-    public static LentHistory of(LocalDateTime startedAt, LocalDateTime expiredAt, Long userId,
-                                 Long cabinetId) {
-        LentHistory lentHistory = new LentHistory(startedAt, expiredAt, userId, cabinetId);
-        if (!lentHistory.isValid()) {
-            throw new DomainException(ExceptionStatus.INVALID_ARGUMENT);
-        }
-        return lentHistory;
-    }
+	/**
+	 * @param startedAt 대여 시작일
+	 * @param expiredAt 연체 시작일
+	 * @param userId    대여하는 user id
+	 * @param cabinetId 대여하는 cabinet id
+	 * @return 인자 정보를 담고있는 {@link LentHistory}
+	 */
+	public static LentHistory of(LocalDateTime startedAt, LocalDateTime expiredAt, Long userId,
+			Long cabinetId) {
+		LentHistory lentHistory = new LentHistory(startedAt, expiredAt, userId, cabinetId);
+		if (!lentHistory.isValid()) {
+			throw new DomainException(ExceptionStatus.INVALID_ARGUMENT);
+		}
+		return lentHistory;
+	}
 
-    /**
-     * startedAt, userId, cabinetId, expiredAt 의 null 이 아닌지 확인합니다.
-     *
-     * @return 유효한 인스턴스 여부
-     */
+	/**
+	 * startedAt, userId, cabinetId, expiredAt 의 null 이 아닌지 확인합니다.
+	 *
+	 * @return 유효한 인스턴스 여부
+	 */
 
-    private boolean isValid() {
-        return this.startedAt != null && this.userId != null && this.cabinetId != null
-            && this.expiredAt != null;
-    }
+	private boolean isValid() {
+		return this.startedAt != null && this.userId != null && this.cabinetId != null
+				&& this.expiredAt != null;
+	}
 
-    /**
-     * endedAt 보다 startedAt 이 나중이 아닌지 확인합니다. endedAt 종료시점이 null 이 아닌지 확인합니다.
-     *
-     * @param endedAt 대여 종료 날짜, 시간
-     * @return
-     */
-    private boolean isEndLentValid(LocalDateTime endedAt) {
-        return endedAt != null && 0 <= DateUtil.calculateTwoDateDiff(endedAt, this.startedAt);
-    }
-
-
-    @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (!(other instanceof LentHistory)) {
-            return false;
-        }
-        return (this.lentHistoryId.equals(((LentHistory) other).lentHistoryId));
-    }
-
-    /**
-     * 대여한 아이디와 같은지 비교한다.
-     *
-     * @param cabinetId 비교하고 싶은 id
-     * @return boolean 같으면 true 다르면 false
-     */
-    public boolean isCabinetIdEqual(Long cabinetId) {
-        return this.cabinetId.equals(cabinetId);
-    }
-
-    /**
-     * 만료일을 변경합니다.
-     *
-     * @param expiredAt 변경하고 싶은 만료일
-     */
-    public void setExpiredAt(LocalDateTime expiredAt) {
-        log.info("setExpiredAt : {}", expiredAt);
-        this.expiredAt = expiredAt;
-        ExceptionUtil.throwIfFalse(this.isValid(),
-            new DomainException(ExceptionStatus.INVALID_STATUS));
-    }
-
-    /**
-     * 만료일이 설정 되어있는 지 확인합니다. 만료일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
-     *
-     * @return 설정이 되어있으면 true 아니면 false
-     */
-    public boolean isSetExpiredAt() {
-        LocalDateTime expiredAt = getExpiredAt();
-        if (expiredAt == null) {
-            return false;
-        }
-        if (expiredAt.isEqual(DateUtil.getInfinityDate())) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * 반납일이 설정 되어있는 지 확인합니다. 반납일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
-     *
-     * @return 설정이 되어있으면 ture 아니면 false
-     */
-    public boolean isSetEndedAt() {
-        if (getEndedAt() == null) {
-            return false;
-        }
-        if (getEndedAt().isEqual(DateUtil.getInfinityDate())) {
-            return false;
-        }
-        return true;
-    }
+	/**
+	 * endedAt 보다 startedAt 이 나중이 아닌지 확인합니다. endedAt 종료시점이 null 이 아닌지 확인합니다.
+	 *
+	 * @param endedAt 대여 종료 날짜, 시간
+	 * @return
+	 */
+	private boolean isEndLentValid(LocalDateTime endedAt) {
+		return endedAt != null && 0 <= DateUtil.calculateTwoDateDiff(endedAt, this.startedAt);
+	}
 
 
-    /**
-     * 반납일과 만료일의 차이를 계산합니다.
-     *
-     * @return endedAt - expiredAt의 값을(일 기준)
-     */
-    public Long getDaysDiffEndedAndExpired() {
-        if (isSetExpiredAt() && isSetEndedAt()) {
-            return DateUtil.calculateTwoDateDiff(endedAt, expiredAt);
-        }
-        return null;
-    }
+	@Override
+	public boolean equals(final Object other) {
+		if (this == other) {
+			return true;
+		}
+		if (!(other instanceof LentHistory)) {
+			return false;
+		}
+		return (this.lentHistoryId.equals(((LentHistory) other).lentHistoryId));
+	}
 
-    /**
-     * 만료일이 지났는지 확인합니다.
-     *
-     * @return 만료일이 지났으면 true 아니면 false, 만료일이 설정되어 있지 않으면 false
-     */
-    public Boolean isExpired(LocalDateTime now) {
-        if (isSetExpiredAt()) {
-            return DateUtil.calculateTwoDateDiffCeil(expiredAt, now) > 0;
-        }
-        return false;
-    }
+	/**
+	 * 대여한 아이디와 같은지 비교한다.
+	 *
+	 * @param cabinetId 비교하고 싶은 id
+	 * @return boolean 같으면 true 다르면 false
+	 */
+	public boolean isCabinetIdEqual(Long cabinetId) {
+		return this.cabinetId.equals(cabinetId);
+	}
 
-    /**
-     * 만료일까지 남은 일수를 계산합니다. 만료시간이 설정되지 않았으면 null을 반환합니다.
-     *
-     * @return 만료일까지 남은 일수 (만료일 - 현재시간) (일 기준, 올림)
-     */
-    public Long getDaysUntilExpiration(LocalDateTime now) {
-        if (isSetExpiredAt()) {
-            return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
-        }
-        return null;
-    }
+	/**
+	 * 만료일을 변경합니다.
+	 *
+	 * @param expiredAt 변경하고 싶은 만료일
+	 */
+	public void setExpiredAt(LocalDateTime expiredAt) {
+		log.info("setExpiredAt : {}", expiredAt);
+		this.expiredAt = expiredAt;
+		ExceptionUtil.throwIfFalse(this.isValid(),
+				new DomainException(ExceptionStatus.INVALID_STATUS));
+	}
+
+	/**
+	 * 만료일이 설정 되어있는 지 확인합니다. 만료일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
+	 *
+	 * @return 설정이 되어있으면 true 아니면 false
+	 */
+	public boolean isSetExpiredAt() {
+		LocalDateTime expiredAt = getExpiredAt();
+		if (expiredAt == null) {
+			return false;
+		}
+		if (expiredAt.isEqual(DateUtil.getInfinityDate())) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * 반납일이 설정 되어있는 지 확인합니다. 반납일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
+	 *
+	 * @return 설정이 되어있으면 ture 아니면 false
+	 */
+	public boolean isSetEndedAt() {
+		if (getEndedAt() == null) {
+			return false;
+		}
+		if (getEndedAt().isEqual(DateUtil.getInfinityDate())) {
+			return false;
+		}
+		return true;
+	}
 
 
-    /**
-     * 반납일을 설정합니다.
-     *
-     * @param now 설정하려고 하는 반납일
-     */
-    public void endLent(LocalDateTime now) {
-        log.info("setEndLent : {}", now);
-        ExceptionUtil.throwIfFalse((this.isEndLentValid(now)),
-            new DomainException(ExceptionStatus.INVALID_ARGUMENT));
-        this.endedAt = now;
-        ExceptionUtil.throwIfFalse((this.isValid()),
-            new DomainException(ExceptionStatus.INVALID_STATUS));
-    }
+	/**
+	 * 반납일과 만료일의 차이를 계산합니다.
+	 *
+	 * @return endedAt - expiredAt의 값을(일 기준)
+	 */
+	public Long getDaysDiffEndedAndExpired() {
+		if (isSetExpiredAt() && isSetEndedAt()) {
+			return DateUtil.calculateTwoDateDiff(endedAt, expiredAt) + 1;
+		}
+		return null;
+	}
+
+	/**
+	 * 만료일이 지났는지 확인합니다.
+	 *
+	 * @return 만료일이 지났으면 true 아니면 false, 만료일이 설정되어 있지 않으면 false
+	 */
+	public Boolean isExpired(LocalDateTime now) {
+		if (isSetExpiredAt()) {
+			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now) > 0;
+		}
+		return false;
+	}
+
+	/**
+	 * 만료일까지 남은 일수를 계산합니다. 만료시간이 설정되지 않았으면 null을 반환합니다.
+	 *
+	 * @return 만료일까지 남은 일수 (만료일 - 현재시간) (일 기준, 올림)
+	 */
+	public Long getDaysUntilExpiration(LocalDateTime now) {
+		if (isSetExpiredAt()) {
+			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
+		}
+		return null;
+	}
+
+
+	/**
+	 * 반납일을 설정합니다.
+	 *
+	 * @param now 설정하려고 하는 반납일
+	 */
+	public void endLent(LocalDateTime now) {
+		log.info("setEndLent : {}", now);
+		ExceptionUtil.throwIfFalse((this.isEndLentValid(now)),
+				new DomainException(ExceptionStatus.INVALID_ARGUMENT));
+		this.endedAt = now;
+		ExceptionUtil.throwIfFalse((this.isValid()),
+				new DomainException(ExceptionStatus.INVALID_STATUS));
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentPolicyImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentPolicyImpl.java
@@ -62,7 +62,10 @@ public class LentPolicyImpl implements LentPolicy {
 		LentType lentType = cabinet.getLentType();
 		switch (lentType) {
 			case PRIVATE:
-				return now.plusDays(getDaysForLentTermPrivate());
+				return now.plusDays(getDaysForLentTermPrivate())
+						.withHour(23)
+						.withMinute(59)
+						.withSecond(59);
 			case SHARE:
 				if (activeLentHistories.isEmpty()) {
 					return DateUtil.getInfinityDate();

--- a/backend/src/main/java/org/ftclub/cabinet/utils/DateUtil.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/DateUtil.java
@@ -76,7 +76,7 @@ public class DateUtil {
 	 * @return day1 - day2
 	 */
 	public static Long calculateTwoDateDiff(LocalDateTime day1, LocalDateTime day2) {
-		return Duration.between(day2, day1).toDays();
+		return Duration.between(day2, day1).toDays() + 1;
 	}
 
 	/**
@@ -117,10 +117,11 @@ public class DateUtil {
 
 	/**
 	 * now 가 서버의 현재 시간보다 과거인지 확입합니다.
+	 *
 	 * @param now
 	 * @return
 	 */
-	public static boolean isPast(LocalDateTime now){
+	public static boolean isPast(LocalDateTime now) {
 		LocalDate currentServerDate = LocalDate.now();
 		return currentServerDate.isAfter(now.toLocalDate());
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/utils/DateUtil.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/DateUtil.java
@@ -76,7 +76,7 @@ public class DateUtil {
 	 * @return day1 - day2
 	 */
 	public static Long calculateTwoDateDiff(LocalDateTime day1, LocalDateTime day2) {
-		return Duration.between(day2, day1).toDays() + 1;
+		return Duration.between(day2, day1).toDays();
 	}
 
 	/**

--- a/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryUnitTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryUnitTest.java
@@ -143,13 +143,17 @@ class LentHistoryUnitTest {
 	void getDaysDiffEndedAndExpired_성공_조기반납() {
 		LentHistory lentHistory = LentHistory.of(
 				LocalDateTime.now(),
-				LocalDateTime.now().plusDays(3),
+				LocalDateTime.now()
+						.plusDays(3)
+						.withHour(23)
+						.withMinute(59)
+						.withSecond(59),
 				1L,
 				1L);
 
 		lentHistory.endLent(LocalDateTime.now()); // 바로 반납
 
-		assertEquals(-3, lentHistory.getDaysDiffEndedAndExpired());
+		assertEquals(-2, lentHistory.getDaysDiffEndedAndExpired());
 	}
 
 

--- a/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryUnitTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryUnitTest.java
@@ -1,15 +1,18 @@
 package org.ftclub.cabinet.lent.domain;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
 import org.ftclub.cabinet.exception.DomainException;
 import org.ftclub.cabinet.exception.ExceptionStatus;
 import org.ftclub.cabinet.utils.DateUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class LentHistoryUnitTest {
 
@@ -161,7 +164,7 @@ class LentHistoryUnitTest {
 
 		lentHistory.endLent(LocalDateTime.now().plusDays(5)); // 2일 연체 반납
 
-		assertEquals(2, lentHistory.getDaysDiffEndedAndExpired());
+		assertEquals(3, lentHistory.getDaysDiffEndedAndExpired());
 	}
 
 

--- a/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentPolicyUnitTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentPolicyUnitTest.java
@@ -40,7 +40,11 @@ class LentPolicyUnitTest {
 	@DisplayName("성공: 만료일자 설정 - 개인사물함")
 	void 성공_개인사물함_generateExpirationDate() {
 		LocalDateTime current = LocalDateTime.now();
-		LocalDateTime expect = LocalDateTime.now().plusDays(21);
+		LocalDateTime expect = LocalDateTime.now()
+				.plusDays(21)
+				.withHour(23)
+				.withMinute(59)
+				.withSecond(59);
 		given(cabinetProperties.getLentTermPrivate()).willReturn(21);
 
 		Cabinet cabinet = mock(Cabinet.class);
@@ -223,9 +227,9 @@ class LentPolicyUnitTest {
 
 	/**
 	 * @See {@link LentPolicyImpl#verifyUserForLent(User, Cabinet, int, List)}
-	 *
+	 * <p>
 	 * 설계 상의 문제로 테스트 코드 비활성화 처리 해두었습니다.
- 	 */
+	 */
 //	@Test
 //	@DisplayName("실패: 블랙홀 유저")
 //	void 실패_BLACKHOLED_USER_verifyUserForLent() {
@@ -239,7 +243,6 @@ class LentPolicyUnitTest {
 //
 //		assertEquals(LentPolicyStatus.BLACKHOLED_USER, result);
 //	}
-
 	@Test
 	@DisplayName("실패: ALL BAN 유저")
 	void 실패_ALL_BANNED_USER_verifyUserForLent() {
@@ -316,7 +319,7 @@ class LentPolicyUnitTest {
 
 	/**
 	 * @See {@link LentPolicyImpl#verifyUserForLent(User, Cabinet, int, List)}
-	 *
+	 * <p>
 	 * 설계 상의 문제로 테스트 코드 비활성화 처리 해두었습니다.
 	 */
 //	@Test
@@ -334,7 +337,6 @@ class LentPolicyUnitTest {
 //
 //		assertEquals(LentPolicyStatus.FINE, result);
 //	}
-
 	@Test
 	@DisplayName("실패: FULL캐비넷 대여시도")
 	void 실패_FULL_verifyCabinetForLent() {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

- 기존에 사물함 만료일이 대여일 + 대여일자의 시/분/초로 설정되어 있었던 부분을 만료일 당일 23시59분59초로 설정되도록 수정하였습니다.
- 사물함 연체일이 하루 적게 나오는 로직을 수정하였습니다.

https://github.com/innovationacademy-kr/42cabi/issues/
