### PR TITLE
[FE] FEAT: PendingPage 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from "@/pages/Layout";
 import LogPage from "@/pages/LogPage";
 import LoginPage from "@/pages/LoginPage";
 import MainPage from "@/pages/MainPage";
+import PendingPage from "@/pages/PendingPage/PendingPage";
 import AdminMainPage from "@/pages/admin/AdminMainPage";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
 import ProfilePage from "./pages/ProfilePage";
@@ -31,6 +32,7 @@ function App(): React.ReactElement {
             <Route path="main" element={<MainPage />} />
             <Route path="profile/log" element={<LogPage />} />
             <Route path="profile" element={<ProfilePage />} />
+            <Route path="pending" element={<PendingPage />} />
           </Route>
           {/* admin용 라우터 */}
           <Route path="/admin/" element={<AdminLayout />}>
@@ -39,6 +41,7 @@ function App(): React.ReactElement {
             <Route path="main" element={<AdminMainPage />} />
             <Route path="search" element={<SearchPage />} />
             <Route path="club" element={<AdminClubPage />} />
+            <Route path="pending" element={<PendingPage />} />
           </Route>
           <Route path="/login/failure" element={<LoginFailurePage />} />
           <Route

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -489,9 +489,7 @@ const axiosGetPendingCabinetsURL = "/v4/cabinets/pending";
 export const axiosGetPendingCabinets = async (): Promise<any> => {
   try {
     const response = await instance.get(axiosGetPendingCabinetsURL);
-
-    // console.log(response.data.cabinetInfoResponseDtos);
-    return response.data.cabinetInfoResponseDtos;
+    return response;
   } catch (error) {
     throw error;
   }

--- a/frontend/src/api/axios/axios.custom.ts
+++ b/frontend/src/api/axios/axios.custom.ts
@@ -484,3 +484,15 @@ export const axiosCancel = async (cabinetId: number | null): Promise<any> => {
     throw error;
   }
 };
+
+const axiosGetPendingCabinetsURL = "/v4/cabinets/pending";
+export const axiosGetPendingCabinets = async (): Promise<any> => {
+  try {
+    const response = await instance.get(axiosGetPendingCabinetsURL);
+
+    // console.log(response.data.cabinetInfoResponseDtos);
+    return response.data.cabinetInfoResponseDtos;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/frontend/src/assets/images/alarm.svg
+++ b/frontend/src/assets/images/alarm.svg
@@ -1,0 +1,23 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M5.45887 2L1 6.01478L2.33826 7.50107L6.79713 3.48629L5.45887 2Z"
+    fill="currentColor"
+  />
+  <path d="M11 8H13V12H16V14H11V8Z" fill="currentColor" />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12ZM5 12C5 8.13401 8.13401 5 12 5C15.866 5 19 8.13401 19 12C19 15.866 15.866 19 12 19C8.13401 19 5 15.866 5 12Z"
+    fill="currentColor"
+  />
+  <path
+    d="M18.5411 2L23 6.01478L21.6617 7.50107L17.2029 3.48629L18.5411 2Z"
+    fill="currentColor"
+  />
+</svg>

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.container.tsx
@@ -124,6 +124,11 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
     closeAll();
   };
 
+  const onClickPendingButton = () => {
+    navigator("pending");
+    closeAll();
+  };
+
   const onClickLogoutButton = (): void => {
     const adminToken = isAdmin ? "admin_" : "";
     if (import.meta.env.VITE_IS_LOCAL === "true") {
@@ -154,6 +159,7 @@ const LeftMainNavContainer = ({ isAdmin }: { isAdmin?: boolean }) => {
       onClickLogoutButton={onClickLogoutButton}
       onClickClubButton={onClickClubButton}
       onClickProfileButton={onClickProfileButton}
+      onClickPendingButton={onClickPendingButton}
       isAdmin={isAdmin}
     />
   );

--- a/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -16,6 +16,7 @@ interface ILeftMainNav {
   onClickSearchButton: React.MouseEventHandler;
   onClickClubButton: React.MouseEventHandler;
   onClickProfileButton: React.MouseEventHandler;
+  onClickPendingButton: React.MouseEventHandler;
   isAdmin?: boolean;
 }
 
@@ -30,6 +31,7 @@ const LeftMainNav = ({
   onClickSearchButton,
   onClickClubButton,
   onClickProfileButton,
+  onClickPendingButton,
   isAdmin,
 }: ILeftMainNav) => {
   return (
@@ -60,6 +62,16 @@ const LeftMainNav = ({
                 {floor + "층"}
               </TopBtnStyled>
             ))}
+          <TopBtnStyled
+            className={
+              pathname.includes("pending")
+                ? "leftNavButtonActive cabiButton"
+                : "cabiButton"
+            }
+            onClick={onClickPendingButton}
+          >
+            오픈예정
+          </TopBtnStyled>
         </TopBtnsStyled>
       </TopSectionStyled>
       <BottomSectionStyled>

--- a/frontend/src/pages/PendingPage/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage/PendingPage.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
-import { set } from "react-ga";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { isCurrentSectionRenderState } from "@/recoil/atoms";
+import FloorContainer from "@/pages/PendingPage/components/FloorContainer";
+import Timer from "@/pages/PendingPage/components/Timer";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
 import { CabinetPreviewInfo } from "@/types/dto/cabinet.dto";
 import { axiosGetPendingCabinets } from "@/api/axios/axios.custom";
-import FloorContainer from "./components/FloorContainer";
-import Timer from "./components/Timer";
 
 const PendingPage = () => {
   const [pendingCabinets, setPendingCabinets] = useState<

--- a/frontend/src/pages/PendingPage/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage/PendingPage.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
+import { isCurrentSectionRenderState } from "@/recoil/atoms";
+import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import { CabinetPreviewInfo } from "@/types/dto/cabinet.dto";
+import { axiosGetPendingCabinets } from "@/api/axios/axios.custom";
+import FloorContainer from "./components/FloorContainer";
+import Timer from "./components/Timer";
+
+const PendingPage = () => {
+  const [pendingCabinets, setPendingCabinets] = useState<
+    CabinetPreviewInfo[][]
+  >([[]]);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [isOpenTime, setIsOpenTime] = useState<boolean>(false);
+  const [isCurrentSectionRender] = useRecoilState(isCurrentSectionRenderState);
+
+  const getPendingCabinets = async () => {
+    try {
+      const response = await axiosGetPendingCabinets();
+      setPendingCabinets(response);
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  useEffect(() => {
+    setTimeout(() => {
+      // 새로고침 광클 방지를 위한 딜레이
+      setIsLoaded(true);
+    }, 500);
+  }, []);
+
+  useEffect(() => {
+    getPendingCabinets();
+  }, [isCurrentSectionRender]);
+
+  useEffect(() => {
+    if (isOpenTime) {
+      getPendingCabinets();
+    }
+  }, [isOpenTime]);
+
+  return (
+    <WrapperStyled>
+      <HeaderStyled>오픈 예정 사물함</HeaderStyled>
+      <SubHeaderStyled>
+        <span>매일 오후 1시</span> 일괄적으로 오픈됩니다.
+      </SubHeaderStyled>
+      <Timer observeOpenTime={() => setIsOpenTime(true)} />
+      {isLoaded && pendingCabinets ? (
+        Object.entries(pendingCabinets).map(([key, value]) => (
+          <FloorContainer
+            key={key}
+            floorNumber={key} // 2층부터 시작
+            pendingCabinetsList={value}
+          />
+        ))
+      ) : (
+        <LoadingAnimation />
+      )}
+      <FooterStyled>아래 여백을 주기 위한 태그입니다.</FooterStyled>
+    </WrapperStyled>
+  );
+};
+
+const WrapperStyled = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  overflow-y: scroll;
+`;
+
+const HeaderStyled = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+  margin-top: 50px;
+`;
+
+const SubHeaderStyled = styled.h2`
+  text-align: center;
+  font-size: 1.2rem;
+  color: var(--lightpurple-color);
+  margin-top: 25px;
+  line-height: 1.5;
+  word-break: keep-all;
+  margin: 25px 10px 0px 10px;
+  span {
+    font-weight: 700;
+    text-decoration: underline;
+  }
+`;
+
+const FooterStyled = styled.footer`
+  color: transparent;
+  margin-top: 50px;
+`;
+
+export default PendingPage;

--- a/frontend/src/pages/PendingPage/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage/PendingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { set } from "react-ga";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { isCurrentSectionRenderState } from "@/recoil/atoms";
@@ -19,7 +20,8 @@ const PendingPage = () => {
   const getPendingCabinets = async () => {
     try {
       const response = await axiosGetPendingCabinets();
-      setPendingCabinets(response);
+      const pendingCabinets = response.data.cabinetInfoResponseDtos;
+      setPendingCabinets(pendingCabinets);
     } catch (error) {
       throw error;
     }
@@ -33,10 +35,12 @@ const PendingPage = () => {
   }, []);
 
   useEffect(() => {
+    // CabinetInfoArea 컴포넌트에서 사물함 정보가 갱신되면 사물함 정보를 다시 가져온다.
     getPendingCabinets();
   }, [isCurrentSectionRender]);
 
   useEffect(() => {
+    // 오프 타임이 되면 업데이트 된 사물함 정보를 다시 가져온다.
     if (isOpenTime) {
       getPendingCabinets();
     }
@@ -46,7 +50,7 @@ const PendingPage = () => {
     <WrapperStyled>
       <HeaderStyled>오픈 예정 사물함</HeaderStyled>
       <SubHeaderStyled>
-        <span>매일 오후 1시</span> 일괄적으로 오픈됩니다.
+        <span>매일 오후 1시</span> 일괄적으로 오픈됩니다.{" "}
       </SubHeaderStyled>
       <Timer observeOpenTime={() => setIsOpenTime(true)} />
       {isLoaded && pendingCabinets ? (

--- a/frontend/src/pages/PendingPage/components/FloorContainer.tsx
+++ b/frontend/src/pages/PendingPage/components/FloorContainer.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+import AdminCabinetListItem from "@/components/CabinetList/CabinetListItem/AdminCabinetListItem";
+import CabinetListItem from "@/components/CabinetList/CabinetListItem/CabinetListItem";
+import { CabinetPreviewInfo } from "@/types/dto/cabinet.dto";
+
+// 하나의 층에 대한 타이틀과 캐비넷 리스트를 담고 있는 컴포넌트
+const FloorContainer = ({
+  pendingCabinetsList,
+  floorNumber,
+}: {
+  pendingCabinetsList: CabinetPreviewInfo[];
+  floorNumber: string;
+}) => {
+  const [isToggled, setIsToggled] = useState<boolean>(false);
+
+  const isAdmin = useLocation().pathname.includes("admin");
+
+  const toggle = () => {
+    setIsToggled(!isToggled);
+  };
+
+  return (
+    <FloorContainerStyled>
+      <FloorTitleStyled isToggled={isToggled}>
+        <div>{floorNumber}층</div>
+        <button onClick={toggle}></button>
+      </FloorTitleStyled>
+      {pendingCabinetsList.length !== 0 ? (
+        <FlootCabinetsContainerStyled isToggled={isToggled}>
+          {pendingCabinetsList.map((cabinet: CabinetPreviewInfo) =>
+            isAdmin ? (
+              <AdminCabinetListItem key={cabinet.cabinetId} {...cabinet} />
+            ) : (
+              <CabinetListItem key={cabinet.cabinetId} {...cabinet} />
+            )
+          )}
+        </FlootCabinetsContainerStyled>
+      ) : (
+        <NoPendingCabinetMessageStyled isToggled={isToggled}>
+          <p>해당 층에는 오픈 예정인 사물함이 없습니다 </p>
+          <img src="/src/assets/images/sadCcabi.png" alt="noPending" />
+        </NoPendingCabinetMessageStyled>
+      )}
+    </FloorContainerStyled>
+  );
+};
+
+const FloorContainerStyled = styled.div`
+  width: 70%;
+  margin-top: 50px;
+`;
+
+const FloorTitleStyled = styled.h2<{ isToggled: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.1rem;
+  color: var(--black);
+  padding-left: 5px;
+
+  border-bottom: 1.5px solid #d9d9d9;
+  div {
+  }
+  button {
+    z-index: 2;
+    height: 30px;
+    width: 10px;
+    background: url(/src/assets/images/select.svg) no-repeat 100%;
+    transform: ${(props) =>
+      props.isToggled ? "rotate(180deg)" : "rotate(0deg)"};
+    margin-right: 5px;
+  }
+`;
+
+const FlootCabinetsContainerStyled = styled.div<{ isToggled: boolean }>`
+  display: ${(props) => (props.isToggled ? "none" : "flex")};
+  transition: all 0.3s ease-in-out;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  margin-left: -5px;
+  & > div {
+    margin-top: 0px;
+    margin-right: 0px;
+  }
+`;
+
+const NoPendingCabinetMessageStyled = styled.div<{ isToggled: boolean }>`
+  display: ${(props) => (props.isToggled ? "none" : "flex")};
+  align-items: center;
+  margin-top: 20px;
+  margin-left: 5px;
+  p {
+    color: var(--gray-color);
+    line-height: 1.5;
+    word-break: keep-all;
+  }
+  img {
+    width: 30px;
+    aspect-ratio: 1 / 1;
+    margin-left: 8px;
+  }
+`;
+
+const LoadingContainerStyled = styled.div`
+  margin-top: 30px;
+`;
+
+export default FloorContainer;

--- a/frontend/src/pages/PendingPage/components/Timer.tsx
+++ b/frontend/src/pages/PendingPage/components/Timer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { serverTimeState } from "@/recoil/atoms";

--- a/frontend/src/pages/PendingPage/components/Timer.tsx
+++ b/frontend/src/pages/PendingPage/components/Timer.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const openTime = "오후 1:00:00";
+
+const Timer = ({ observeOpenTime }: { observeOpenTime: () => void }) => {
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCurrentTime(new Date());
+    }, 500);
+
+    if (currentTime.toLocaleTimeString() === openTime) observeOpenTime();
+
+    return () => clearInterval(intervalId);
+  }, [currentTime, observeOpenTime]); //
+
+  const formattedTime = currentTime.toLocaleTimeString().substring(2, 11);
+
+  return (
+    <>
+      <TimerIconStyled src="/src/assets/images/alarm.svg" />
+      <TimerStyled>{formattedTime}</TimerStyled>
+    </>
+  );
+};
+
+const TimerIconStyled = styled.img`
+  height: 25px;
+  width: 25px;
+  margin-top: 50px;
+`;
+
+const TimerStyled = styled.div`
+  margin-top: 5px;
+  color: var(--main-color);
+  font-size: 1.8rem;
+  font-weight: 600;
+`;
+
+export default Timer;

--- a/frontend/src/pages/PendingPage/components/Timer.tsx
+++ b/frontend/src/pages/PendingPage/components/Timer.tsx
@@ -1,22 +1,18 @@
 import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
+import { serverTimeState } from "@/recoil/atoms";
 
 const openTime = "오후 1:00:00";
 
 const Timer = ({ observeOpenTime }: { observeOpenTime: () => void }) => {
-  const [currentTime, setCurrentTime] = useState(new Date());
+  const [serverTime] = useRecoilState<Date>(serverTimeState);
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      setCurrentTime(new Date());
-    }, 500);
+    if (serverTime.toLocaleTimeString() === openTime) observeOpenTime();
+  }, [serverTime]); //
 
-    if (currentTime.toLocaleTimeString() === openTime) observeOpenTime();
-
-    return () => clearInterval(intervalId);
-  }, [currentTime, observeOpenTime]); //
-
-  const formattedTime = currentTime.toLocaleTimeString().substring(2, 11);
+  const formattedTime = serverTime.toLocaleTimeString().substring(2, 11);
 
   return (
     <>

--- a/frontend/src/recoil/atoms.ts
+++ b/frontend/src/recoil/atoms.ts
@@ -161,3 +161,8 @@ export const selectedClubInfoState = atom<ClubUserDto | null>({
   key: "selectedClub",
   default: null,
 });
+
+export const serverTimeState = atom<Date>({
+  key: "serverTime",
+  default: new Date(),
+});


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

<img width="1512" alt="스크린샷 2023-11-27 오전 10 18 47" src="https://github.com/innovationacademy-kr/42cabi/assets/101867295/f63962c3-2cd2-43ca-b683-9ac7870df792">

1. 오픈 예정 및 사용 가능한 사물함들을 층 별로 모아볼 수 있는 새로운 페이지를 생성하였습니다.
2. 오픈 예정 사물함은 오픈 시간(현재 오후 1:00:00)에 맞춰 사용 가능한 사물함으로 변경됩니다.
3. 타이머의 시간은 로그인 후 최초 접속 시 서버 시간을 받아옵니다(전역 상태로 관리).
4. 전역 상태로 관리되는 서버 시간은 Layout 컴포넌트에서 Interval로 지속적으로 현재 시간을 업데이트해 줍니다
    -> 추후 다른 컴포넌트에서 서버 시간 사용이 필요할 때 사용하시면 됩니다.

https://github.com/innovationacademy-kr/42cabi/issues/1414
