### PR TITLE
[FE] FIX: 공유 사물함 랜더링 추가문제 해결

### DIFF
--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -97,10 +97,10 @@ const CabinetListItem = (props: CabinetPreviewInfo): JSX.Element => {
         setTargetCabinetInfo(selectCabinetData);
 
         if (myCabinetInfo.cabinetId === cabinetId) {
-          const isUserIdMatching = selectCabinetData.lents.some(
+          const isLentedByMyUserId = selectCabinetData.lents.some(
             (user: { userId: number }) => user.userId === myInfo.userId
           );
-          if (status !== selectCabinetData.status || !isUserIdMatching) {
+          if (status !== selectCabinetData.status || !isLentedByMyUserId) {
             const { data: myCabinetData } = await axiosMyLentInfo();
             setMyLentInfo(myCabinetData);
           }

--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -8,6 +8,7 @@ import {
   currentFloorNumberState,
   myCabinetInfoState,
   targetCabinetInfoState,
+  userState,
 } from "@/recoil/atoms";
 import UnavailableModal from "@/components/Modals/UnavailableModal/UnavailableModal";
 import {
@@ -81,6 +82,7 @@ const CabinetListItem = (props: CabinetPreviewInfo): JSX.Element => {
   const currentBuilding = useRecoilValue<string>(currentBuildingNameState);
   const currentFloor = useRecoilValue<number>(currentFloorNumberState);
   const setCurrentFloorData = useSetRecoilState(currentFloorCabinetState);
+  const myInfo = useRecoilValue(userState);
 
   const selectCabinetOnClick = (status: CabinetStatus, cabinetId: number) => {
     if (currentCabinetId === cabinetId) {
@@ -93,17 +95,21 @@ const CabinetListItem = (props: CabinetPreviewInfo): JSX.Element => {
       try {
         const { data: selectCabinetData } = await axiosCabinetById(cabinetId);
         setTargetCabinetInfo(selectCabinetData);
-        if (status !== selectCabinetData.status) {
-          if (myCabinetInfo.cabinetId === cabinetId) {
+
+        if (myCabinetInfo.cabinetId === cabinetId) {
+          const isUserIdMatching = selectCabinetData.lents.some(
+            (user: { userId: number }) => user.userId === myInfo.userId
+          );
+          if (status !== selectCabinetData.status || !isUserIdMatching) {
             const { data: myCabinetData } = await axiosMyLentInfo();
             setMyLentInfo(myCabinetData);
-          } else {
-            const { data: floorData } = await axiosCabinetByBuildingFloor(
-              currentBuilding,
-              currentFloor
-            );
-            setCurrentFloorData(floorData);
           }
+        } else if (status !== selectCabinetData.status) {
+          const { data: floorData } = await axiosCabinetByBuildingFloor(
+            currentBuilding,
+            currentFloor
+          );
+          setCurrentFloorData(floorData);
         }
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1425
- 내 사물함의 세션이 만료되어서 다른 사람이 들어가서 새로운 세션이 생겼을 때, 사물함 상태의 변화는 없기에 데이터가 업데이트 되지 않는 문제를 lent정보에서 userid를 순회하며 내가 있지 않으면 내 사물함 데이터를 업데이트 하도록 추가하였습니다.
