### PR TITLE
[BE] FIX: 프러덕션에서 Config 파일을 런타임에 주입 받도록 수정

### DIFF
--- a/.github/workflows/back-ci.yaml
+++ b/.github/workflows/back-ci.yaml
@@ -9,18 +9,10 @@ jobs:
   backend-CI:
     runs-on: ubuntu-latest
     steps:
-      - name: Make ssh file
-        run: |
-          mkdir -p ~/.ssh
-          echo '${{ secrets.SSH_CONFIG }}' | base64 -d > ~/.ssh/id_rsa
-          chmod 400 ~/.ssh/id_rsa
       - name: 체크아웃
         uses: actions/checkout@v3
         with:
           submodule: true
-      - name: 서브모듈 업데이트
-        run: |
-          git submodule update --init config
 
       - name: JDK 11 설정
         uses: actions/setup-java@v3
@@ -37,6 +29,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
       - name: Gradle 빌드
         run: |
           cd backend

--- a/deploy-dev/deploy.sh
+++ b/deploy-dev/deploy.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+cd /home/ec2-user
+
+if [ ! -d "/home/ec2-user/server-config" ]; then
+  git clone git@github.com:42cabi/config.git server-config
+fi
+
+cd server-config
+git pull origin main
+
 mkdir -p /home/ec2-user/deploy/zip
 cd /home/ec2-user/deploy/zip/
 

--- a/deploy-dev/pinpoint-application/Dockerfile
+++ b/deploy-dev/pinpoint-application/Dockerfile
@@ -6,4 +6,4 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 
 COPY build/cabinet-0.0.1-SNAPSHOT.jar cabi.jar
 
-CMD java -jar -Dspring.profiles.active=dev ${JAVA_OPTS} cabi.jar
+CMD java -jar -Dspring.profiles.active=dev ${JAVA_OPTS} cabi.jar --spring.config.location=file:/resources/application-dev.yml

--- a/deploy-dev/pinpoint-application/docker-compose.yml
+++ b/deploy-dev/pinpoint-application/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - data-volume:/pinpoint-agent
       - $HOME/logs/:/logs/
+      - $HOME/server-config/backend/src/main/resources:/resources/
     environment:
       JAVA_OPTS: "-javaagent:/pinpoint-agent/pinpoint-bootstrap-${PINPOINT_VERSION}.jar -Dpinpoint.agentId=${AGENT_ID} -Dpinpoint.applicationName=${APP_NAME} -Dpinpoint.profiler.profiles.active=${SPRING_PROFILES}"
     networks:

--- a/deploy-main/deploy.sh
+++ b/deploy-main/deploy.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+cd /home/ec2-user
+
+if [ ! -d "/home/ec2-user/server-config" ]; then
+  git clone git@github.com:42cabi/config.git server-config
+fi
+
+cd server-config
+git pull origin main
+
 mkdir -p /home/ec2-user/deploy/zip
 cd /home/ec2-user/deploy/zip/
 

--- a/deploy-main/pinpoint-application/Dockerfile
+++ b/deploy-main/pinpoint-application/Dockerfile
@@ -6,4 +6,4 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 
 COPY build/cabinet-0.0.1-SNAPSHOT.jar cabi.jar
 
-CMD java -jar -Dspring.profiles.active=prod ${JAVA_OPTS} cabi.jar
+CMD java -jar -Dspring.profiles.active=prod ${JAVA_OPTS} cabi.jar --spring.config.location=file:/resources/application-prod.yml

--- a/deploy-main/pinpoint-application/docker-compose.yml
+++ b/deploy-main/pinpoint-application/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - data-volume:/pinpoint-agent
       - $HOME/logs/:/logs/
+      - $HOME/server-config/backend/src/main/resources:/resources/
     environment:
       JAVA_OPTS: "-javaagent:/pinpoint-agent/pinpoint-bootstrap-${PINPOINT_VERSION}.jar -Dpinpoint.agentId=${AGENT_ID} -Dpinpoint.applicationName=${APP_NAME} -Dpinpoint.profiler.profiles.active=${SPRING_PROFILES}"
     networks:


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1408

### 작업 설명

현재는 이미지 빌드를 서버 인스턴스 내부에서 진행중이기 때문에, 배포가 될 때 메모리 사용률이 높아져 문제가 발생할 위험이 있습니다.
관련 이슈: #1400 

따라서 서버 인스턴스 내부에서 이미지 빌드를 수행하지 않고, CI 워크플로우에서 빌드를 수행한 후, 이미지를 Registry에 업로드 한 후
CD에서 이 이미지를 pull 받는 구조로 변경하려고 합니다.

이미지 Registry를 public 레포지토리로 이용하는 구조를 원하기 때문에 Config 파일이 이미지에 포함되지 않아야 합니다.
이를 위해서 프러덕션에서 Config 파일을 런타임에 주입 받도록 수정하는 작업을 진행하겠습니다.


### 접근 방법

### 이번 작업 내용
- CI workflow에서 submodule을 update 하는 부분을 제외한다.
- 배포 스크립트에서 애플리케이션을 실행하기 전 submodule을 pull 받도록 수정한다.
- submodule이 속한 경로를 볼륨에 연결하도록 배포용 Dockerfile을 수정한다.


### 다음에 진행할 작업
- CI workflow에서 도커 이미지를 빌드한다.
- 도커 이미지를 registry에 업로드시킨다.
- registry에 업로드한 이미지를 pull 받도록 배포 스크립트를 수정한다.
