### PR TITLE
[FE] FEAT: 프로필 페이지 추가 #1410

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,6 @@ import MainPage from "@/pages/MainPage";
 import AdminMainPage from "@/pages/admin/AdminMainPage";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
 import ProfilePage from "./pages/ProfilePage";
-import "./firebase-messaging-sw"
-
 
 const NotFoundPage = lazy(() => import("@/pages/NotFoundPage"));
 const LoginFailurePage = lazy(() => import("@/pages/LoginFailurePage"));

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -107,7 +107,7 @@ const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
   // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
   const { lentType, title, maxUser, lents } = selectedCabinetInfo;
   if (lentType === "CLUB" && title) return title;
-  else if (maxUser === 0) return lents[0].name;
+  else if (maxUser === 0) return "";
 
   // 그 외에는 유저리스트 반환
   const userNameList = new Array(maxUser)
@@ -193,7 +193,10 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
         status: targetCabinetInfo.status,
         lentType: targetCabinetInfo.lentType,
         userNameList: getCabinetUserList(targetCabinetInfo),
-        expireDate: targetCabinetInfo.lents[0]?.expiredAt,
+        expireDate:
+          targetCabinetInfo.lents.length !== 0
+            ? targetCabinetInfo.lents[0].expiredAt
+            : undefined,
         detailMessage: getDetailMessage(targetCabinetInfo),
         detailMessageColor: getDetailMessageColor(targetCabinetInfo),
         isAdmin: isAdmin,

--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -85,7 +85,7 @@ export type TModalState =
 
 export type TAdminModalState = "returnModal" | "statusModal" | "clubLentModal";
 
-const calExpiredTime = (expireTime: Date) =>
+export const calExpiredTime = (expireTime: Date) =>
   Math.floor(
     (expireTime.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
   );
@@ -118,7 +118,9 @@ const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
   return userNameList;
 };
 
-const getDetailMessage = (selectedCabinetInfo: CabinetInfo): string | null => {
+export const getDetailMessage = (
+  selectedCabinetInfo: CabinetInfo
+): string | null => {
   const { status, lentType, lents } = selectedCabinetInfo;
   // 밴, 고장 사물함
   if (status === CabinetStatus.BANNED || status === CabinetStatus.BROKEN)
@@ -136,7 +138,9 @@ const getDetailMessage = (selectedCabinetInfo: CabinetInfo): string | null => {
   else return null;
 };
 
-const getDetailMessageColor = (selectedCabinetInfo: CabinetInfo): string => {
+export const getDetailMessageColor = (
+  selectedCabinetInfo: CabinetInfo
+): string => {
   const { status, lentType, lents } = selectedCabinetInfo;
   // 밴, 고장 사물함
   if (status === CabinetStatus.BANNED || status === CabinetStatus.BROKEN)

--- a/frontend/src/components/Card/Card.tsx
+++ b/frontend/src/components/Card/Card.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  CardButtonStyled,
+  CardButtonWrapper,
+  CardHeaderStyled,
+  CardStyled,
+  CardTitleStyled,
+} from "@/components/Card/CardStyles";
+
+export interface IButtonProps {
+  label: string;
+  onClick?: () => void;
+  backgroundColor?: string;
+  color?: string;
+  isClickable: boolean;
+  isExtensible?: boolean;
+}
+
+interface CardProps {
+  title: string;
+  children: React.ReactElement;
+  buttons?: IButtonProps[];
+  gridArea: string;
+  width?: string;
+  height?: string;
+}
+
+const Card = ({
+  title,
+  gridArea,
+  width = "350px",
+  height = "163px",
+  buttons,
+  children,
+}: CardProps) => {
+  return (
+    <CardStyled gridArea={gridArea} width={width} height={height}>
+      <CardHeaderStyled>
+        <CardTitleStyled>{title}</CardTitleStyled>
+        <CardButtonWrapper>
+          {buttons?.map((button, index) => (
+            <CardButtonStyled
+              key={index}
+              onClick={button.onClick}
+              color={button.color}
+              backgroundColor={button.backgroundColor}
+              isClickable={button.isClickable}
+              isExtensible={button.isExtensible}
+            >
+              {button.label}
+            </CardButtonStyled>
+          ))}
+        </CardButtonWrapper>
+      </CardHeaderStyled>
+      {children}
+    </CardStyled>
+  );
+};
+
+export default Card;

--- a/frontend/src/components/Card/Card.tsx
+++ b/frontend/src/components/Card/Card.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  CardButtonStyled,
-  CardButtonWrapper,
-  CardHeaderStyled,
-  CardStyled,
-  CardTitleStyled,
-} from "@/components/Card/CardStyles";
+import styled from "styled-components";
 
 export interface IButtonProps {
   label: string;
@@ -56,5 +50,59 @@ const Card = ({
     </CardStyled>
   );
 };
+
+export const CardStyled = styled.div<{
+  width: string;
+  height: string;
+  gridArea: string;
+}>`
+  width: ${(props) => props.width};
+  border-radius: 10px;
+  background-color: var(--lightgary-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: ${(props) => props.height};
+  grid-area: ${(props) => props.gridArea};
+`;
+
+export const CardHeaderStyled = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 20px 10px 30px;
+`;
+
+export const CardTitleStyled = styled.div`
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-right: auto;
+`;
+
+export const CardButtonWrapper = styled.div`
+  display: flex;
+`;
+
+export const CardButtonStyled = styled.div<{
+  backgroundColor?: string;
+  color?: string;
+  isClickable?: boolean;
+  isExtensible?: boolean;
+}>`
+  background-color: ${(props) =>
+    props.backgroundColor ? props.backgroundColor : "var(--white)"};
+  color: ${(props) =>
+    props.color
+      ? props.color
+      : props.isExtensible
+      ? "var(--main-color)"
+      : "var(--gray-color)"};
+  padding: 5px 15px;
+  border: none;
+  border-radius: 5px;
+  cursor: ${(props) => (props.isClickable ? "pointer" : "default")};
+  margin-left: 10px;
+`;
 
 export default Card;

--- a/frontend/src/components/Card/CardStyles.ts
+++ b/frontend/src/components/Card/CardStyles.ts
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+
+export const CardStyled = styled.div<{
+  width: string;
+  height: string;
+  gridArea: string;
+}>`
+  width: ${(props) => props.width};
+  border-radius: 10px;
+  background-color: var(--lightgary-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: ${(props) => props.height};
+  grid-area: ${(props) => props.gridArea};
+`;
+
+export const CardHeaderStyled = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 20px 10px 30px;
+`;
+
+export const CardTitleStyled = styled.div`
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-right: auto;
+`;
+
+export const CardButtonWrapper = styled.div`
+  display: flex;
+`;
+
+export const CardButtonStyled = styled.div<{
+  backgroundColor?: string;
+  color?: string;
+  isClickable?: boolean;
+  isExtensible?: boolean;
+}>`
+  background-color: ${(props) =>
+    props.backgroundColor ? props.backgroundColor : "var(--white)"};
+  color: ${(props) =>
+    props.color
+      ? props.color
+      : props.isExtensible
+      ? "var(--main-color)"
+      : "var(--gray-color)"};
+  padding: 5px 15px;
+  border: none;
+  border-radius: 5px;
+  cursor: ${(props) => (props.isClickable ? "pointer" : "default")};
+  margin-left: 10px;
+`;
+
+export const CardContentWrapper = styled.div`
+  background-color: var(--white);
+  border-radius: 10px;
+  padding: 15px 0;
+  margin: 10px 5px 0 5px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const CardContentStyled = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 5px 0 5px 0;
+`;
+
+export const ContentInfoStyled = styled.div`
+  display: flex;
+  margin: 0 0 0 10px;
+`;
+
+export const ContentDeatilStyled = styled.div`
+  display: flex;
+  margin: 0 10px 5px 0;
+  font-weight: bold;
+`;

--- a/frontend/src/components/Card/CardStyles.ts
+++ b/frontend/src/components/Card/CardStyles.ts
@@ -1,59 +1,5 @@
 import styled from "styled-components";
 
-export const CardStyled = styled.div<{
-  width: string;
-  height: string;
-  gridArea: string;
-}>`
-  width: ${(props) => props.width};
-  border-radius: 10px;
-  background-color: var(--lightgary-color);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: ${(props) => props.height};
-  grid-area: ${(props) => props.gridArea};
-`;
-
-export const CardHeaderStyled = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 20px 10px 30px;
-`;
-
-export const CardTitleStyled = styled.div`
-  font-size: 1.2em;
-  font-weight: bold;
-  margin-right: auto;
-`;
-
-export const CardButtonWrapper = styled.div`
-  display: flex;
-`;
-
-export const CardButtonStyled = styled.div<{
-  backgroundColor?: string;
-  color?: string;
-  isClickable?: boolean;
-  isExtensible?: boolean;
-}>`
-  background-color: ${(props) =>
-    props.backgroundColor ? props.backgroundColor : "var(--white)"};
-  color: ${(props) =>
-    props.color
-      ? props.color
-      : props.isExtensible
-      ? "var(--main-color)"
-      : "var(--gray-color)"};
-  padding: 5px 15px;
-  border: none;
-  border-radius: 5px;
-  cursor: ${(props) => (props.isClickable ? "pointer" : "default")};
-  margin-left: 10px;
-`;
-
 export const CardContentWrapper = styled.div`
   background-color: var(--white);
   border-radius: 10px;

--- a/frontend/src/components/Card/CardStyles.ts
+++ b/frontend/src/components/Card/CardStyles.ts
@@ -58,7 +58,7 @@ export const CardContentWrapper = styled.div`
   background-color: var(--white);
   border-radius: 10px;
   padding: 15px 0;
-  margin: 10px 5px 0 5px;
+  margin: 5px 5px 10px 5px;
   width: 90%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/Card/CardStyles.ts
+++ b/frontend/src/components/Card/CardStyles.ts
@@ -15,6 +15,7 @@ export const CardContentStyled = styled.div`
   justify-content: space-between;
   align-items: center;
   margin: 5px 0 5px 0;
+  padding: 0 10px 0 10px;
 `;
 
 export const ContentInfoStyled = styled.div`

--- a/frontend/src/components/Card/ExtensionCard/ExtensionCard.container.tsx
+++ b/frontend/src/components/Card/ExtensionCard/ExtensionCard.container.tsx
@@ -1,0 +1,17 @@
+import ExtensionCard from "@/components/Card/ExtensionCard/ExtensionCard";
+
+const ExtensionCardContainer = ({ extensible }: { extensible: boolean }) => {
+  return (
+    <ExtensionCard
+      extensible={extensible}
+      button={{
+        label: extensible ? "보유중" : "미보유",
+        onClick: () => {},
+        isClickable: false,
+        isExtensible: extensible,
+      }}
+    />
+  );
+};
+
+export default ExtensionCardContainer;

--- a/frontend/src/components/Card/ExtensionCard/ExtensionCard.tsx
+++ b/frontend/src/components/Card/ExtensionCard/ExtensionCard.tsx
@@ -1,0 +1,44 @@
+import Card, { IButtonProps } from "@/components/Card/Card";
+import {
+  CardContentStyled,
+  CardContentWrapper,
+  ContentDeatilStyled,
+  ContentInfoStyled,
+} from "@/components/Card/CardStyles";
+import { getLastDayofMonthString } from "@/utils/dateUtils";
+
+interface ExtensionProps {
+  extensible: boolean;
+  button: IButtonProps;
+}
+
+const ExtensionCard = ({ extensible, button }: ExtensionProps) => {
+  return (
+    <Card
+      title={"연장권"}
+      gridArea={"extension"}
+      width={"350px"}
+      height={"183px"}
+      buttons={[button]}
+    >
+      <CardContentWrapper>
+        <CardContentStyled>
+          <ContentInfoStyled>사용 기한</ContentInfoStyled>
+          <ContentDeatilStyled>
+            {extensible ? getLastDayofMonthString(null, ".") : "-"}
+          </ContentDeatilStyled>
+        </CardContentStyled>
+        <CardContentStyled>
+          <ContentInfoStyled>연장 기간</ContentInfoStyled>
+          <ContentDeatilStyled>
+            {extensible
+              ? parseInt(import.meta.env.VITE_EXTENDED_LENT_PERIOD) + "일"
+              : "-"}
+          </ContentDeatilStyled>
+        </CardContentStyled>
+      </CardContentWrapper>
+    </Card>
+  );
+};
+
+export default ExtensionCard;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
@@ -1,0 +1,55 @@
+import { useRecoilValue } from "recoil";
+import { myCabinetInfoState } from "@/recoil/atoms";
+import LentInfoCard from "@/components/Card/LentInfoCard/LentInfoCard";
+import { CabinetInfo } from "@/types/dto/cabinet.dto";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+
+export interface MyCabinetInfo {
+  floor: number;
+  section: string;
+  cabinetId: number;
+  visibleNum: number;
+  lentType: CabinetType;
+  userNameList: string;
+  expireDate?: Date;
+  isLented: boolean;
+  previousUserName: string;
+}
+
+const LentInfoCardContainer = () => {
+  const myCabinetInfo = useRecoilValue(myCabinetInfoState);
+
+  const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
+    const { lents } = selectedCabinetInfo;
+    // 동아리 사물함인 경우 cabinet_title 에 있는 동아리 이름 반환
+    // if (lentType === "CLUB" && title) return TitleStyled;
+    if (lents.length === 0) return "";
+    // 그 외에는 유저리스트 반환
+    return new Array(lents.length)
+      .fill(null)
+      .map((_, idx) => lents[idx])
+      .map((info) => (info ? info.name : ""))
+      .join(", ");
+  };
+
+  const cabinetLentInfo: MyCabinetInfo | null = myCabinetInfo
+    ? {
+        floor: myCabinetInfo.floor,
+        section: myCabinetInfo.section,
+        cabinetId: myCabinetInfo.cabinetId,
+        visibleNum: myCabinetInfo.visibleNum,
+        lentType: myCabinetInfo.lentType,
+        userNameList: getCabinetUserList(myCabinetInfo),
+        expireDate:
+          myCabinetInfo.lents.length !== 0
+            ? myCabinetInfo.lents[0].expiredAt
+            : undefined,
+        isLented: myCabinetInfo.lents.length !== 0,
+        previousUserName: myCabinetInfo.previousUserName,
+      }
+    : null;
+
+  return <LentInfoCard cabinetInfo={cabinetLentInfo} />;
+};
+
+export default LentInfoCardContainer;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
@@ -1,6 +1,7 @@
 import { useRecoilValue } from "recoil";
 import { myCabinetInfoState } from "@/recoil/atoms";
 import LentInfoCard from "@/components/Card/LentInfoCard/LentInfoCard";
+import { getDefaultCabinetInfo } from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 
@@ -22,10 +23,7 @@ const LentInfoCardContainer = () => {
 
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     const { lents } = selectedCabinetInfo;
-    // 동아리 사물함인 경우 cabinet_title 에 있는 동아리 이름 반환
-    // if (lentType === "CLUB" && title) return TitleStyled;
     if (lents.length === 0) return "";
-    // 그 외에는 유저리스트 반환
     return new Array(lents.length)
       .fill(null)
       .map((_, idx) => lents[idx])
@@ -33,7 +31,9 @@ const LentInfoCardContainer = () => {
       .join(", ");
   };
 
-  const cabinetLentInfo: MyCabinetInfo | null = myCabinetInfo
+  const defaultCabinetInfo: CabinetInfo = getDefaultCabinetInfo();
+
+  const cabinetLentInfo: MyCabinetInfo = myCabinetInfo
     ? {
         floor: myCabinetInfo.floor,
         section: myCabinetInfo.section,
@@ -49,7 +49,18 @@ const LentInfoCardContainer = () => {
         isLented: myCabinetInfo.lents.length !== 0,
         previousUserName: myCabinetInfo.previousUserName,
       }
-    : null;
+    : {
+        floor: defaultCabinetInfo.floor,
+        section: defaultCabinetInfo.section,
+        cabinetId: defaultCabinetInfo.cabinetId,
+        visibleNum: defaultCabinetInfo.visibleNum,
+        lentType: defaultCabinetInfo.lentType,
+        userCount: 0,
+        userNameList: "",
+        expireDate: undefined,
+        isLented: false,
+        previousUserName: "",
+      };
 
   return <LentInfoCard cabinetInfo={cabinetLentInfo} />;
 };

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
@@ -10,6 +10,7 @@ export interface MyCabinetInfo {
   cabinetId: number;
   visibleNum: number;
   lentType: CabinetType;
+  userCount: number;
   userNameList: string;
   expireDate?: Date;
   isLented: boolean;
@@ -39,6 +40,7 @@ const LentInfoCardContainer = () => {
         cabinetId: myCabinetInfo.cabinetId,
         visibleNum: myCabinetInfo.visibleNum,
         lentType: myCabinetInfo.lentType,
+        userCount: myCabinetInfo.lents.length,
         userNameList: getCabinetUserList(myCabinetInfo),
         expireDate:
           myCabinetInfo.lents.length !== 0

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
@@ -1,5 +1,5 @@
 import { useRecoilValue } from "recoil";
-import { myCabinetInfoState } from "@/recoil/atoms";
+import { myCabinetInfoState, targetUserInfoState } from "@/recoil/atoms";
 import LentInfoCard from "@/components/Card/LentInfoCard/LentInfoCard";
 import { getDefaultCabinetInfo } from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
@@ -16,10 +16,13 @@ export interface MyCabinetInfo {
   expireDate?: Date;
   isLented: boolean;
   previousUserName: string;
+  status: string;
 }
 
 const LentInfoCardContainer = () => {
   const myCabinetInfo = useRecoilValue(myCabinetInfoState);
+  const targetUserInfo = useRecoilValue(targetUserInfoState);
+  const bannedAt = targetUserInfo ? !!targetUserInfo.bannedAt : false;
 
   const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
     const { lents } = selectedCabinetInfo;
@@ -48,6 +51,7 @@ const LentInfoCardContainer = () => {
             : undefined,
         isLented: myCabinetInfo.lents.length !== 0,
         previousUserName: myCabinetInfo.previousUserName,
+        status: myCabinetInfo.status,
       }
     : {
         floor: defaultCabinetInfo.floor,
@@ -60,9 +64,10 @@ const LentInfoCardContainer = () => {
         expireDate: undefined,
         isLented: false,
         previousUserName: "",
+        status: defaultCabinetInfo.status,
       };
 
-  return <LentInfoCard cabinetInfo={cabinetLentInfo} />;
+  return <LentInfoCard cabinetInfo={cabinetLentInfo} bannedAt={bannedAt} />;
 };
 
 export default LentInfoCardContainer;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
@@ -7,11 +7,22 @@ import {
   ContentInfoStyled,
 } from "@/components/Card/CardStyles";
 import { MyCabinetInfo } from "@/components/Card/LentInfoCard/LentInfoCard.container";
-import { cabinetIconSrcMap } from "@/assets/data/maps";
+import {
+  cabinetIconSrcMap,
+  cabinetLabelColorMap,
+  cabinetStatusColorMap,
+} from "@/assets/data/maps";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import { formatDate, getRemainingTime } from "@/utils/dateUtils";
 
-const LentInfoCard = ({ cabinetInfo }: { cabinetInfo: MyCabinetInfo }) => {
+const LentInfoCard = ({
+  cabinetInfo,
+  bannedAt,
+}: {
+  cabinetInfo: MyCabinetInfo;
+  bannedAt: boolean;
+}) => {
   const calculateFontSize = (userCount: number): string => {
     const baseSize = 1;
     const decrement = 0.2;
@@ -31,8 +42,15 @@ const LentInfoCard = ({ cabinetInfo }: { cabinetInfo: MyCabinetInfo }) => {
     >
       <>
         <CabinetInfoWrapper>
-          <CabinetRectangleStyled isMine={cabinetInfo?.cabinetId !== 0}>
-            {cabinetInfo.visibleNum !== 0 ? cabinetInfo.visibleNum : "-"}
+          <CabinetRectangleStyled
+            status={cabinetInfo.status as CabinetStatus}
+            banned={!!bannedAt}
+          >
+            {cabinetInfo.visibleNum !== 0
+              ? cabinetInfo.visibleNum
+              : !!bannedAt
+              ? "!"
+              : "-"}
           </CabinetRectangleStyled>
           <CabinetInfoDetailStyled>
             <CabinetInfoTextStyled
@@ -110,14 +128,26 @@ const CabinetInfoWrapper = styled.div`
 `;
 
 const CabinetRectangleStyled = styled.div<{
-  isMine: boolean;
+  status: CabinetStatus;
+  banned?: boolean;
 }>`
   width: 60px;
   height: 60px;
   line-height: 60px;
   border-radius: 10px;
   margin-right: 20px;
-  background-color: var(--mine);
+  background-color: ${(props) =>
+    props.banned
+      ? "var(--expired)"
+      : props.status === "FULL"
+      ? "var(--mine)"
+      : cabinetStatusColorMap[props.status]};
+  color: ${(props) =>
+    props.banned
+      ? "var(--white)"
+      : props.status && props.status !== "PENDING"
+      ? cabinetLabelColorMap[props.status]
+      : "var(--black)"};
   font-size: 32px;
   text-align: center;
 `;
@@ -125,7 +155,7 @@ const CabinetRectangleStyled = styled.div<{
 const CabinetInfoDetailStyled = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 `;
 
 const CabinetInfoTextStyled = styled.div<{
@@ -147,10 +177,8 @@ const CabinetUserListWrapper = styled.div`
 `;
 
 const CabinetIconStyled = styled.div<{ cabinetType: CabinetType }>`
-  width: 24px;
-  height: 24px;
-  min-width: 24px;
-  min-height: 24px;
+  width: 18px;
+  height: 18px;
   margin-right: 10px;
   background-image: url(${(props) => cabinetIconSrcMap[props.cabinetType]});
   background-size: contain;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
@@ -1,0 +1,151 @@
+import styled from "styled-components";
+import Card from "@/components/Card/Card";
+import {
+  CardContentStyled,
+  CardContentWrapper,
+  ContentDeatilStyled,
+  ContentInfoStyled,
+} from "@/components/Card/CardStyles";
+import { MyCabinetInfo } from "@/components/Card/LentInfoCard/LentInfoCard.container";
+import { cabinetIconSrcMap } from "@/assets/data/maps";
+import CabinetType from "@/types/enum/cabinet.type.enum";
+import { formatDate, getRemainingTime } from "@/utils/dateUtils";
+
+const LentInfoCard = ({
+  cabinetInfo,
+}: {
+  cabinetInfo: MyCabinetInfo | null;
+}) => {
+  return (
+    <Card
+      title={"대여정보"}
+      gridArea="lentInfo"
+      width={"350px"}
+      height={"366px"}
+    >
+      <>
+        <CabinetInfoWrapper>
+          <CabinetRectangleStyled isMine={cabinetInfo?.cabinetId !== 0}>
+            {cabinetInfo!.visibleNum !== 0 ? cabinetInfo!.visibleNum : "-"}
+          </CabinetRectangleStyled>
+          <CabinetInfoDetailStyled>
+            <CabinetInfoTextStyled
+              fontSize="1rem"
+              fontColor="var(--gray-color)"
+            >
+              {cabinetInfo!.floor !== 0
+                ? cabinetInfo!.floor + "층 - " + cabinetInfo!.section
+                : ""}
+            </CabinetInfoTextStyled>
+            {cabinetInfo?.isLented && (
+              <CabinetUserListWrapper>
+                <CabinetIconStyled
+                  title={cabinetInfo!.lentType}
+                  cabinetType={cabinetInfo!.lentType}
+                />
+                <CabinetInfoTextStyled fontSize="1rem" fontColor="black">
+                  {cabinetInfo!.userNameList}
+                </CabinetInfoTextStyled>
+              </CabinetUserListWrapper>
+            )}
+          </CabinetInfoDetailStyled>
+        </CabinetInfoWrapper>
+        <CardContentWrapper>
+          <CardContentStyled>
+            <ContentInfoStyled>사용 기간</ContentInfoStyled>
+            <ContentDeatilStyled>
+              {cabinetInfo?.isLented
+                ? `${
+                    cabinetInfo!.lentType === "PRIVATE"
+                      ? parseInt(import.meta.env.VITE_PRIVATE_LENT_PERIOD)
+                      : parseInt(import.meta.env.VITE_SHARE_LENT_PERIOD)
+                  }일`
+                : "-"}
+            </ContentDeatilStyled>
+          </CardContentStyled>
+          <CardContentStyled>
+            <ContentInfoStyled>남은 기간</ContentInfoStyled>
+            <ContentDeatilStyled>
+              {cabinetInfo?.expireDate
+                ? getRemainingTime(cabinetInfo?.expireDate) + "일"
+                : "-"}
+            </ContentDeatilStyled>
+          </CardContentStyled>
+          <CardContentStyled>
+            <ContentInfoStyled>종료 일자</ContentInfoStyled>
+            <ContentDeatilStyled>
+              {cabinetInfo?.expireDate
+                ? formatDate(new Date(cabinetInfo?.expireDate), ".")
+                : "-"}
+            </ContentDeatilStyled>
+          </CardContentStyled>
+        </CardContentWrapper>
+        <CardContentWrapper>
+          <CardContentStyled>
+            <ContentInfoStyled>이전 대여자</ContentInfoStyled>
+            <ContentDeatilStyled>
+              {cabinetInfo?.previousUserName || "-"}
+            </ContentDeatilStyled>
+          </CardContentStyled>
+        </CardContentWrapper>
+      </>
+    </Card>
+  );
+};
+
+const CabinetInfoWrapper = styled.div`
+  display: flex;
+  width: 80%;
+  margin: 10px 0 15px 0;
+  align-items: center;
+`;
+
+const CabinetRectangleStyled = styled.div<{
+  isMine: boolean;
+}>`
+  width: 60px;
+  height: 60px;
+  line-height: 60px;
+  border-radius: 10px;
+  margin-right: 20px;
+  background-color: var(--mine);
+  font-size: 32px;
+  text-align: center;
+`;
+
+const CabinetInfoDetailStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const CabinetInfoTextStyled = styled.div<{
+  fontSize: string;
+  fontColor: string;
+}>`
+  font-size: ${(props) => props.fontSize};
+  font-weight: 400;
+  line-height: 28px;
+  color: ${(props) => props.fontColor};
+  text-align: center;
+  white-space: pre-line;
+`;
+
+const CabinetUserListWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const CabinetIconStyled = styled.div<{ cabinetType: CabinetType }>`
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  margin-right: 10px;
+  background-image: url(${(props) => cabinetIconSrcMap[props.cabinetType]});
+  background-size: contain;
+  background-repeat: no-repeat;
+`;
+
+export default LentInfoCard;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
@@ -16,10 +16,20 @@ const LentInfoCard = ({
 }: {
   cabinetInfo: MyCabinetInfo | null;
 }) => {
+  const calculateFontSize = (userCount: number): string => {
+    const baseSize = 1;
+    const decrement = 0.2;
+    const minSize = 0.6;
+    const calculatedSize = Math.max(
+      baseSize - (userCount - 1) * decrement,
+      minSize
+    );
+    return `${calculatedSize}rem`;
+  };
   return (
     <Card
       title={"대여정보"}
-      gridArea="lentInfo"
+      gridArea={"lentInfo"}
       width={"350px"}
       height={"366px"}
     >
@@ -43,7 +53,10 @@ const LentInfoCard = ({
                   title={cabinetInfo!.lentType}
                   cabinetType={cabinetInfo!.lentType}
                 />
-                <CabinetInfoTextStyled fontSize="1rem" fontColor="black">
+                <CabinetInfoTextStyled
+                  fontSize={calculateFontSize(cabinetInfo!.userCount)}
+                  fontColor="black"
+                >
                   {cabinetInfo!.userNameList}
                 </CabinetInfoTextStyled>
               </CabinetUserListWrapper>
@@ -95,7 +108,7 @@ const LentInfoCard = ({
 
 const CabinetInfoWrapper = styled.div`
   display: flex;
-  width: 80%;
+  width: 85%;
   margin: 10px 0 15px 0;
   align-items: center;
 `;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
@@ -11,11 +11,7 @@ import { cabinetIconSrcMap } from "@/assets/data/maps";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import { formatDate, getRemainingTime } from "@/utils/dateUtils";
 
-const LentInfoCard = ({
-  cabinetInfo,
-}: {
-  cabinetInfo: MyCabinetInfo | null;
-}) => {
+const LentInfoCard = ({ cabinetInfo }: { cabinetInfo: MyCabinetInfo }) => {
   const calculateFontSize = (userCount: number): string => {
     const baseSize = 1;
     const decrement = 0.2;
@@ -36,28 +32,28 @@ const LentInfoCard = ({
       <>
         <CabinetInfoWrapper>
           <CabinetRectangleStyled isMine={cabinetInfo?.cabinetId !== 0}>
-            {cabinetInfo!.visibleNum !== 0 ? cabinetInfo!.visibleNum : "-"}
+            {cabinetInfo.visibleNum !== 0 ? cabinetInfo.visibleNum : "-"}
           </CabinetRectangleStyled>
           <CabinetInfoDetailStyled>
             <CabinetInfoTextStyled
               fontSize="1rem"
               fontColor="var(--gray-color)"
             >
-              {cabinetInfo!.floor !== 0
-                ? cabinetInfo!.floor + "층 - " + cabinetInfo!.section
+              {cabinetInfo.floor !== 0
+                ? cabinetInfo.floor + "층 - " + cabinetInfo.section
                 : ""}
             </CabinetInfoTextStyled>
             {cabinetInfo?.isLented && (
               <CabinetUserListWrapper>
                 <CabinetIconStyled
-                  title={cabinetInfo!.lentType}
-                  cabinetType={cabinetInfo!.lentType}
+                  title={cabinetInfo.lentType}
+                  cabinetType={cabinetInfo.lentType}
                 />
                 <CabinetInfoTextStyled
-                  fontSize={calculateFontSize(cabinetInfo!.userCount)}
+                  fontSize={calculateFontSize(cabinetInfo.userCount)}
                   fontColor="black"
                 >
-                  {cabinetInfo!.userNameList}
+                  {cabinetInfo.userNameList}
                 </CabinetInfoTextStyled>
               </CabinetUserListWrapper>
             )}
@@ -69,7 +65,7 @@ const LentInfoCard = ({
             <ContentDeatilStyled>
               {cabinetInfo?.isLented
                 ? `${
-                    cabinetInfo!.lentType === "PRIVATE"
+                    cabinetInfo.lentType === "PRIVATE"
                       ? parseInt(import.meta.env.VITE_PRIVATE_LENT_PERIOD)
                       : parseInt(import.meta.env.VITE_SHARE_LENT_PERIOD)
                   }일`

--- a/frontend/src/components/Card/NotificationCard/NotificationCard.container.tsx
+++ b/frontend/src/components/Card/NotificationCard/NotificationCard.container.tsx
@@ -1,0 +1,7 @@
+import NotificationCard from "@/components/Card/NotificationCard/NotificationCard";
+
+const NotificationCardContainer = () => {
+  return <NotificationCard />;
+};
+
+export default NotificationCardContainer;

--- a/frontend/src/components/Card/NotificationCard/NotificationCard.tsx
+++ b/frontend/src/components/Card/NotificationCard/NotificationCard.tsx
@@ -1,0 +1,36 @@
+import Card from "@/components/Card/Card";
+import {
+  CardContentStyled,
+  CardContentWrapper,
+  ContentInfoStyled,
+} from "@/components/Card/CardStyles";
+import PillButton from "@/components/Common/PillButton";
+import ToggleSwitch from "@/components/Common/ToggleSwitch";
+
+const NotificationCard = () => {
+  return (
+    <Card
+      title={"알림"}
+      gridArea="notification"
+      width={"350px"}
+      height={"215px"}
+    >
+      <CardContentWrapper>
+        <CardContentStyled>
+          <ContentInfoStyled>메일</ContentInfoStyled>
+          <ToggleSwitch id={"email-notification"} checked={false} />
+        </CardContentStyled>
+        <CardContentStyled>
+          <ContentInfoStyled>슬랙</ContentInfoStyled>
+          <ToggleSwitch id={"slack-notification"} checked={false} />
+        </CardContentStyled>
+        <CardContentStyled>
+          <ContentInfoStyled>브라우저</ContentInfoStyled>
+          <ToggleSwitch id={"browser-notification"} checked={false} />
+        </CardContentStyled>
+      </CardContentWrapper>
+    </Card>
+  );
+};
+
+export default NotificationCard;

--- a/frontend/src/components/Card/NotificationCard/NotificationCard.tsx
+++ b/frontend/src/components/Card/NotificationCard/NotificationCard.tsx
@@ -4,7 +4,6 @@ import {
   CardContentWrapper,
   ContentInfoStyled,
 } from "@/components/Card/CardStyles";
-import PillButton from "@/components/Common/PillButton";
 import ToggleSwitch from "@/components/Common/ToggleSwitch";
 
 const NotificationCard = () => {

--- a/frontend/src/components/Card/ProfileCard/ProfileCard.container.tsx
+++ b/frontend/src/components/Card/ProfileCard/ProfileCard.container.tsx
@@ -1,0 +1,47 @@
+import { useNavigate } from "react-router-dom";
+import { useResetRecoilState } from "recoil";
+import {
+  currentBuildingNameState,
+  currentFloorNumberState,
+  currentSectionNameState,
+} from "@/recoil/atoms";
+import ProfileCard from "@/components/Card/ProfileCard/ProfileCard";
+import { removeCookie } from "@/api/react_cookie/cookies";
+
+const ProfileCardContainer = ({ name }: { name: string | null }) => {
+  const navigator = useNavigate();
+  const resetCurrentFloor = useResetRecoilState(currentFloorNumberState);
+  const resetCurrentSection = useResetRecoilState(currentSectionNameState);
+  const resetBuilding = useResetRecoilState(currentBuildingNameState);
+
+  const onClickLogoutButton = (): void => {
+    if (import.meta.env.VITE_IS_LOCAL === "true") {
+      removeCookie("access_token", {
+        path: "/",
+        domain: "localhost",
+      });
+    } else {
+      removeCookie("access_token", {
+        path: "/",
+        domain: "cabi.42seoul.io",
+      });
+    }
+    resetBuilding();
+    resetCurrentFloor();
+    resetCurrentSection();
+    navigator("/login");
+  };
+
+  return (
+    <ProfileCard
+      name={name}
+      button={{
+        label: "로그아웃",
+        onClick: onClickLogoutButton,
+        isClickable: true,
+      }}
+    />
+  );
+};
+
+export default ProfileCardContainer;

--- a/frontend/src/components/Card/ProfileCard/ProfileCard.tsx
+++ b/frontend/src/components/Card/ProfileCard/ProfileCard.tsx
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+import Card, { IButtonProps } from "@/components/Card/Card";
+
+type ProfileProps = {
+  name: string | null;
+  button: IButtonProps;
+};
+
+const ProfileCard = ({ name, button }: ProfileProps) => {
+  return (
+    <Card
+      title={"프로필"}
+      gridArea={"profile"}
+      width={"350px"}
+      height={"163px"}
+      buttons={[button]}
+    >
+      <ProfileContent>
+        <ProfileImage src="/src/assets/images/logo.png" alt="Profile Avatar" />
+        <ProfileDetailWrapper>
+          <ProfileDetail>{name}</ProfileDetail>
+          <ProfileDetail>{name}@student.42seoul.kr</ProfileDetail>
+        </ProfileDetailWrapper>
+      </ProfileContent>
+    </Card>
+  );
+};
+
+const ProfileContent = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 10px;
+`;
+
+const ProfileImage = styled.img`
+  width: 60px;
+  height: 60px;
+  border-radius: 10px;
+  margin-right: 20px;
+`;
+
+const ProfileDetailWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const ProfileDetail = styled.div`
+  padding: 5px 0 0 0;
+`;
+
+export default ProfileCard;

--- a/frontend/src/components/Card/ThemeColorCard/ThemeColorCard.container.tsx
+++ b/frontend/src/components/Card/ThemeColorCard/ThemeColorCard.container.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import ThemeColorCard from "@/components/Card/ThemeColorCard/ThemeColorCard";
+
+const ThemeColorCardContainer = () => {
+  const savedColor = localStorage.getItem("mainColor");
+  const defaultColor = "#9747ff";
+  const [mainColor, setMainColor] = useState<string>(
+    savedColor ? savedColor : defaultColor
+  );
+  const [showColorPicker, setShowColorPicker] = useState(false);
+  const root: HTMLElement = document.documentElement;
+
+  const handleChange = (mainColor: { hex: string }) => {
+    const selectedColor: string = mainColor.hex;
+    setMainColor(selectedColor);
+  };
+
+  const handleReset = () => {
+    setMainColor(defaultColor);
+    root.style.setProperty("--main-color", defaultColor);
+    root.style.setProperty("--lightpurple-color", "#b18cff");
+    localStorage.setItem("mainColor", defaultColor);
+  };
+
+  const handleSave = () => {
+    localStorage.setItem("mainColor", mainColor);
+    root.style.setProperty("--main-color", mainColor);
+    toggleColorPicker(true);
+  };
+
+  const handleCancel = () => {
+    const savedColor = localStorage.getItem("mainColor");
+    root.style.setProperty("--main-color", savedColor);
+    toggleColorPicker(true);
+  };
+
+  const toggleColorPicker = (isChange: boolean) => {
+    if (isChange) setShowColorPicker(!showColorPicker);
+  };
+
+  const confirmBeforeUnload = (e: BeforeUnloadEvent) => {
+    if (mainColor !== localStorage.getItem("mainColor")) {
+      e.returnValue =
+        "변경된 색상이 저장되지 않을 수 있습니다. 계속하시겠습니까?";
+    }
+  };
+
+  useEffect(() => {
+    root.style.setProperty("--main-color", mainColor);
+    window.addEventListener("beforeunload", confirmBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", confirmBeforeUnload);
+    };
+  }, [mainColor]);
+
+  return (
+    <ThemeColorCard
+      showColorPicker={showColorPicker}
+      setShowColorPicker={setShowColorPicker}
+      handleChange={handleChange}
+      handleReset={handleReset}
+      handleSave={handleSave}
+      handleCancel={handleCancel}
+      mainColor={mainColor}
+    />
+  );
+};
+
+export default ThemeColorCardContainer;

--- a/frontend/src/components/Card/ThemeColorCard/ThemeColorCard.tsx
+++ b/frontend/src/components/Card/ThemeColorCard/ThemeColorCard.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { TwitterPicker } from "react-color";
+import styled from "styled-components";
+import Card from "@/components/Card/Card";
+import {
+  CardContentStyled,
+  CardContentWrapper,
+  ContentInfoStyled,
+} from "@/components/Card/CardStyles";
+
+interface ThemeColorProps {
+  showColorPicker: boolean;
+  setShowColorPicker: React.Dispatch<React.SetStateAction<boolean>>;
+  handleChange: (mainColor: { hex: string }) => void;
+  handleReset: () => void;
+  handleSave: () => void;
+  handleCancel: () => void;
+  mainColor: string;
+}
+
+const ThemeColorCard = ({
+  showColorPicker,
+  setShowColorPicker,
+  handleChange,
+  handleReset,
+  handleSave,
+  handleCancel,
+  mainColor,
+}: ThemeColorProps) => {
+  return (
+    <>
+      {showColorPicker && <BackgroundOverlayStyled />}
+      <ThemeColorCardWrapper>
+        <Card
+          title={"테마 컬러"}
+          gridArea={"theme"}
+          width={"350px"}
+          height={"215px"}
+          buttons={
+            showColorPicker
+              ? [
+                  {
+                    label: "저장",
+                    onClick: handleSave,
+                    color: "var(--white)",
+                    backgroundColor: "var(--main-color)",
+                    isClickable: true,
+                  },
+                  {
+                    label: "취소",
+                    onClick: handleCancel,
+                    isClickable: true,
+                  },
+                ]
+              : [
+                  {
+                    label: "초기화",
+                    onClick: handleReset,
+                    isClickable: true,
+                  },
+                ]
+          }
+        >
+          <CardContentWrapper>
+            <CardContentStyled>
+              <ContentInfoStyled>메인 컬러</ContentInfoStyled>
+              <MainColorButtonStyled
+                onClick={() => setShowColorPicker(!showColorPicker)}
+              />
+            </CardContentStyled>
+            {showColorPicker && (
+              <TwitterPicker
+                color={mainColor}
+                onChangeComplete={handleChange}
+              />
+            )}
+          </CardContentWrapper>
+        </Card>
+      </ThemeColorCardWrapper>
+    </>
+  );
+};
+
+const BackgroundOverlayStyled = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 0;
+`;
+
+const ThemeColorCardWrapper = styled.div`
+  z-index: 1;
+`;
+
+const MainColorButtonStyled = styled.button`
+  width: 28px;
+  height: 28px;
+  background-color: var(--main-color);
+  margin: 0 10px 5px 0;
+  border-radius: 8px;
+`;
+
+export default ThemeColorCard;

--- a/frontend/src/components/Common/ToggleSwitch.tsx
+++ b/frontend/src/components/Common/ToggleSwitch.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from "react";
+import styled, { css } from "styled-components";
+
+interface ToggleSwitchInterface {
+  id: string;
+  onChange?: (checked: boolean) => void;
+  checked: boolean;
+  disabled?: boolean;
+}
+
+const ToggleSwitch = ({
+  id,
+  onChange,
+  checked = false,
+  disabled,
+}: ToggleSwitchInterface) => {
+  const [isChecked, setIsChecked] = useState(checked);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newState = event.target.checked;
+    setIsChecked(newState);
+    if (onChange) {
+      onChange(newState);
+    }
+  };
+
+  return (
+    <ToggleSwitchContainerStyled disabled={disabled}>
+      <InputStyled
+        type="checkbox"
+        id={id}
+        checked={isChecked}
+        onChange={handleChange}
+        disabled={disabled}
+      />
+      <ToggleSwitchStyled htmlFor={id} checked={isChecked} disabled={disabled}>
+        <ToggleKnobStyled checked={isChecked} />
+      </ToggleSwitchStyled>
+    </ToggleSwitchContainerStyled>
+  );
+};
+
+const ToggleSwitchContainerStyled = styled.div<{ disabled?: boolean }>`
+  display: inline-block;
+  position: relative;
+  margin-right: 10px;
+  opacity: ${(props) => (props.disabled ? 0.5 : 1)};
+`;
+
+const InputStyled = styled.input.attrs({ type: "checkbox" })`
+  opacity: 0;
+  position: absolute;
+  width: 0;
+  height: 0;
+`;
+
+const ToggleSwitchStyled = styled.label<{
+  checked: boolean;
+  disabled?: boolean;
+}>`
+  cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+  display: inline-block;
+  position: relative;
+  background: ${(props) =>
+    props.checked ? "var(--main-color)" : "var(--lightgary-color)"};
+  width: 56px;
+  height: 28px;
+  border-radius: 50px;
+  transition: background-color 0.2s ease;
+  &:after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 24px;
+    height: 24px;
+    transition: 0.2s;
+    transform: ${(props) =>
+      props.checked ? "translateX(28px)" : "translateX(0)"};
+  }
+`;
+
+const ToggleKnobStyled = styled.span<{ checked: boolean }>`
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--white);
+  transition: transform 0.2s;
+  transform: ${(props) =>
+    props.checked ? "translateX(28px)" : "translateX(0)"};
+`;
+
+export default ToggleSwitch;

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -194,7 +194,7 @@ const BottomBtnsStyled = styled.ul`
   text-align: center;
 `;
 
-const BottomBtnStyled = styled.li`
+const BottomBtnStyled = styled.li<{ src: string }>`
   width: 100%;
   min-height: 48px;
   line-height: 1.125rem;
@@ -217,6 +217,7 @@ const BottomBtnStyled = styled.li`
     height: 24px;
     margin: 0 auto;
     margin-bottom: 4px;
+    background-image: url(${(props) => props.src});
   }
   &.active {
     color: var(--main-color);

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -72,53 +72,58 @@ const LeftMainNav = ({
                     ? "active cabiButton"
                     : " cabiButton"
                 }
+                src={"/src/assets/images/search.svg"}
                 onClick={onClickSearchButton}
               >
-                <SearchImg stroke="var(--gray-color)" />
+                <div></div>
                 Search
               </BottomBtnStyled>
-              <BottomBtnStyled className="cabiButton">
+              <BottomBtnStyled
+                src={"/src/assets/images/slack.svg"}
+                className="cabiButton"
+              >
                 <a
                   href="https://42born2code.slack.com/archives/C02V6GE8LD7"
                   target="_blank"
                   title="슬랙 캐비닛 채널 새창으로 열기"
                 >
-                  <SlackImg stroke="var(--gray-color)" />
+                  <div></div>
                   Contact
                 </a>
               </BottomBtnStyled>
               <BottomBtnStyled
-                className={
-                  pathname.includes("club")
-                    ? "active cabiButton"
-                    : " cabiButton"
-                }
+                src={"/src/assets/images/clubIconGray.svg"}
+                className="cabiButton"
                 onClick={onClickClubButton}
               >
-                <CulbImg stroke="var(--gray-color)" />
+                <div></div>
                 Club
               </BottomBtnStyled>
               <BottomBtnStyled
                 className="cabiButton"
                 onClick={onClickLogoutButton}
+                src={"/src/assets/images/close-square.svg"}
               >
-                <LogoutImg stroke="var(--gray-color)" />
+                <div></div>
                 Logout
               </BottomBtnStyled>
             </>
           )}
           {!isAdmin && (
-            <BottomBtnStyled
-              className={
-                pathname.includes("profile")
-                  ? "active cabiButton"
-                  : " cabiButton"
-              }
-              onClick={onClickProfileButton}
-            >
-              <ProfileImg stroke="var(--gray-color)" />
-              Profile
-            </BottomBtnStyled>
+            <>
+              <BottomBtnStyled
+                className={
+                  pathname.includes("profile")
+                    ? "active cabiButton"
+                    : " cabiButton"
+                }
+                src={"/src/assets/images/profile-circle.svg"}
+                onClick={onClickProfileButton}
+              >
+                <div></div>
+                Profile
+              </BottomBtnStyled>
+            </>
           )}
         </BottomBtnsStyled>
       </BottomSectionStyled>

--- a/frontend/src/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
+++ b/frontend/src/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
@@ -73,14 +73,14 @@ const LeftSectionNav = ({
           title="슬랙 캐비닛 채널 새창으로 열기"
         >
           문의하기
-          <LinkImg stroke="var(--gray-color)" />
+          <img src="/src/assets/images/link.svg" alt="" />
         </SectionLinkStyled>
         <SectionLinkStyled
           onClick={() => onClickClubForm()}
           title="동아리 사물함 사용 신청서 새창으로 열기"
         >
           동아리 신청서
-          <LinkImg stroke="var(--gray-color)" />
+          <img src="/src/assets/images/link.svg" alt="" />
         </SectionLinkStyled>
       </ProfileLeftNavOptionStyled>
     </>
@@ -147,7 +147,7 @@ const SectionLinkStyled = styled.div`
   display: flex;
   align-items: center;
   color: var(--gray-color);
-  & svg {
+  & img {
     width: 15px;
     height: 15px;
     margin-left: auto;
@@ -155,9 +155,10 @@ const SectionLinkStyled = styled.div`
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       color: var(--main-color);
-      svg {
-        stroke: var(--main-color);
-      }
+    }
+    &:hover img {
+      filter: invert(33%) sepia(55%) saturate(3554%) hue-rotate(230deg)
+        brightness(99%) contrast(107%);
     }
   }
 `;

--- a/frontend/src/components/Modals/ExtendModal/ExtendModal.tsx
+++ b/frontend/src/components/Modals/ExtendModal/ExtendModal.tsx
@@ -51,7 +51,8 @@ const ExtendModal: React.FC<{
   연장권을 사용하시겠습니까?`;
   const extendInfoDetail = `사물함을 대여하시면 연장권 사용이 가능합니다.
 연장권은 <strong>${getLastDayofMonthString(
-    null
+    null,
+    "/"
   )} 23:59</strong> 이후 만료됩니다.`;
   const getModalTitle = (cabinetId: number | null) => {
     return cabinetId === null

--- a/frontend/src/components/Modals/OverduePenaltyModal/OverduePenaltyModal.tsx
+++ b/frontend/src/components/Modals/OverduePenaltyModal/OverduePenaltyModal.tsx
@@ -5,7 +5,7 @@ import ModalPortal from "@/components/Modals/ModalPortal";
 import { additionalModalType, modalPropsMap } from "@/assets/data/maps";
 import errorIcon from "@/assets/images/errorIcon.svg";
 import CabinetStatus from "@/types/enum/cabinet.status.enum";
-import { getFormatDate } from "@/utils/dateUtils";
+import { formatDate } from "@/utils/dateUtils";
 
 const OverduePenaltyModal: React.FC<{
   status: CabinetStatus | additionalModalType;
@@ -14,8 +14,9 @@ const OverduePenaltyModal: React.FC<{
 }> = (props) => {
   const unbannedAtDate = props.unbannedAt ? new Date(props.unbannedAt) : null;
 
-  const penaltyDateDetail = `패널티 기간은 <strong> ${getFormatDate(
-    unbannedAtDate
+  const penaltyDateDetail = `패널티 기간은 <strong> ${formatDate(
+    unbannedAtDate,
+    "/"
   )} 23:59</strong> 까지 입니다.
     해당 기간까지 대여를 하실 수 없습니다.`;
   const localStorageKey = "hideOverdueModalForOneDay";

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/api/axios/axios.custom";
 import useMenu from "@/hooks/useMenu";
 
-export const getDefaultCabinetInfo = (myInfo: UserDto): CabinetInfo => ({
+export const getDefaultCabinetInfo = () => ({
   building: "",
   floor: 0,
   cabinetId: 0,
@@ -44,7 +44,7 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
   const [myCabinetInfo, setMyCabinetInfo] = useRecoilState(myCabinetInfoState);
   const { pathname } = useLocation();
   const navigator = useNavigate();
-  const defaultCabinetInfo = getDefaultCabinetInfo(myInfo);
+  const defaultCabinetInfo = getDefaultCabinetInfo();
   const resetCabinetInfo = () => {
     setMyCabinetInfo({
       ...defaultCabinetInfo,

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/api/axios/axios.custom";
 import useMenu from "@/hooks/useMenu";
 
-const getDefaultCabinetInfo = (myInfo: UserDto): CabinetInfo => ({
+export const getDefaultCabinetInfo = (myInfo: UserDto): CabinetInfo => ({
   building: "",
   floor: 0,
   cabinetId: 0,

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -27,7 +27,7 @@ export const getDefaultCabinetInfo = () => ({
   lentType: CabinetType.PRIVATE,
   title: null,
   maxUser: 0,
-  status: CabinetStatus.AVAILABLE,
+  status: CabinetStatus.PENDING,
   section: "",
   lents: [] as LentDto[],
   statusNote: "",

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -29,15 +29,7 @@ export const getDefaultCabinetInfo = (myInfo: UserDto): CabinetInfo => ({
   maxUser: 0,
   status: CabinetStatus.AVAILABLE,
   section: "",
-  lents: [
-    {
-      userId: myInfo.userId,
-      name: myInfo.name,
-      lentHistoryId: 0,
-      startedAt: new Date(),
-      expiredAt: new Date(),
-    },
-  ] as LentDto[],
+  lents: [] as LentDto[],
   statusNote: "",
 });
 const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -16,7 +16,7 @@ const ProfilePage = () => {
   useEffect(() => {
     setIsLoading(true);
     setIsLoading(false);
-  }, []);
+  }, [myInfo]);
 
   return (
     <>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,31 +1,20 @@
 import { useEffect, useState } from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
-import { myCabinetInfoState, userState } from "@/recoil/atoms";
+import { userState } from "@/recoil/atoms";
 import ExtensionCardContainer from "@/components/Card/ExtensionCard/ExtensionCard.container";
 import LentInfoCardContainer from "@/components/Card/LentInfoCard/LentInfoCard.container";
 import NotificationCardContainer from "@/components/Card/NotificationCard/NotificationCard.container";
 import ProfileCardContainer from "@/components/Card/ProfileCard/ProfileCard.container";
 import ThemeColorCardContainer from "@/components/Card/ThemeColorCard/ThemeColorCard.container";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
-import { getDefaultCabinetInfo } from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 
 const ProfilePage = () => {
   const [isLoading, setIsLoading] = useState(true);
-  const [myCabinetInfo, setMyCabinetInfo] = useRecoilState(myCabinetInfoState);
   const myInfo = useRecoilValue(userState);
-  const defaultCabinetInfo = getDefaultCabinetInfo();
 
   useEffect(() => {
     setIsLoading(true);
-    if (!myCabinetInfo) {
-      setMyCabinetInfo({
-        ...defaultCabinetInfo,
-        memo: "",
-        shareCode: 0,
-        previousUserName: "",
-      });
-    }
     setIsLoading(false);
   }, []);
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,44 +1,75 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
-import ThemeColorContainer from "@/components/Profile/ThemeColor.container";
+import { myCabinetInfoState, userState } from "@/recoil/atoms";
+import ExtensionCardContainer from "@/components/Card/ExtensionCard/ExtensionCard.container";
+import LentInfoCardContainer from "@/components/Card/LentInfoCard/LentInfoCard.container";
+import NotificationCardContainer from "@/components/Card/NotificationCard/NotificationCard.container";
+import ProfileCardContainer from "@/components/Card/ProfileCard/ProfileCard.container";
+import ThemeColorCardContainer from "@/components/Card/ThemeColorCard/ThemeColorCard.container";
+import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import { getDefaultCabinetInfo } from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 
 const ProfilePage = () => {
-  const [showThemeChange, setShowThemeChange] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [myCabinetInfo, setMyCabinetInfo] = useRecoilState(myCabinetInfoState);
+  const myInfo = useRecoilValue(userState);
+  const defaultCabinetInfo = getDefaultCabinetInfo(myInfo);
+
+  useEffect(() => {
+    setIsLoading(true);
+    if (!myCabinetInfo) {
+      setMyCabinetInfo({
+        ...defaultCabinetInfo,
+        memo: "",
+        shareCode: 0,
+        previousUserName: "",
+      });
+    }
+    setIsLoading(false);
+  }, []);
+
   return (
-    <WrapperStyled>
-      {showThemeChange && <BackgroundOverlayStyled />}
-      <ItemStyeld>
-        <ThemeColorContainer
-          showColorPicker={showThemeChange}
-          setShowColorPicker={setShowThemeChange}
-        />
-      </ItemStyeld>
-    </WrapperStyled>
+    <>
+      {isLoading ? (
+        <LoadingAnimation />
+      ) : (
+        <CardGridWrapper>
+          <ProfileCardContainer name={myInfo.name} />
+          <ExtensionCardContainer extensible={myInfo.extensible} />
+          <LentInfoCardContainer />
+          <ThemeColorCardContainer />
+          <NotificationCardContainer />
+        </CardGridWrapper>
+      )}
+    </>
   );
 };
 
-const WrapperStyled = styled.div`
-  display: flex;
-  flex-direction: column;
+const CardGridWrapper = styled.div`
+  display: grid;
+  padding: 60px 0;
   justify-content: center;
   align-items: center;
-  padding: 70px 0;
-  @media screen and (max-width: 768px) {
-    padding: 40px 20px;
+  width: 100%;
+  grid-gap: 20px;
+  grid-template-columns: 350px 350px;
+  grid-template-rows: 163px 183px 215px;
+  grid-template-areas:
+    "profile lentInfo"
+    "extension lentInfo"
+    "theme notification";
+
+  @media (max-width: 768px) {
+    grid-template-columns: 350px;
+    grid-template-rows: 163px 366px 183px 215px 215px;
+    grid-template-areas:
+      "profile"
+      "lentInfo"
+      "extension"
+      "theme"
+      "notification";
   }
 `;
 
-const BackgroundOverlayStyled = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 0;
-`;
-
-const ItemStyeld = styled.div`
-  z-index: 1;
-`;
 export default ProfilePage;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -44,10 +44,9 @@ const CardGridWrapper = styled.div`
   grid-gap: 20px;
   grid-template-columns: 350px 350px;
   grid-template-rows: 163px 183px 215px;
-  grid-template-areas:
-    "profile lentInfo"
-    "extension lentInfo"
-    "theme notification";
+  grid-template-areas: "profile lentInfo" // h: 163px h: 366px
+    "extension lentInfo" // h: 183px
+    "theme notification"; // h: 215px h: 215px
 
   @media (max-width: 768px) {
     grid-template-columns: 350px;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -14,7 +14,7 @@ const ProfilePage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [myCabinetInfo, setMyCabinetInfo] = useRecoilState(myCabinetInfoState);
   const myInfo = useRecoilValue(userState);
-  const defaultCabinetInfo = getDefaultCabinetInfo(myInfo);
+  const defaultCabinetInfo = getDefaultCabinetInfo();
 
   useEffect(() => {
     setIsLoading(true);

--- a/frontend/src/pages/admin/SearchPage.tsx
+++ b/frontend/src/pages/admin/SearchPage.tsx
@@ -61,7 +61,7 @@ const SearchPage = () => {
       searchValue.current,
       currentPage.current
     );
-    
+
     setSearchListByIntraId(searchResult.data.result ?? []);
     setTotalSearchList(Math.ceil(searchResult.data.totalLength / 10) ?? 0);
     setTimeout(() => {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -2,7 +2,8 @@ export const padTo2Digits = (num: number) => {
   return num.toString().padStart(2, "0");
 };
 
-export const formatDate = (date: Date, divider: string) => {
+export const formatDate = (date: Date | null, divider: string) => {
+  if (date === null) return "";
   return [
     date.getFullYear(),
     padTo2Digits(date.getMonth() + 1),
@@ -22,7 +23,8 @@ export const getExpireDateString = (
 
   if (!existExpireDate)
     expireDate.setDate(expireDate.getDate() + parseInt(addDays));
-  return formatDate(expireDate, "/");
+    return formatDate(expireDate, "/");
+  }
 };
 
 // 공유 사물함 반납 시 남은 대여일 수 차감 (원래 남은 대여일 수 * (남은 인원 / 원래 있던 인원))
@@ -66,10 +68,19 @@ export const getTotalPage = (totalLength: number, size: number) => {
   return Math.ceil(totalLength / size);
 };
 
-export const getFormatDate = (date: Date | null): string => {
-  if (!date) return "";
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, "0");
-  const day = date.getDate().toString().padStart(2, "0");
-  return `${year}/${month}/${day}`;
+export const calExpiredTime = (expireTime: Date) =>
+  Math.floor(
+    (expireTime.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+export const getRemainingTime = (expireTime: Date | undefined) => {
+  if (!expireTime) return 0;
+  const remainTime = calExpiredTime(new Date(expireTime));
+  return remainTime < 0 ? -remainTime : remainTime;
+};
+
+export const getExpireDate = (date: Date | undefined) => {
+  if (!date) return null;
+  if (date.toString().slice(0, 4) === "9999") return null;
+  return date.toString().slice(0, 10);
 };

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -23,8 +23,7 @@ export const getExpireDateString = (
 
   if (!existExpireDate)
     expireDate.setDate(expireDate.getDate() + parseInt(addDays));
-    return formatDate(expireDate, "/");
-  }
+  return formatDate(expireDate, "/");
 };
 
 // 공유 사물함 반납 시 남은 대여일 수 차감 (원래 남은 대여일 수 * (남은 인원 / 원래 있던 인원))
@@ -56,12 +55,6 @@ export const getLastDayofMonthString = (date: Date | null, divider: string) => {
   if (date === null) date = new Date();
   let lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
   return formatDate(lastDay, divider);
-};
-
-export const getLastDayofMonthString = (date: Date | null) => {
-  if (date === null) date = new Date();
-  let lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-  return formatDate(lastDay);
 };
 
 export const getTotalPage = (totalLength: number, size: number) => {

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -2,12 +2,12 @@ export const padTo2Digits = (num: number) => {
   return num.toString().padStart(2, "0");
 };
 
-export const formatDate = (date: Date) => {
+export const formatDate = (date: Date, divider: string) => {
   return [
     date.getFullYear(),
     padTo2Digits(date.getMonth() + 1),
     padTo2Digits(date.getDate()),
-  ].join("/");
+  ].join(divider);
 };
 
 export const getExpireDateString = (
@@ -22,7 +22,7 @@ export const getExpireDateString = (
 
   if (!existExpireDate)
     expireDate.setDate(expireDate.getDate() + parseInt(addDays));
-  return formatDate(expireDate);
+  return formatDate(expireDate, "/");
 };
 
 // 공유 사물함 반납 시 남은 대여일 수 차감 (원래 남은 대여일 수 * (남은 인원 / 원래 있던 인원))
@@ -39,7 +39,7 @@ export const getShortenedExpireDateString = (
   let dateRemainig =
     (daysUntilExpire * (currentNumUsers - 1)) / currentNumUsers;
   let newExpireDate = new Date().getTime() + dateRemainig * dayInMilisec;
-  return formatDate(new Date(newExpireDate));
+  return formatDate(new Date(newExpireDate), "/");
 };
 
 export const getExtendedDateString = (existExpireDate?: Date) => {
@@ -47,7 +47,13 @@ export const getExtendedDateString = (existExpireDate?: Date) => {
   expireDate.setDate(
     expireDate.getDate() + parseInt(import.meta.env.VITE_EXTENDED_LENT_PERIOD)
   );
-  return formatDate(expireDate);
+  return formatDate(expireDate, "/");
+};
+
+export const getLastDayofMonthString = (date: Date | null, divider: string) => {
+  if (date === null) date = new Date();
+  let lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+  return formatDate(lastDay, divider);
 };
 
 export const getLastDayofMonthString = (date: Date | null) => {


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 프로필 페이지 (사물함 대여 중이 아닐 때, 대여 중일 때)
![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/52136b73-0049-41d4-85ae-a988cc9c0f4f)
![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/0f047ece-3861-45db-ad05-0ba84fb4a365)

### 프로필 모바일 뷰 (프로필, 대여정보, 연장권, 테마, 알림 순)
![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/d1d7949c-3c61-44a6-8359-2a025a40a659)
![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/a00db72f-7b1f-4d65-9234-d91b9d763181)

- 프로필 페이지 추가
  - 정보를 표시할 Card 컴포넌트를 만든 후 이를 기반으로 ProfileCard, ExtensionCard, LentInfoCard, ThemeColorCard, NotificationCard 를 만들어 ProfilePage 간소화
  - 알림 (NotificationCard) 외 다용도로 쓰일 수 있는 ToggleSwitch 컴포넌트 추가
- 서브모듈 FE 에 연장권 기한 업데이트

https://github.com/innovationacademy-kr/42cabi/issues/1410
