### PR TITLE
[FE] FIX: 연체 시 프로필 페이지에서 연체 기간을 표시하도록 수정 #1453

### DIFF
--- a/frontend/src/components/Card/CardStyles.ts
+++ b/frontend/src/components/Card/CardStyles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
 
 export const CardContentWrapper = styled.div`
   background-color: var(--white);
@@ -23,7 +24,11 @@ export const ContentInfoStyled = styled.div`
   margin: 0 0 0 10px;
 `;
 
-export const ContentDeatilStyled = styled.div`
+export const ContentDeatilStyled = styled.div<{
+  status?: CabinetStatus;
+}>`
+  color: ${(props) =>
+    props.status === CabinetStatus.OVERDUE ? "var(--expired)" : ""};
   display: flex;
   margin: 5px 10px 5px 10px;
   font-weight: bold;

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.container.tsx
@@ -4,6 +4,7 @@ import LentInfoCard from "@/components/Card/LentInfoCard/LentInfoCard";
 import { getDefaultCabinetInfo } from "@/components/TopNav/TopNavButtonGroup/TopNavButtonGroup";
 import { CabinetInfo } from "@/types/dto/cabinet.dto";
 import { LentDto } from "@/types/dto/lent.dto";
+import CabinetStatus from "@/types/enum/cabinet.status.enum";
 import CabinetType from "@/types/enum/cabinet.type.enum";
 import { getRemainingTime } from "@/utils/dateUtils";
 
@@ -21,7 +22,7 @@ export interface MyCabinetInfo {
   expireDate?: Date;
   isLented: boolean;
   previousUserName: string;
-  status: string;
+  status: CabinetStatus;
 }
 
 const findLentInfoByName = (lents: LentDto[], name: string) => {

--- a/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
+++ b/frontend/src/components/Card/LentInfoCard/LentInfoCard.tsx
@@ -85,8 +85,10 @@ const LentInfoCard = ({
             </ContentDeatilStyled>
           </CardContentStyled>
           <CardContentStyled>
-            <ContentInfoStyled>남은 기간</ContentInfoStyled>
-            <ContentDeatilStyled>
+            <ContentInfoStyled>
+              {cabinetInfo?.status === "OVERDUE" ? "연체 기간" : "남은 기간"}
+            </ContentInfoStyled>
+            <ContentDeatilStyled status={cabinetInfo.status as CabinetStatus}>
               {cabinetInfo?.expireDate ? `${cabinetInfo.dateLeft}일` : "-"}
             </ContentDeatilStyled>
           </CardContentStyled>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 연체 시 CabinetInfoArea 처럼 연체일을 표시하는 기능을 프로필 페이지에 추가

![image](https://github.com/innovationacademy-kr/42cabi/assets/14016311/ae352088-9f35-42a4-aa92-a6d4d699c2aa)

https://github.com/innovationacademy-kr/42cabi/issues/1453
