### PR TITLE
[BE] 연장권 삭제 로직 변경 및 변경에 따른 조회 로직 수정

### DIFF
--- a/backend/database/cabi_local.sql
+++ b/backend/database/cabi_local.sql
@@ -212,6 +212,7 @@ CREATE TABLE `lent_extension`
     `type`              varchar(32) not null,
     `expired_at`        datetime(6) not null,
     `used_at`           datetime(6) null,
+    `deleted_at`           datetime(6) null,
     PRIMARY KEY (lent_extension_id),
     CONSTRAINT lent_extension_user_user_id_fk
         FOREIGN KEY (user_id) REFERENCES user (user_id)

--- a/backend/src/main/java/org/ftclub/cabinet/dto/LentExtensionResponseDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/LentExtensionResponseDto.java
@@ -2,10 +2,12 @@ package org.ftclub.cabinet.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import org.ftclub.cabinet.user.domain.LentExtensionType;
 
 @Getter
 @AllArgsConstructor
+@ToString
 public class LentExtensionResponseDto {
 
 	private long lentExtensionId;

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
@@ -1,18 +1,5 @@
 package org.ftclub.cabinet.user.domain;
 
-import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +7,10 @@ import lombok.ToString;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.exception.DomainException;
 import org.ftclub.cabinet.exception.ExceptionStatus;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "LENT_EXTENSION")
@@ -29,60 +20,67 @@ import org.ftclub.cabinet.exception.ExceptionStatus;
 @Log4j2
 public class LentExtension {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "LENT_EXTENSION_ID")
-    private Long lentExtensionId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "LENT_EXTENSION_ID")
+	private Long lentExtensionId;
 
-    @Column(name = "name", nullable = false)
-    private String name;
-    @Column(name = "extension_period", nullable = false)
-    private int extensionPeriod;
-    @Column(name = "expired_at", nullable = false)
-    private LocalDateTime expiredAt;
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "type", nullable = false)
-    private LentExtensionType lentExtensionType;
-    @Column(name = "used_at")
-    private LocalDateTime usedAt;
+	@Column(name = "name", nullable = false)
+	private String name;
+	@Column(name = "extension_period", nullable = false)
+	private int extensionPeriod;
+	@Column(name = "expired_at", nullable = false)
+	private LocalDateTime expiredAt;
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "type", nullable = false)
+	private LentExtensionType lentExtensionType;
+	@Column(name = "used_at")
+	private LocalDateTime usedAt;
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
-    @JoinColumn(name = "USER_ID", insertable = false, updatable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+	@JoinColumn(name = "USER_ID", insertable = false, updatable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
 
-    @NotNull
-    @Column(name = "USER_ID", nullable = false)
-    private Long userId;
+	@NotNull
+	@Column(name = "USER_ID", nullable = false)
+	private Long userId;
 
-    protected LentExtension(String name, int extensionPeriod, LocalDateTime expiredAt,
-            LentExtensionType lentExtensionType, Long userId) {
-        this.name = name;
-        this.extensionPeriod = extensionPeriod;
-        this.expiredAt = expiredAt;
-        this.lentExtensionType = lentExtensionType;
-        this.userId = userId;
-    }
+	protected LentExtension(String name, int extensionPeriod, LocalDateTime expiredAt,
+	                        LentExtensionType lentExtensionType, Long userId) {
+		this.name = name;
+		this.extensionPeriod = extensionPeriod;
+		this.expiredAt = expiredAt;
+		this.lentExtensionType = lentExtensionType;
+		this.userId = userId;
+		this.deletedAt = null;
+	}
 
-    public static LentExtension of(String name, int extensionPeriod, LocalDateTime expiredAt,
-            LentExtensionType lentExtensionType, Long userId) {
-        LentExtension lentExtension = new LentExtension(name, extensionPeriod, expiredAt,
-                lentExtensionType, userId);
-        if (!lentExtension.isValid()) {
-            throw new DomainException(ExceptionStatus.INVALID_STATUS);
-        }
-        return lentExtension;
-    }
+	public static LentExtension of(String name, int extensionPeriod, LocalDateTime expiredAt,
+	                               LentExtensionType lentExtensionType, Long userId) {
+		LentExtension lentExtension = new LentExtension(name, extensionPeriod, expiredAt,
+				lentExtensionType, userId);
+		if (!lentExtension.isValid()) {
+			throw new DomainException(ExceptionStatus.INVALID_STATUS);
+		}
+		return lentExtension;
+	}
 
-    private boolean isValid() {
-        return name != null && extensionPeriod > 0 && expiredAt != null &&
-                lentExtensionType != null && userId != null;
-    }
+	private boolean isValid() {
+		return name != null && extensionPeriod > 0 && expiredAt != null &&
+				lentExtensionType != null && userId != null;
+	}
 
-    public void use() {
-        this.usedAt = LocalDateTime.now();
-    }
+	public void use() {
+		this.usedAt = LocalDateTime.now();
+	}
 
-    public int compareTo(LentExtension lentExtension) {
-        return this.expiredAt.compareTo(lentExtension.expiredAt);
-    }
+	public int compareTo(LentExtension lentExtension) {
+		return this.expiredAt.compareTo(lentExtension.expiredAt);
+	}
+
+	public void delete(LocalDateTime at) {
+		this.deletedAt = at;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
@@ -85,6 +85,6 @@ public class LentExtension {
 	}
 
 	public boolean isDeleted() {
-		return this.deletedAt == null;
+		return this.deletedAt != null;
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
@@ -83,4 +83,8 @@ public class LentExtension {
 	public void delete(LocalDateTime at) {
 		this.deletedAt = at;
 	}
+
+	public boolean isDeleted() {
+		return this.deletedAt == null;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
@@ -87,4 +87,8 @@ public class LentExtension {
 	public boolean isDeleted() {
 		return this.deletedAt != null;
 	}
+
+	public boolean isUsed() {
+		return this.usedAt != null;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/LentExtension.java
@@ -84,6 +84,10 @@ public class LentExtension {
 		this.deletedAt = at;
 	}
 
+	public boolean isExpiredSince(LocalDateTime at) {
+		return this.expiredAt.isBefore(at);
+	}
+
 	public boolean isDeleted() {
 		return this.deletedAt != null;
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
@@ -21,33 +21,35 @@ public class LentExtensionOptionalFetcher {
 
 	/*-------------------------------------------FIND-------------------------------------------*/
 	@Transactional(readOnly = true)
-	public Page<LentExtension> findAllLentExtension(PageRequest pageable) {
+	public Page<LentExtension> findAllNotDeleted(PageRequest pageable) {
 		return new PageImpl<>(lentExtensionRepository.findAll(pageable)
 				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList()));
 	}
 
 	@Transactional(readOnly = true)
-	public Page<LentExtension> findAllNotExpired(PageRequest pageable) {
+	public Page<LentExtension> findAllNotExpiredAndNotDeleted(PageRequest pageable) {
 		return lentExtensionRepository.findAllNotExpired(pageable)
 				.stream().filter(e -> !e.isUsed() && !e.isDeleted())
 				.collect(Collectors.collectingAndThen(Collectors.toList(), PageImpl::new));
 	}
 
 	@Transactional(readOnly = true)
-	public List<LentExtension> findAllNotExpired() {
+	public List<LentExtension> findAllNotExpiredAndNotDeleted() {
 		return lentExtensionRepository.findAll()
 				.stream().filter(e -> !e.isUsed() && !e.isDeleted())
 				.collect(Collectors.toList());
 	}
 
 	@Transactional(readOnly = true)
-	public List<LentExtension> findLentExtensionByUserId(Long userId) {
+	public List<LentExtension> findNotDeletedByUserId(Long userId) {
 		return lentExtensionRepository.findAllByUserId(userId)
 				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
 	}
 
+	// Active라는 표현 자체가 비즈니스적 의미를 담고 있으므로 변경해야할 필요가 있음.
+	// 추후 리팩터링 필요.
 	@Transactional(readOnly = true)
-	public List<LentExtension> findActiveLentExtensionsByUserId(Long userId) {
+	public List<LentExtension> findActiveByUserId(Long userId) {
 		return lentExtensionRepository.findAllByUserIdAndUsedAtIsNull(userId)
 				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
@@ -1,39 +1,52 @@
 package org.ftclub.cabinet.user.repository;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.user.domain.LentExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Log4j2
 public class LentExtensionOptionalFetcher {
 
-    private final LentExtensionRepository lentExtensionRepository;
+	private final LentExtensionRepository lentExtensionRepository;
 
-    /*-------------------------------------------FIND-------------------------------------------*/
-    @Transactional(readOnly = true)
-    public Page<LentExtension> findAllLentExtension(PageRequest pageable) {
-        return lentExtensionRepository.findAll(pageable);
-    }
+	/*-------------------------------------------FIND-------------------------------------------*/
+	@Transactional(readOnly = true)
+	public Page<LentExtension> findAllLentExtension(PageRequest pageable) {
+		return new PageImpl<>(lentExtensionRepository.findAll(pageable)
+				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList()));
+	}
 
-    @Transactional(readOnly = true)
-    public Page<LentExtension> findAllNotExpired(PageRequest pageable) {
-        return lentExtensionRepository.findAllNotExpired(pageable);
-    }
+	@Transactional(readOnly = true)
+	public Page<LentExtension> findAllNotExpired(PageRequest pageable) {
+		return lentExtensionRepository.findAllNotExpired(pageable);
+	}
 
-    @Transactional(readOnly = true)
-    public List<LentExtension> findLentExtensionByUserId(Long userId) {
-        return lentExtensionRepository.findAllByUserId(userId);
-    }
+	@Transactional(readOnly = true)
+	public List<LentExtension> findAllNotExpired() {
+		return lentExtensionRepository.findAll()
+				.stream().filter(e -> e.getUsedAt() != null)
+				.collect(Collectors.toList());
+	}
 
-    @Transactional(readOnly = true)
-    public List<LentExtension> findActiveLentExtensionsByUserId(Long userId) {
-        return lentExtensionRepository.findAllByUserIdAndUsedAtIsNull(userId);
-    }
+	@Transactional(readOnly = true)
+	public List<LentExtension> findLentExtensionByUserId(Long userId) {
+		return lentExtensionRepository.findAllByUserId(userId)
+				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public List<LentExtension> findActiveLentExtensionsByUserId(Long userId) {
+		return lentExtensionRepository.findAllByUserIdAndUsedAtIsNull(userId)
+				.stream().filter(e -> !e.isDeleted()).collect(Collectors.toList());
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
@@ -28,13 +28,15 @@ public class LentExtensionOptionalFetcher {
 
 	@Transactional(readOnly = true)
 	public Page<LentExtension> findAllNotExpired(PageRequest pageable) {
-		return lentExtensionRepository.findAllNotExpired(pageable);
+		return lentExtensionRepository.findAllNotExpired(pageable)
+				.stream().filter(e -> !e.isUsed() && !e.isDeleted())
+				.collect(Collectors.collectingAndThen(Collectors.toList(), PageImpl::new));
 	}
 
 	@Transactional(readOnly = true)
 	public List<LentExtension> findAllNotExpired() {
 		return lentExtensionRepository.findAll()
-				.stream().filter(e -> !e.isUsed())
+				.stream().filter(e -> !e.isUsed() && !e.isDeleted())
 				.collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
@@ -34,7 +34,7 @@ public class LentExtensionOptionalFetcher {
 	@Transactional(readOnly = true)
 	public List<LentExtension> findAllNotExpired() {
 		return lentExtensionRepository.findAll()
-				.stream().filter(e -> e.getUsedAt() == null)
+				.stream().filter(e -> !e.isUsed())
 				.collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/LentExtensionOptionalFetcher.java
@@ -34,7 +34,7 @@ public class LentExtensionOptionalFetcher {
 	@Transactional(readOnly = true)
 	public List<LentExtension> findAllNotExpired() {
 		return lentExtensionRepository.findAll()
-				.stream().filter(e -> e.getUsedAt() != null)
+				.stream().filter(e -> e.getUsedAt() == null)
 				.collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionService.java
@@ -1,22 +1,23 @@
 package org.ftclub.cabinet.user.service;
 
-import java.util.List;
 import org.ftclub.cabinet.dto.LentExtensionResponseDto;
 import org.ftclub.cabinet.dto.UserSessionDto;
 
+import java.util.List;
+
 public interface LentExtensionService {
 
-    void issueLentExtension();
+	void issueLentExtension();
 
-    void deleteLentExtension();
+	void deleteExpiredExtensions();
 
-    void useLentExtension(Long userId, String username);
+	void useLentExtension(Long userId, String username);
 
-    void assignLentExtension(String username);
+	void assignLentExtension(String username);
 
-    List<LentExtensionResponseDto> getActiveLentExtensionList(UserSessionDto userSessionDto);
+	List<LentExtensionResponseDto> getActiveLentExtensionList(UserSessionDto userSessionDto);
 
-    LentExtensionResponseDto getActiveLentExtension(UserSessionDto userSessionDto);
+	LentExtensionResponseDto getActiveLentExtension(UserSessionDto userSessionDto);
 
 
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
@@ -1,9 +1,5 @@
 package org.ftclub.cabinet.user.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
@@ -18,15 +14,20 @@ import org.ftclub.cabinet.lent.domain.LentHistory;
 import org.ftclub.cabinet.lent.repository.LentOptionalFetcher;
 import org.ftclub.cabinet.mapper.UserMapper;
 import org.ftclub.cabinet.occupiedtime.OccupiedTimeManager;
-import org.ftclub.cabinet.user.domain.LentExtensions;
 import org.ftclub.cabinet.user.domain.LentExtension;
 import org.ftclub.cabinet.user.domain.LentExtensionPolicy;
 import org.ftclub.cabinet.user.domain.LentExtensionType;
+import org.ftclub.cabinet.user.domain.LentExtensions;
 import org.ftclub.cabinet.user.repository.LentExtensionOptionalFetcher;
 import org.ftclub.cabinet.user.repository.LentExtensionRepository;
 import org.ftclub.cabinet.user.repository.UserOptionalFetcher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -108,7 +109,12 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 	@Scheduled(cron = "${spring.schedule.cron.extension-delete-time}")
 	public void deleteLentExtension() {
 		log.debug("Called deleteExtension");
-		lentExtensionRepository.deleteAll();
+		LocalDateTime now = LocalDateTime.now();
+		lentExtensionOptionalFetcher.findAllNotExpired().forEach(e -> {
+			if (e.getExpiredAt().isBefore(now)) {
+				e.delete(now);
+			}
+		});
 	}
 
 	@Override

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
@@ -84,7 +84,7 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 		log.debug("Called getLentExtensionList {}", userSessionDto.getName());
 
 		LentExtensions lentExtensions = LentExtensions.builder()
-				.lentExtensions(lentExtensionOptionalFetcher.findActiveLentExtensionsByUserId(
+				.lentExtensions(lentExtensionOptionalFetcher.findActiveByUserId(
 						userSessionDto.getUserId())).build();
 
 		return lentExtensions.getLentExtensions().stream()
@@ -94,7 +94,7 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 	@Override
 	public LentExtensionResponseDto getActiveLentExtension(UserSessionDto userSessionDto) {
 		LentExtensionResponseDto lentExtensionResponseDto = null;
-		List<LentExtension> activeLentExtensionsByUserId = lentExtensionOptionalFetcher.findActiveLentExtensionsByUserId(
+		List<LentExtension> activeLentExtensionsByUserId = lentExtensionOptionalFetcher.findActiveByUserId(
 				userSessionDto.getUserId());
 		LentExtensions lentExtensions = LentExtensions.builder()
 				.lentExtensions(activeLentExtensionsByUserId).build();
@@ -111,13 +111,9 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 		log.debug("Called deleteExtension");
 		LocalDateTime now = LocalDateTime.now();
 
-		List<LentExtension> allNotExpired = lentExtensionOptionalFetcher.findAllNotExpired();
-		allNotExpired.forEach(e -> {
-			if (e.getExpiredAt().isBefore(now)) {
-				e.delete(now);
-			}
-		});
-		System.out.println(allNotExpired);
+		lentExtensionOptionalFetcher.findAllNotExpiredAndNotDeleted().stream()
+				.filter(e -> e.isExpiredSince(now))
+				.forEach(e -> e.delete(now));
 	}
 
 	@Override
@@ -125,7 +121,7 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 		log.debug("Called useLentExtension {}", username);
 
 		List<LentExtension> findLentExtension =
-				lentExtensionOptionalFetcher.findLentExtensionByUserId(userId);
+				lentExtensionOptionalFetcher.findNotDeletedByUserId(userId);
 
 		LentExtensions lentExtensions = LentExtensions.builder().lentExtensions(findLentExtension)
 				.build();

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
@@ -111,11 +111,13 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 		log.debug("Called deleteExtension");
 		LocalDateTime now = LocalDateTime.now();
 
-		lentExtensionOptionalFetcher.findAllNotExpired().forEach(e -> {
+		List<LentExtension> allNotExpired = lentExtensionOptionalFetcher.findAllNotExpired();
+		allNotExpired.forEach(e -> {
 			if (e.getExpiredAt().isBefore(now)) {
 				e.delete(now);
 			}
 		});
+		System.out.println(allNotExpired);
 	}
 
 	@Override

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
@@ -107,9 +107,10 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 
 	@Override
 	@Scheduled(cron = "${spring.schedule.cron.extension-delete-time}")
-	public void deleteLentExtension() {
+	public void deleteExpiredExtensions() {
 		log.debug("Called deleteExtension");
 		LocalDateTime now = LocalDateTime.now();
+
 		lentExtensionOptionalFetcher.findAllNotExpired().forEach(e -> {
 			if (e.getExpiredAt().isBefore(now)) {
 				e.delete(now);

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeServiceImpl.java
@@ -1,37 +1,15 @@
 package org.ftclub.cabinet.user.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
 import org.ftclub.cabinet.cabinet.domain.LentType;
 import org.ftclub.cabinet.cabinet.repository.CabinetOptionalFetcher;
-import org.ftclub.cabinet.dto.BlockedUserPaginationDto;
-import org.ftclub.cabinet.dto.CabinetDto;
-import org.ftclub.cabinet.dto.ClubUserListDto;
-import org.ftclub.cabinet.dto.LentExtensionPaginationDto;
-import org.ftclub.cabinet.dto.LentExtensionResponseDto;
-import org.ftclub.cabinet.dto.MyProfileResponseDto;
-import org.ftclub.cabinet.dto.OverdueUserCabinetDto;
-import org.ftclub.cabinet.dto.OverdueUserCabinetPaginationDto;
-import org.ftclub.cabinet.dto.UserBlockedInfoDto;
-import org.ftclub.cabinet.dto.UserCabinetDto;
-import org.ftclub.cabinet.dto.UserCabinetPaginationDto;
-import org.ftclub.cabinet.dto.UserProfileDto;
-import org.ftclub.cabinet.dto.UserProfilePaginationDto;
-import org.ftclub.cabinet.dto.UserSessionDto;
+import org.ftclub.cabinet.dto.*;
 import org.ftclub.cabinet.lent.repository.LentOptionalFetcher;
 import org.ftclub.cabinet.mapper.CabinetMapper;
 import org.ftclub.cabinet.mapper.UserMapper;
-import org.ftclub.cabinet.user.domain.AdminRole;
-import org.ftclub.cabinet.user.domain.BanHistory;
-import org.ftclub.cabinet.user.domain.LentExtension;
-import org.ftclub.cabinet.user.domain.User;
-import org.ftclub.cabinet.user.domain.UserRole;
+import org.ftclub.cabinet.user.domain.*;
 import org.ftclub.cabinet.user.repository.LentExtensionOptionalFetcher;
 import org.ftclub.cabinet.user.repository.UserOptionalFetcher;
 import org.ftclub.cabinet.utils.DateUtil;
@@ -40,262 +18,268 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
 public class UserFacadeServiceImpl implements UserFacadeService {
 
-    private final UserService userService;
-    private final UserOptionalFetcher userOptionalFetcher;
-    private final LentOptionalFetcher lentOptionalFetcher;
-    private final UserMapper userMapper;
-    private final CabinetOptionalFetcher cabinetOptionalFetcher;
-    private final CabinetMapper cabinetMapper;
-    private final LentExtensionService lentExtensionService;
-    private final LentExtensionOptionalFetcher lentExtensionOptionalFetcher;
+	private final UserService userService;
+	private final UserOptionalFetcher userOptionalFetcher;
+	private final LentOptionalFetcher lentOptionalFetcher;
+	private final UserMapper userMapper;
+	private final CabinetOptionalFetcher cabinetOptionalFetcher;
+	private final CabinetMapper cabinetMapper;
+	private final LentExtensionService lentExtensionService;
+	private final LentExtensionOptionalFetcher lentExtensionOptionalFetcher;
 
-    @Override
-    public MyProfileResponseDto getMyProfile(UserSessionDto user) {
-        log.debug("Called getMyProfile: {}", user.getName());
+	@Override
+	public MyProfileResponseDto getMyProfile(UserSessionDto user) {
+		log.debug("Called getMyProfile: {}", user.getName());
 
-        Cabinet cabinet = lentOptionalFetcher.findActiveLentCabinetByUserId(user.getUserId());
-        BanHistory banHistory = userOptionalFetcher.findRecentActiveBanHistory(user.getUserId(),
-                LocalDateTime.now());
+		Cabinet cabinet = lentOptionalFetcher.findActiveLentCabinetByUserId(user.getUserId());
+		BanHistory banHistory = userOptionalFetcher.findRecentActiveBanHistory(user.getUserId(),
+				LocalDateTime.now());
 
-        LentExtensionResponseDto activeLentExtension = lentExtensionService.getActiveLentExtension(
-                user);
-        
-        return userMapper.toMyProfileResponseDto(user, cabinet, banHistory,
-                activeLentExtension);
-    }
+		LentExtensionResponseDto activeLentExtension = lentExtensionService.getActiveLentExtension(
+				user);
 
-    @Override
-    public BlockedUserPaginationDto getAllBanUsers(Integer page, Integer size, LocalDateTime now) {
-        log.debug("Called getAllBanUsers");
-        if (size <= 0) {
-            size = Integer.MAX_VALUE;
-        }
-        PageRequest pageable = PageRequest.of(page, size);
-        Page<BanHistory> activeBanList = userOptionalFetcher.findPaginationActiveBanHistories(
-                pageable, now);
-        List<UserBlockedInfoDto> userBlockedInfoDtos = activeBanList.stream().map(
-                        banHistory -> userMapper.toUserBlockedInfoDto(
-                                banHistory, banHistory.getUser()))
-                .collect(Collectors.toList());
-        return userMapper.toBlockedUserPaginationDto(userBlockedInfoDtos,
-                activeBanList.getTotalElements());
-    }
+		return userMapper.toMyProfileResponseDto(user, cabinet, banHistory,
+				activeLentExtension);
+	}
 
-    @Override
-    public UserProfilePaginationDto getUserProfileListByPartialName(String name, Integer page,
-            Integer size) {
-        log.debug("Called getUserProfileListByPartialName: {}", name);
-        // todo - size가 0일 때 모든 데이터를 가져오기
-        if (size <= 0) {
-            size = Integer.MAX_VALUE;
-        }
-        PageRequest pageable = PageRequest.of(page, size);
-        Page<User> users = userOptionalFetcher.findUsersByPartialName(name, pageable);
-        List<UserProfileDto> userProfileDtoList = users.stream()
-                .map(userMapper::toUserProfileDto).collect(Collectors.toList());
-        return userMapper.toUserProfilePaginationDto(userProfileDtoList,
-                users.getTotalElements());
-    }
+	@Override
+	public BlockedUserPaginationDto getAllBanUsers(Integer page, Integer size, LocalDateTime now) {
+		log.debug("Called getAllBanUsers");
+		if (size <= 0) {
+			size = Integer.MAX_VALUE;
+		}
+		PageRequest pageable = PageRequest.of(page, size);
+		Page<BanHistory> activeBanList = userOptionalFetcher.findPaginationActiveBanHistories(
+				pageable, now);
+		List<UserBlockedInfoDto> userBlockedInfoDtos = activeBanList.stream().map(
+						banHistory -> userMapper.toUserBlockedInfoDto(
+								banHistory, banHistory.getUser()))
+				.collect(Collectors.toList());
+		return userMapper.toBlockedUserPaginationDto(userBlockedInfoDtos,
+				activeBanList.getTotalElements());
+	}
 
-    @Override
-    public UserCabinetPaginationDto findUserCabinetListByPartialName(String name, Integer page,
-            Integer size) {
-        log.debug("Called findUserCabinetListByPartialName: {}", name);
-        // todo - size가 0일 때 모든 데이터를 가져오기
-        if (size <= 0) {
-            size = Integer.MAX_VALUE;
-        }
-        PageRequest pageable = PageRequest.of(page, size);
-        Page<User> users = userOptionalFetcher.findUsersByPartialName(name, pageable);
-        List<UserCabinetDto> userCabinetDtoList = new ArrayList<>();
-        users.toList().forEach(user -> {
-            BanHistory banHistory = userOptionalFetcher.findRecentActiveBanHistory(
-                    user.getUserId(), LocalDateTime.now());
-            //todo : banhistory join으로 한번에 가능
-            UserBlockedInfoDto blockedInfoDto = userMapper.toUserBlockedInfoDto(banHistory, user);
-            Cabinet cabinet = cabinetOptionalFetcher.findLentCabinetByUserId(user.getUserId());
-            CabinetDto cabinetDto = cabinetMapper.toCabinetDto(cabinet);
-            userCabinetDtoList.add(cabinetMapper.toUserCabinetDto(blockedInfoDto, cabinetDto));
-        });
-        return cabinetMapper.toUserCabinetPaginationDto(userCabinetDtoList,
-                users.getTotalElements());
-    }
+	@Override
+	public UserProfilePaginationDto getUserProfileListByPartialName(String name, Integer page,
+	                                                                Integer size) {
+		log.debug("Called getUserProfileListByPartialName: {}", name);
+		// todo - size가 0일 때 모든 데이터를 가져오기
+		if (size <= 0) {
+			size = Integer.MAX_VALUE;
+		}
+		PageRequest pageable = PageRequest.of(page, size);
+		Page<User> users = userOptionalFetcher.findUsersByPartialName(name, pageable);
+		List<UserProfileDto> userProfileDtoList = users.stream()
+				.map(userMapper::toUserProfileDto).collect(Collectors.toList());
+		return userMapper.toUserProfilePaginationDto(userProfileDtoList,
+				users.getTotalElements());
+	}
 
-    @Override
-    public List<User> getAllUsers() {
-        log.debug("Called getAllUsers");
-        return userOptionalFetcher.findAllUsers();
-    }
+	@Override
+	public UserCabinetPaginationDto findUserCabinetListByPartialName(String name, Integer page,
+	                                                                 Integer size) {
+		log.debug("Called findUserCabinetListByPartialName: {}", name);
+		// todo - size가 0일 때 모든 데이터를 가져오기
+		if (size <= 0) {
+			size = Integer.MAX_VALUE;
+		}
+		PageRequest pageable = PageRequest.of(page, size);
+		Page<User> users = userOptionalFetcher.findUsersByPartialName(name, pageable);
+		List<UserCabinetDto> userCabinetDtoList = new ArrayList<>();
+		users.toList().forEach(user -> {
+			BanHistory banHistory = userOptionalFetcher.findRecentActiveBanHistory(
+					user.getUserId(), LocalDateTime.now());
+			//todo : banhistory join으로 한번에 가능
+			UserBlockedInfoDto blockedInfoDto = userMapper.toUserBlockedInfoDto(banHistory, user);
+			Cabinet cabinet = cabinetOptionalFetcher.findLentCabinetByUserId(user.getUserId());
+			CabinetDto cabinetDto = cabinetMapper.toCabinetDto(cabinet);
+			userCabinetDtoList.add(cabinetMapper.toUserCabinetDto(blockedInfoDto, cabinetDto));
+		});
+		return cabinetMapper.toUserCabinetPaginationDto(userCabinetDtoList,
+				users.getTotalElements());
+	}
 
-    @Override
-    public boolean checkUserExists(String name) {
-        log.debug("Called checkUserExists: {}", name);
-        return userService.checkUserExists(name);
-    }
+	@Override
+	public List<User> getAllUsers() {
+		log.debug("Called getAllUsers");
+		return userOptionalFetcher.findAllUsers();
+	}
 
-    @Override
-    public void createUser(String name, String email, LocalDateTime blackholedAt, UserRole role) {
-        log.debug("Called createUser: {}", name);
-        userService.createUser(name, email, blackholedAt, role);
-    }
+	@Override
+	public boolean checkUserExists(String name) {
+		log.debug("Called checkUserExists: {}", name);
+		return userService.checkUserExists(name);
+	}
 
-    @Override
-    public void createClubUser(String clubName) {
-        log.debug("Called createClubUser: {}", clubName);
-        userService.createClubUser(clubName);
-    }
+	@Override
+	public void createUser(String name, String email, LocalDateTime blackholedAt, UserRole role) {
+		log.debug("Called createUser: {}", name);
+		userService.createUser(name, email, blackholedAt, role);
+	}
 
-    @Override
-    public boolean checkAdminUserExists(String email) {
-        log.debug("Called checkAdminUserExists: {}", email);
-        return userService.checkAdminUserExists(email);
-    }
+	@Override
+	public void createClubUser(String clubName) {
+		log.debug("Called createClubUser: {}", clubName);
+		userService.createClubUser(clubName);
+	}
 
-    @Override
-    public void createAdminUser(String email) {
-        log.debug("Called createAdminUser: {}", email);
-        userService.createAdminUser(email);
-    }
+	@Override
+	public boolean checkAdminUserExists(String email) {
+		log.debug("Called checkAdminUserExists: {}", email);
+		return userService.checkAdminUserExists(email);
+	}
 
-    @Override
-    public void deleteUser(Long userId, LocalDateTime deletedAt) {
-        log.debug("Called deleteUser: {}", userId);
-        userService.deleteUser(userId, deletedAt);
-    }
+	@Override
+	public void createAdminUser(String email) {
+		log.debug("Called createAdminUser: {}", email);
+		userService.createAdminUser(email);
+	}
 
-    @Override
-    public void deleteAdminUser(Long adminUserId) {
-        log.debug("Called deleteAdminUser: {}", adminUserId);
-        userService.deleteAdminUser(adminUserId);
-    }
+	@Override
+	public void deleteUser(Long userId, LocalDateTime deletedAt) {
+		log.debug("Called deleteUser: {}", userId);
+		userService.deleteUser(userId, deletedAt);
+	}
 
-    @Override
-    public void updateAdminUserRole(Long adminUserId, AdminRole role) {
-        log.debug("Called updateAdminUserRole: {}", adminUserId);
-        userService.updateAdminUserRole(adminUserId, role);
-    }
+	@Override
+	public void deleteAdminUser(Long adminUserId) {
+		log.debug("Called deleteAdminUser: {}", adminUserId);
+		userService.deleteAdminUser(adminUserId);
+	}
 
-    @Override
-    public void promoteUserToAdmin(String email) {
-        log.debug("Called promoteUserToAdmin: {}", email);
-        userService.promoteAdminByEmail(email);
-    }
+	@Override
+	public void updateAdminUserRole(Long adminUserId, AdminRole role) {
+		log.debug("Called updateAdminUserRole: {}", adminUserId);
+		userService.updateAdminUserRole(adminUserId, role);
+	}
 
-    @Override
-    public void updateUserBlackholedAt(Long userId, LocalDateTime newBlackholedAt) {
-        log.debug("Called updateUserBlackholedAt: {}", userId);
-        userService.updateUserBlackholedAt(userId, newBlackholedAt);
-    }
+	@Override
+	public void promoteUserToAdmin(String email) {
+		log.debug("Called promoteUserToAdmin: {}", email);
+		userService.promoteAdminByEmail(email);
+	}
 
-    @Override
-    public void banUser(Long userId, LentType lentType, LocalDateTime startedAt,
-            LocalDateTime endedAt,
-            LocalDateTime expiredAt) {
-        log.debug("Called banUser: {}", userId);
-        userService.banUser(userId, lentType, startedAt, endedAt, expiredAt);
-    }
+	@Override
+	public void updateUserBlackholedAt(Long userId, LocalDateTime newBlackholedAt) {
+		log.debug("Called updateUserBlackholedAt: {}", userId);
+		userService.updateUserBlackholedAt(userId, newBlackholedAt);
+	}
 
-    @Override
-    public void deleteRecentBanHistory(Long userId, LocalDateTime today) {
-        log.debug("Called deleteRecentBanHistory: {}", userId);
-        userService.deleteRecentBanHistory(userId, today);
-    }
+	@Override
+	public void banUser(Long userId, LentType lentType, LocalDateTime startedAt,
+	                    LocalDateTime endedAt,
+	                    LocalDateTime expiredAt) {
+		log.debug("Called banUser: {}", userId);
+		userService.banUser(userId, lentType, startedAt, endedAt, expiredAt);
+	}
 
-    @Override
-    public OverdueUserCabinetPaginationDto getOverdueUserList(Integer page, Integer size) {
-        log.debug("Called getOverdueUserList");
-        List<OverdueUserCabinetDto> overdueList = new ArrayList<>();
-        // todo - size가 0일 때 모든 데이터를 가져오기
-        if (size <= 0) {
-            size = Integer.MAX_VALUE;
-        }
-        PageRequest pageable = PageRequest.of(page, size);
-        lentOptionalFetcher.findAllOverdueLent(LocalDateTime.now(), pageable).stream().forEach(
-                (lh) -> {
-                    User user = lh.getUser();
-                    Long overdueDays = DateUtil.calculateTwoDateDiff(LocalDateTime.now(),
-                            lh.getExpiredAt());
-                    Cabinet cabinet = lh.getCabinet();
-                    overdueList.add(
-                            cabinetMapper.toOverdueUserCabinetDto(lh, user,
-                                    cabinet, overdueDays));
-                }
-        );
-        return cabinetMapper.toOverdueUserCabinetPaginationDto(overdueList,
-                Long.valueOf(overdueList.size()));
-    }
+	@Override
+	public void deleteRecentBanHistory(Long userId, LocalDateTime today) {
+		log.debug("Called deleteRecentBanHistory: {}", userId);
+		userService.deleteRecentBanHistory(userId, today);
+	}
 
-    @Override
-    public ClubUserListDto findAllClubUser(Integer page, Integer size) {
-        log.debug("Called findAllClubUser");
-        if (size <= 0) {
-            size = Integer.MAX_VALUE;
-        }
-        PageRequest pageable = PageRequest.of(page, size);
-        Page<User> pageUser = userOptionalFetcher.findClubUsers(pageable);
-        List<UserProfileDto> userProfileDtos = pageUser
-                .stream().map(u -> userMapper.toUserProfileDto(u)).collect(Collectors.toList());
-        return userMapper.toClubUserListDto(userProfileDtos, pageUser.getTotalElements());
-    }
+	@Override
+	public OverdueUserCabinetPaginationDto getOverdueUserList(Integer page, Integer size) {
+		log.debug("Called getOverdueUserList");
+		List<OverdueUserCabinetDto> overdueList = new ArrayList<>();
+		// todo - size가 0일 때 모든 데이터를 가져오기
+		if (size <= 0) {
+			size = Integer.MAX_VALUE;
+		}
+		PageRequest pageable = PageRequest.of(page, size);
+		lentOptionalFetcher.findAllOverdueLent(LocalDateTime.now(), pageable).stream().forEach(
+				(lh) -> {
+					User user = lh.getUser();
+					Long overdueDays = DateUtil.calculateTwoDateDiff(LocalDateTime.now(),
+							lh.getExpiredAt());
+					Cabinet cabinet = lh.getCabinet();
+					overdueList.add(
+							cabinetMapper.toOverdueUserCabinetDto(lh, user,
+									cabinet, overdueDays));
+				}
+		);
+		return cabinetMapper.toOverdueUserCabinetPaginationDto(overdueList,
+				Long.valueOf(overdueList.size()));
+	}
 
-    @Override
-    public void deleteClubUser(Long userId) {
-        log.debug("Called deleteClubUser");
-        userService.deleteClubUser(userId, LocalDateTime.now());
-    }
+	@Override
+	public ClubUserListDto findAllClubUser(Integer page, Integer size) {
+		log.debug("Called findAllClubUser");
+		if (size <= 0) {
+			size = Integer.MAX_VALUE;
+		}
+		PageRequest pageable = PageRequest.of(page, size);
+		Page<User> pageUser = userOptionalFetcher.findClubUsers(pageable);
+		List<UserProfileDto> userProfileDtos = pageUser
+				.stream().map(u -> userMapper.toUserProfileDto(u)).collect(Collectors.toList());
+		return userMapper.toClubUserListDto(userProfileDtos, pageUser.getTotalElements());
+	}
 
-    @Override
-    public void updateClubUser(Long clubId, String clubName) {
-        log.debug("Called updateClubUser");
-        userService.updateClubUser(clubId, clubName);
-    }
+	@Override
+	public void deleteClubUser(Long userId) {
+		log.debug("Called deleteClubUser");
+		userService.deleteClubUser(userId, LocalDateTime.now());
+	}
 
-    @Override
-    public LentExtensionPaginationDto getAllLentExtension(Integer page, Integer size) {
-        PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
-        List<LentExtensionResponseDto> result =
-                lentExtensionOptionalFetcher.findAllLentExtension(pageable).stream()
-                        .map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
-        return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
-    }
+	@Override
+	public void updateClubUser(Long clubId, String clubName) {
+		log.debug("Called updateClubUser");
+		userService.updateClubUser(clubId, clubName);
+	}
 
-    @Override
-    public LentExtensionPaginationDto getAllActiveLentExtension(Integer page, Integer size) {
-        PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
-        List<LentExtensionResponseDto> result =
-                lentExtensionOptionalFetcher.findAllNotExpired(pageable).stream()
-                        .map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
-        return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
-    }
+	@Override
+	public LentExtensionPaginationDto getAllLentExtension(Integer page, Integer size) {
+		PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
+		List<LentExtensionResponseDto> result =
+				lentExtensionOptionalFetcher.findAllLentExtension(pageable).stream()
+						.map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
+		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
+	}
 
-    @Override
-    public LentExtensionPaginationDto getMyLentExtension(UserSessionDto userSessionDto) {
-        log.debug("Called getMyLentExtension");
-        List<LentExtensionResponseDto> result =
-                lentExtensionOptionalFetcher.findLentExtensionByUserId(userSessionDto.getUserId())
-                        .stream()
-                        .sorted(Comparator.comparing(LentExtension::getExpiredAt))
-                        .map(userMapper::toLentExtensionResponseDto)
-                        .collect(Collectors.toList());
-        return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
-    }
+	@Override
+	public LentExtensionPaginationDto getAllActiveLentExtension(Integer page, Integer size) {
+		PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
+		List<LentExtensionResponseDto> result =
+				lentExtensionOptionalFetcher.findAllNotExpired(pageable).stream()
+						.map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
+		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
+	}
 
-    @Override
-    public LentExtensionPaginationDto getMyActiveLentExtensionPage(UserSessionDto userSessionDto) {
-        log.debug("Called getMyActiveLentExtension");
-        List<LentExtensionResponseDto> result = lentExtensionService.getActiveLentExtensionList(
-                userSessionDto);
-        return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
-    }
+	@Override
+	public LentExtensionPaginationDto getMyLentExtension(UserSessionDto userSessionDto) {
+		log.debug("Called getMyLentExtension");
+		List<LentExtensionResponseDto> result =
+				lentExtensionOptionalFetcher.findLentExtensionByUserId(userSessionDto.getUserId())
+						.stream()
+						.sorted(Comparator.comparing(LentExtension::getExpiredAt))
+						.map(userMapper::toLentExtensionResponseDto)
+						.collect(Collectors.toList());
+		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
+	}
 
-    @Override
-    public void useLentExtension(UserSessionDto userSessionDto) {
-        log.debug("Called useLentExtension");
-        lentExtensionService.useLentExtension(userSessionDto.getUserId(), userSessionDto.getName());
-    }
+	@Override
+	public LentExtensionPaginationDto getMyActiveLentExtensionPage(UserSessionDto userSessionDto) {
+		log.debug("Called getMyActiveLentExtension");
+		List<LentExtensionResponseDto> result = lentExtensionService.getActiveLentExtensionList(
+				userSessionDto);
+		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
+	}
+
+	@Override
+	public void useLentExtension(UserSessionDto userSessionDto) {
+		log.debug("Called useLentExtension");
+		lentExtensionService.useLentExtension(userSessionDto.getUserId(), userSessionDto.getName());
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeServiceImpl.java
@@ -243,7 +243,7 @@ public class UserFacadeServiceImpl implements UserFacadeService {
 	public LentExtensionPaginationDto getAllLentExtension(Integer page, Integer size) {
 		PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
 		List<LentExtensionResponseDto> result =
-				lentExtensionOptionalFetcher.findAllLentExtension(pageable).stream()
+				lentExtensionOptionalFetcher.findAllNotDeleted(pageable).stream()
 						.map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
 		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
 	}
@@ -252,7 +252,7 @@ public class UserFacadeServiceImpl implements UserFacadeService {
 	public LentExtensionPaginationDto getAllActiveLentExtension(Integer page, Integer size) {
 		PageRequest pageable = PageRequest.of(page, size, Sort.by("expiredAt"));
 		List<LentExtensionResponseDto> result =
-				lentExtensionOptionalFetcher.findAllNotExpired(pageable).stream()
+				lentExtensionOptionalFetcher.findAllNotExpiredAndNotDeleted(pageable).stream()
 						.map(userMapper::toLentExtensionResponseDto).collect(Collectors.toList());
 		return userMapper.toLentExtensionPaginationDto(result, (long) result.size());
 	}
@@ -261,7 +261,7 @@ public class UserFacadeServiceImpl implements UserFacadeService {
 	public LentExtensionPaginationDto getMyLentExtension(UserSessionDto userSessionDto) {
 		log.debug("Called getMyLentExtension");
 		List<LentExtensionResponseDto> result =
-				lentExtensionOptionalFetcher.findLentExtensionByUserId(userSessionDto.getUserId())
+				lentExtensionOptionalFetcher.findNotDeletedByUserId(userSessionDto.getUserId())
 						.stream()
 						.sorted(Comparator.comparing(LentExtension::getExpiredAt))
 						.map(userMapper::toLentExtensionResponseDto)

--- a/backend/src/test/java/org/ftclub/cabinet/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/controller/UserControllerTest.java
@@ -36,7 +36,7 @@ public class UserControllerTest {
 	public void testGetMyProfile_대여_사물함_없는_경우() throws Exception {
 		// penaltyuser2 대여 중인 사물함 x 벤 기록 x
 		MyProfileResponseDto myProfileResponseDto = new MyProfileResponseDto(4L, "penaltyuser2",
-				null, null, true);
+				null, null, null);
 
 		String userToken = TestUtils.getTestUserTokenByName(jwtProperties.getSigningKey(),
 				LocalDateTime.now(), DateUtil.getInfinityDate(), "penaltyuser2", "user.domain.com");
@@ -55,7 +55,7 @@ public class UserControllerTest {
 	public void testGetMyProfile_대여_사물함_있는_경우() throws Exception {
 		// lentuser1 대여 중인 사물함 3번
 		MyProfileResponseDto myProfileResponseDto = new MyProfileResponseDto(5L, "lentuser1",
-				3L, null, true);
+				3L, null, null);
 
 		String userToken = TestUtils.getTestUserTokenByName(jwtProperties.getSigningKey(),
 				LocalDateTime.now(), DateUtil.getInfinityDate(), "lentuser1", "user.domain.com");

--- a/backend/src/test/java/org/ftclub/cabinet/user/service/LentExtensionServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/service/LentExtensionServiceTest.java
@@ -1,0 +1,64 @@
+package org.ftclub.cabinet.user.service;
+
+import org.ftclub.cabinet.firebase.FCMInitializer;
+import org.ftclub.cabinet.user.domain.LentExtension;
+import org.ftclub.cabinet.user.domain.LentExtensionType;
+import org.ftclub.cabinet.user.domain.User;
+import org.ftclub.cabinet.user.domain.UserRole;
+import org.ftclub.cabinet.user.repository.LentExtensionRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@Disabled // Test를 위한 In-Memory를 얹는 데에 있어서 DDL이 동작하지 않음. 임시 비활성화
+public class LentExtensionServiceTest {
+
+	@Autowired EntityManager em;
+	@Autowired LentExtensionService lentExtensionService;
+	@Autowired LentExtensionRepository lentExtensionRepository;
+	@MockBean FCMInitializer fcmInitializer; // 임시로 의존 제거,
+
+	@Nested
+	@DisplayName("만료된 연장권들을 지울 때,")
+	class DeleteExpiredExtensions {
+		LocalDateTime now = LocalDateTime.now();
+		User sanan;
+		User jpark2;
+
+		@BeforeEach
+		void setUp() {
+			sanan = User.of("sanan", "email@ab.com", LocalDateTime.MAX, UserRole.USER);
+			jpark2 = User.of("jpark2", "email@ac.com", LocalDateTime.MAX, UserRole.USER);
+			em.persist(sanan);
+			em.persist(jpark2);
+		}
+
+		@Test
+		@DisplayName("현재 시간을 기준으로 만료된 연장권들을 soft delete한다.")
+		void 삭제() {
+			LentExtension expired = LentExtension.of("extension", 31, now.minusDays(1), LentExtensionType.ALL, sanan.getUserId());
+			LentExtension valid = LentExtension.of("extension", 31, now.plusDays(1), LentExtensionType.ALL, jpark2.getUserId());
+			em.persist(expired);
+			em.persist(valid);
+			em.flush();
+			em.clear();
+
+			lentExtensionService.deleteExpiredExtensions();
+
+			LentExtension mustDeleted = lentExtensionRepository.findById(expired.getLentExtensionId()).get();
+			LentExtension mustValid = lentExtensionRepository.findById(valid.getLentExtensionId()).get();
+			assertThat(mustDeleted.getDeletedAt()).isNotNull();
+			assertThat(mustValid.getDeletedAt()).isNull();
+		}
+
+	}
+}

--- a/backend/src/test/java/org/ftclub/cabinet/user/service/UserFacadeServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/service/UserFacadeServiceTest.java
@@ -10,11 +10,7 @@ import org.ftclub.cabinet.lent.domain.LentHistory;
 import org.ftclub.cabinet.lent.repository.LentOptionalFetcher;
 import org.ftclub.cabinet.mapper.CabinetMapper;
 import org.ftclub.cabinet.mapper.UserMapper;
-import org.ftclub.cabinet.user.domain.AdminRole;
-import org.ftclub.cabinet.user.domain.BanHistory;
-import org.ftclub.cabinet.user.domain.LentExtension;
-import org.ftclub.cabinet.user.domain.User;
-import org.ftclub.cabinet.user.domain.UserRole;
+import org.ftclub.cabinet.user.domain.*;
 import org.ftclub.cabinet.user.repository.LentExtensionOptionalFetcher;
 import org.ftclub.cabinet.user.repository.UserOptionalFetcher;
 import org.junit.jupiter.api.Disabled;
@@ -109,8 +105,8 @@ public class UserFacadeServiceTest {
 				userSessionDto.getUserId()).get(0);
 		MyProfileResponseDto myProfileResponseDto = new MyProfileResponseDto(
 				userSessionDto.getUserId(), userSessionDto.getName(),
-				cabinet1.getCabinetId(), null, lentExtension);
-		given(userMapper.toMyProfileResponseDto(userSessionDto, cabinet1, null, lentExtension))
+				cabinet1.getCabinetId(), null, null);
+		given(userMapper.toMyProfileResponseDto(userSessionDto, cabinet1, null, null))
 				.willReturn(myProfileResponseDto);
 
 		// when
@@ -141,8 +137,8 @@ public class UserFacadeServiceTest {
 		LentExtension lentExtension = lentExtensionOptionalFetcher.findLentExtensionByUserId(
 				userSessionDto.getUserId()).get(0);
 
-		given(userMapper.toMyProfileResponseDto(userSessionDto, null, banHistory1, lentExtension)).willReturn(
-				new MyProfileResponseDto(2L, "testUser2", null, testDate.plusDays(1), lentExtension));
+		given(userMapper.toMyProfileResponseDto(userSessionDto, null, banHistory1, null)).willReturn(
+				new MyProfileResponseDto(2L, "testUser2", null, testDate.plusDays(1), null));
 
 		// when
 		MyProfileResponseDto myProfile = userFacadeService.getMyProfile(userSessionDto);

--- a/backend/src/test/java/org/ftclub/cabinet/user/service/UserFacadeServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/service/UserFacadeServiceTest.java
@@ -98,10 +98,10 @@ public class UserFacadeServiceTest {
 		given(lentOptionalFetcher.findActiveLentCabinetByUserId(1L)).willReturn(cabinet1);
 		given(userOptionalFetcher.findRecentActiveBanHistory(1L, LocalDateTime.now()))
 				.willReturn(null);
-		given(lentExtensionOptionalFetcher.findLentExtensionByUserId(userSessionDto.getUserId()))
+		given(lentExtensionOptionalFetcher.findNotDeletedByUserId(userSessionDto.getUserId()))
 				.willReturn(null);
 
-		LentExtension lentExtension = lentExtensionOptionalFetcher.findLentExtensionByUserId(
+		LentExtension lentExtension = lentExtensionOptionalFetcher.findNotDeletedByUserId(
 				userSessionDto.getUserId()).get(0);
 		MyProfileResponseDto myProfileResponseDto = new MyProfileResponseDto(
 				userSessionDto.getUserId(), userSessionDto.getName(),
@@ -131,10 +131,10 @@ public class UserFacadeServiceTest {
 		given(lentOptionalFetcher.findActiveLentCabinetByUserId(2L)).willReturn(null);
 		given(userOptionalFetcher.findRecentActiveBanHistory(eq(2L), any())).willReturn(
 				banHistory1);
-		given(lentExtensionOptionalFetcher.findLentExtensionByUserId(userSessionDto.getUserId()))
+		given(lentExtensionOptionalFetcher.findNotDeletedByUserId(userSessionDto.getUserId()))
 				.willReturn(null);
 
-		LentExtension lentExtension = lentExtensionOptionalFetcher.findLentExtensionByUserId(
+		LentExtension lentExtension = lentExtensionOptionalFetcher.findNotDeletedByUserId(
 				userSessionDto.getUserId()).get(0);
 
 		given(userMapper.toMyProfileResponseDto(userSessionDto, null, banHistory1, null)).willReturn(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1457

특정 일자에 적용되는 스케줄링을 통해서, 일괄적으로 리포지터리를 deleteAll하던 로직을,
현재 정책에 맞는 비즈니스 로직(expiredAt이 측정 시각 기준으로 지난 경우)에 맞추어 soft delete하도록 변경하였습니다.
이후에 있을 리팩토링을 고려해서 우선 중복되는 필터 로직으로 작성해두었습니다(이후에 개선할 여지가 있다고 생각합니다).

soft delete를 결정한 이유는 연장권이 어떻게 발급되었고, 얼마나 이용되었고 등에 대한 데이터 수집을 위함입니다.
현재 테스트 환경이 잘 깨져서 자동화된 테스트는 굴려보지 못했지만, 실제 로컬환경에서 테스트해본 결과 잘 동작하는 것을 확인했습니다.
이후에 dev에 업로드 이후에도 같이 QA하듯이 테스트해봐야 할 것 같습니다.
