### PR TITLE
[BE] pending 조회 로직 수정 및 cabinet, lent 리팩토링

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/controller/CabinetController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/controller/CabinetController.java
@@ -52,7 +52,7 @@ public class CabinetController {
 	public List<CabinetsPerSectionResponseDto> getCabinetsPerSection(
 			@PathVariable("building") String building,
 			@PathVariable("floor") Integer floor) {
-		return cabinetFacadeService.getCabinetsPerSectionDSL(building, floor);
+		return cabinetFacadeService.getCabinetsPerSection(building, floor);
 	}
 
 	/**
@@ -75,10 +75,10 @@ public class CabinetController {
 	 *
 	 * @return 오픈 예정인 사물함들의 정보를 반환합니다.
 	 */
-	@GetMapping("/pending")
+	@GetMapping("/buildings/{building}/pending")
 	@AuthGuard(level = AuthLevel.USER_OR_ADMIN)
-	public CabinetPendingResponseDto getPendingCabinets() {
+	public CabinetPendingResponseDto getPendingCabinets(@PathVariable("building") String building) {
 		log.info("Called getPendingCabinets");
-		return cabinetFacadeService.getPendingCabinets();
+		return cabinetFacadeService.getPendingCabinets(building);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetComplexRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetComplexRepository.java
@@ -16,7 +16,5 @@ public interface CabinetComplexRepository {
 	List<ActiveCabinetInfoEntities> findCabinetsActiveLentHistoriesByBuildingAndFloor(
 			String building, Integer floor);
 
-	List<Cabinet> findAllCabinetsByBuildingAndFloor(String building, Integer floor);
-
 	List<Cabinet> findAllCabinetsByCabinetStatusAndBeforeEndedAt(CabinetStatus cabinetStatus, LocalDateTime endedAt);
 }

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetOptionalFetcher.java
@@ -150,7 +150,15 @@ public class CabinetOptionalFetcher {
 		return cabinet;
 	}
 
-	public List<Cabinet> findPendingCabinets(
+	/**
+	 * building과 status에 맞고 lentType이 아닌 사물함을 찾습니다.
+	 *
+	 * @param building 건물 이름
+	 * @param lentType 사물함 타입
+	 * @param cabinetStatuses 사물함 상태 {@link List}
+	 * @return {@link Cabinet} {@link List}
+	 */
+	public List<Cabinet> findPendingCabinetsNotLentTypeAndStatus(
 			String building, LentType lentType, List<CabinetStatus> cabinetStatuses) {
 		return cabinetRepository.findAllByBuildingAndLentTypeNotAndStatusIn(
 				building, lentType, cabinetStatuses);

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetOptionalFetcher.java
@@ -87,7 +87,7 @@ public class CabinetOptionalFetcher {
 	}
 
 	public List<Cabinet> findAllCabinetsByBuildingAndFloor(String building, Integer floor) {
-		return cabinetRepository.findAllByBuildingAndFloorOrderByVisibleNum(building, floor);
+		return cabinetRepository.findAllByBuildingAndFloor(building, floor);
 	}
 	/*-------------------------------------------GET--------------------------------------------*/
 

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
@@ -6,10 +6,8 @@ import javax.persistence.LockModeType;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
 import org.ftclub.cabinet.cabinet.domain.CabinetStatus;
 import org.ftclub.cabinet.cabinet.domain.LentType;
-import org.ftclub.cabinet.cabinet.domain.Location;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -19,95 +17,71 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CabinetRepository extends JpaRepository<Cabinet, Long>, CabinetComplexRepository {
 
+	/**
+	 * 모든 빌딩을 조회한다.
+	 *
+	 * @return 빌딩 {@link List}
+	 */
+	@Query("SELECT DISTINCT p.location.building "
+			+ "FROM CabinetPlace p ")
+	List<String> findAllBuildings();
+
+	/**
+	 * 빌딩의 모든 층을 조회한다.
+	 *
+	 * @param building 빌딩
+	 * @return 층 {@link List}
+	 */
+	@Query("SELECT DISTINCT p.location.floor "
+			+ "FROM CabinetPlace p "
+			+ "WHERE p.location.building = :building")
+	List<Integer> findAllFloorsByBuilding(@Param("building") String building);
+
+	/**
+	 * cabinetId로 사물함을 조회한다.(조회 이후 업데이트를 위해 X Lock을 건다.)
+	 *
+	 * @param cabinetId 사물함 ID
+	 * @return 사물함 {@link Optional}
+	 */
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT c "
 			+ "FROM Cabinet c "
 			+ "WHERE c.cabinetId = :cabinetId")
-	Optional<Cabinet> findByIdForUpdate(@Param("cabinetId") Long cabinetId);
+	Optional<Cabinet> findByCabinetIdForUpdate(@Param("cabinetId") Long cabinetId);
 
-	@Query("SELECT DISTINCT p.location.floor "
-			+ "FROM Cabinet c "
-			+ "JOIN c.cabinetPlace p "
-			+ "WHERE p.location.building = :building")
-	List<Integer> findAllFloorsByBuilding(@Param("building") String building);
-
-	@Query("SELECT DISTINCT p.location.building "
-			+ "FROM Cabinet c "
-			+ "JOIN c.cabinetPlace p")
-	List<String> findAllBuildings();
-
-	@Query("SELECT DISTINCT p.location.section "
-			+ "FROM Cabinet c "
-			+ "JOIN c.cabinetPlace p "
-			+ "WHERE p.location.building = :building AND p.location.floor = :floor")
-	List<String> findAllSectionsByBuildingAndFloor(
-			@Param("building") String building,
-			@Param("floor") Integer floor);
-
-	@Query("SELECT p.location "
-			+ "FROM Cabinet c "
-			+ "JOIN c.cabinetPlace p "
-			+ "WHERE c.cabinetId = :cabinetId")
-	Optional<Location> findLocationById(@Param("cabinetId") Long cabinetId);
-
-
-	@Query(value = "SELECT AUTO_INCREMENT "
-			+ "FROM information_schema.TABLES "
-			+ "WHERE TABLE_SCHEMA = (SELECT DATABASE()) AND TABLE_NAME = 'cabinet'",
-			nativeQuery = true)
-	Optional<Long> getNextCabinetId();
-
+	/**
+	 * userId로 현재 대여 중인 사물함을 조회한다.
+	 *
+	 * @param userId 사용자 ID
+	 * @return 사물함 {@link Optional}
+	 */
 	@Query("SELECT c " +
 			"FROM Cabinet c " +
 			"LEFT JOIN LentHistory lh ON c.cabinetId = lh.cabinetId " +
 			"LEFT JOIN User u ON u.userId = lh.userId " +
 			"WHERE u.userId = :userId AND lh.endedAt IS NULL")
-	Optional<Cabinet> findLentCabinetByUserId(@Param("userId") Long userId);
+	Optional<Cabinet> findByUserIdAndEndedAtIsNull(@Param("userId") Long userId);
 
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.lentType = :lentType")
-	Page<Cabinet> findPaginationByLentType(@Param("lentType") LentType lentType,
-			Pageable pageable);
+	Page<Cabinet> findPaginationByLentType(@Param("lentType") LentType lentType, Pageable pageable);
 
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.status = :status")
-	Page<Cabinet> findPaginationByStatus(@Param("status") CabinetStatus status,
-			Pageable pageable);
+	Page<Cabinet> findPaginationByStatus(@Param("status") CabinetStatus status, Pageable pageable);
 
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.visibleNum = :visibleNum")
-	Page<Cabinet> findPaginationByVisibleNum(@Param("visibleNum") Integer visibleNum,
-			Pageable pageable);
+	Page<Cabinet> findPaginationByVisibleNum(@Param("visibleNum") Integer visibleNum, Pageable pageable);
 
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.cabinetPlace.location = :location")
-	List<Cabinet> findAllCabinetsByLocation(@Param("location") Location location);
-
-	@EntityGraph(attributePaths = {"cabinetPlace"})
-	@Query("SELECT DISTINCT c, lh, u " +
-			"FROM Cabinet c " +
-			"JOIN c.lentHistories lh ON lh.cabinetId = c.cabinetId " +
-			"JOIN lh.user u ON lh.userId = u.userId " +
-			"WHERE c.cabinetPlace.location.building = :building AND c.cabinetPlace.location.floor = :floor "
-			+
-			"AND lh.endedAt IS NULL")
-	List<Object[]> findCabinetActiveLentHistoryUserListByBuildingAndFloor(
+	@Query("SELECT c "
+			+ "FROM Cabinet c "
+			+ "JOIN FETCH c.cabinetPlace p "
+			+ "WHERE p.location.building = :building AND p.location.floor = :floor "
+			+ "ORDER BY c.visibleNum ASC")
+	List<Cabinet> findAllByBuildingAndFloorOrderByVisibleNum(
 			@Param("building") String building, @Param("floor") Integer floor);
 
-	@EntityGraph(attributePaths = {"cabinetPlace"})
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.cabinetPlace.location.building = :building AND c.cabinetPlace.location.floor = :floor")
-	List<Cabinet> findAllByBuildingAndFloor(
-			@Param("building") String building, @Param("floor") Integer floor);
-
-	@EntityGraph(attributePaths = {"cabinetPlace"})
-	@Query("SELECT c " +
-			"FROM Cabinet c " +
-			"WHERE c.cabinetPlace.location.building = :building")
-	List<Cabinet> findAllCabinetsByBuilding(@Param("building") String building);
+	@Query("SELECT c "
+			+ "FROM Cabinet c "
+			+ "JOIN FETCH c.cabinetPlace p "
+			+ "WHERE p.location.building = :building "
+			+ "AND c.lentType <> :lentType "
+			+ "AND c.status IN (:status)")
+	List<Cabinet> findAllByBuildingAndLentTypeNotAndStatusIn(@Param("building") String building,
+			@Param("lentType") LentType lentType, @Param("status") List<CabinetStatus> status);
 }

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/repository/CabinetRepository.java
@@ -71,9 +71,8 @@ public interface CabinetRepository extends JpaRepository<Cabinet, Long>, Cabinet
 	@Query("SELECT c "
 			+ "FROM Cabinet c "
 			+ "JOIN FETCH c.cabinetPlace p "
-			+ "WHERE p.location.building = :building AND p.location.floor = :floor "
-			+ "ORDER BY c.visibleNum ASC")
-	List<Cabinet> findAllByBuildingAndFloorOrderByVisibleNum(
+			+ "WHERE p.location.building = :building AND p.location.floor = :floor")
+	List<Cabinet> findAllByBuildingAndFloor(
 			@Param("building") String building, @Param("floor") Integer floor);
 
 	@Query("SELECT c "

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeService.java
@@ -50,11 +50,6 @@ public interface CabinetFacadeService {
 	 */
 	List<CabinetsPerSectionResponseDto> getCabinetsPerSection(String building, Integer floor);
 
-	List<CabinetsPerSectionResponseDto> getCabinetsPerSectionRefactor(String building,
-			Integer floor);
-
-	List<CabinetsPerSectionResponseDto> getCabinetsPerSectionDSL(String building, Integer floor);
-
 	/**
 	 * 사물함의 상태 메모를 업데이트합니다.
 	 *
@@ -94,15 +89,6 @@ public interface CabinetFacadeService {
 	 * @param cabinetStatusRequestDto 사물함 ID 리스트 dto
 	 */
 	void updateCabinetBundleStatus(CabinetStatusRequestDto cabinetStatusRequestDto);
-
-//	/**
-//	 * 사물함의 대여 타입을 업데이트합니다.
-//	 *
-//	 * @param cabinetIds 사물함 ID 리스트
-//	 * @param lentType   변경할 대여 타입
-//	 */
-//	void updateCabinetBundleLentType(List<Long> cabinetIds, LentType lentType);
-
 
 	/**
 	 * 대여 타입에 따른 사물함 페이지네이션을 가져옵니다.
@@ -158,6 +144,6 @@ public interface CabinetFacadeService {
 	 *
 	 * @return 오픈 예정인 사물함 정보
 	 */
-	CabinetPendingResponseDto getPendingCabinets();
+	CabinetPendingResponseDto getPendingCabinets(String building);
 
 }

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
@@ -1,5 +1,6 @@
 package org.ftclub.cabinet.cabinet.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
@@ -288,9 +289,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 	@Transactional
 	public CabinetPendingResponseDto getPendingCabinets(String building) {
 		log.debug("getPendingCabinets");
-		final LocalDateTime pendingLimit = LocalDateTime.of(
-				LocalDateTime.now().toLocalDate().minusDays(1),
-				LocalTime.of(13, 0, 0));
+		final LocalDate yesterday = LocalDateTime.now().minusDays(1).toLocalDate();
 		List<Cabinet> buildingCabinets =
 				cabinetOptionalFetcher.findPendingCabinets(
 						building,
@@ -313,7 +312,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 				LocalDateTime latestEndedAt = lentHistoriesMap.get(cabinet.getCabinetId()).stream()
 						.map(LentHistory::getEndedAt)
 						.max(LocalDateTime::compareTo).orElse(null);
-				if (latestEndedAt != null && latestEndedAt.isAfter(pendingLimit)) {
+				if (latestEndedAt != null && latestEndedAt.toLocalDate().isEqual(yesterday)) {
 					cabinetFloorMap.get(floor).add(cabinetMapper.toCabinetPreviewDto(cabinet, 0, null));
 				}
 			}

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
@@ -292,9 +292,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 		final LocalDate yesterday = LocalDateTime.now().minusDays(1).toLocalDate();
 		List<Cabinet> buildingCabinets =
 				cabinetOptionalFetcher.findPendingCabinetsNotLentTypeAndStatus(
-						building,
-						LentType.CLUB,
-						List.of(CabinetStatus.AVAILABLE, CabinetStatus.PENDING));
+						building, LentType.CLUB, List.of(AVAILABLE, PENDING));
 		List<Long> cabinetIds = buildingCabinets.stream()
 				.filter(cabinet -> cabinet.isStatus(PENDING))
 				.map(Cabinet::getCabinetId).collect(Collectors.toList());
@@ -302,7 +300,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 				cabinetOptionalFetcher.findAllFloorsByBuilding(building).stream()
 						.collect(toMap(key -> key, value -> new ArrayList<>()));
 		Map<Long, List<LentHistory>> lentHistoriesMap =
-				lentOptionalFetcher.findAllLentHistoriesByCabinetIds(cabinetIds)
+				lentOptionalFetcher.findAllByCabinetIdsAfterDate(yesterday, cabinetIds)
 					.stream().collect(groupingBy(LentHistory::getCabinetId));
 		buildingCabinets.forEach(cabinet -> {
 			Integer floor = cabinet.getCabinetPlace().getLocation().getFloor();

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
@@ -122,8 +122,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public List<CabinetsPerSectionResponseDto> getCabinetsPerSection(String building,
-	                                                                    Integer floor) {
+	public List<CabinetsPerSectionResponseDto> getCabinetsPerSection(String building, Integer floor) {
 		log.debug("getCabinetsPerSection");
 		List<ActiveCabinetInfoEntities> currentLentCabinets = cabinetOptionalFetcher
 				.findCabinetsActiveLentHistoriesByBuildingAndFloor(building, floor);
@@ -135,12 +134,14 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 		List<Cabinet> allCabinetsOnSection =
 				cabinetOptionalFetcher.findAllCabinetsByBuildingAndFloor(building, floor);
 		Map<String, List<CabinetPreviewDto>> cabinetPreviewsBySection = new LinkedHashMap<>();
-		allCabinetsOnSection.forEach(cabinet -> {
-			String section = cabinet.getCabinetPlace().getLocation().getSection();
-			List<LentHistory> lentHistories =
-					cabinetLentHistories.getOrDefault(cabinet, Collections.emptyList());
-			CabinetPreviewDto preview = createCabinetPreviewDto(cabinet, lentHistories);
-			cabinetPreviewsBySection.computeIfAbsent(section, k -> new ArrayList<>()).add(preview);
+		allCabinetsOnSection.stream()
+				.sorted(Comparator.comparing(Cabinet::getVisibleNum))
+				.forEach(cabinet -> {
+					String section = cabinet.getCabinetPlace().getLocation().getSection();
+					List<LentHistory> lentHistories =
+							cabinetLentHistories.getOrDefault(cabinet, Collections.emptyList());
+					CabinetPreviewDto preview = createCabinetPreviewDto(cabinet, lentHistories);
+					cabinetPreviewsBySection.computeIfAbsent(section, k -> new ArrayList<>()).add(preview);
 		});
 		return cabinetPreviewsBySection.entrySet().stream()
 				.map(entry -> cabinetMapper.toCabinetsPerSectionResponseDto(entry.getKey(), entry.getValue()))

--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceImpl.java
@@ -291,7 +291,7 @@ public class CabinetFacadeServiceImpl implements CabinetFacadeService {
 		log.debug("getPendingCabinets");
 		final LocalDate yesterday = LocalDateTime.now().minusDays(1).toLocalDate();
 		List<Cabinet> buildingCabinets =
-				cabinetOptionalFetcher.findPendingCabinets(
+				cabinetOptionalFetcher.findPendingCabinetsNotLentTypeAndStatus(
 						building,
 						LentType.CLUB,
 						List.of(CabinetStatus.AVAILABLE, CabinetStatus.PENDING));

--- a/backend/src/main/java/org/ftclub/cabinet/firebase/FCMInitializer.java
+++ b/backend/src/main/java/org/ftclub/cabinet/firebase/FCMInitializer.java
@@ -6,6 +6,7 @@ import com.google.firebase.FirebaseOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
@@ -27,7 +28,10 @@ public class FCMInitializer {
 
 	@PostConstruct
 	public void initialize() throws IOException {
-		Path currentPath = Paths.get("").toAbsolutePath().normalize();
+
+		Path currentPath = Paths.get(new ClassPathResource("/").getFile().getPath())
+				.getParent().getParent().getParent().getParent().getParent()
+				.toAbsolutePath().normalize();
 		Resource resource = resourceLoader.getResource("file:" + currentPath + credentialsPath);
 		try (InputStream inputStream = resource.getInputStream()) {
 			FirebaseOptions options = FirebaseOptions.builder()

--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
@@ -23,6 +23,7 @@ import org.ftclub.cabinet.exception.ExceptionStatus;
 import org.ftclub.cabinet.user.domain.User;
 import org.ftclub.cabinet.utils.DateUtil;
 import org.ftclub.cabinet.utils.ExceptionUtil;
+import org.hibernate.annotations.BatchSize;
 
 /**
  * lent의 기록을 관리하기 위한 data mapper
@@ -33,6 +34,7 @@ import org.ftclub.cabinet.utils.ExceptionUtil;
 @Getter
 @ToString(exclude = {"user", "cabinet"})
 @Log4j2
+@BatchSize(size = 200)
 public class LentHistory {
 
     @Id

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
@@ -160,7 +160,7 @@ public class LentOptionalFetcher {
 		return lentRepository.findAllActiveLentHistoriesByUserId(userId);
 	}
 
-	public Optional<LentHistory> findPreviousLentHistoryByCabinetId(Long cabinetId) {
+	public List<LentHistory> findPreviousLentHistoryByCabinetId(Long cabinetId) {
 		log.debug("Called findPreviousLentUserNameByCabinetId: {}", cabinetId);
 		return lentRepository.findByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(cabinetId);
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
@@ -1,5 +1,6 @@
 package org.ftclub.cabinet.lent.repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -164,7 +165,7 @@ public class LentOptionalFetcher {
 		return lentRepository.findByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(cabinetId);
 	}
 
-	public List<LentHistory> findAllLentHistoriesByCabinetIds(List<Long> cabinetIds) {
-		return lentRepository.findAllByCabinetIdIn(cabinetIds);
+	public List<LentHistory> findAllByCabinetIdsAfterDate(LocalDate date, List<Long> cabinetIds) {
+		return lentRepository.findAllByCabinetIdsAfterDate(date, cabinetIds);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentOptionalFetcher.java
@@ -144,7 +144,7 @@ public class LentOptionalFetcher {
 
 	public List<LentHistory> findAllOverdueLent(LocalDateTime date, Pageable pageable) {
 		log.debug("Called findAllOverdueLent: {}", date);
-		return lentRepository.findAllOverdueLentHistories(date, pageable);
+		return lentRepository.findAllExpiredAtBeforeAndEndedAtIsNull(date, pageable);
 	}
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -89,7 +89,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param cabinetId 찾으려는 cabinet id
 	 * @return 반납한 {@link LentHistory}의 {@link Optional}
 	 */
-	Optional<LentHistory> findByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(
+	List<LentHistory> findByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(
 			@Param("cabinetId") Long cabinetId);
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -1,5 +1,6 @@
 package org.ftclub.cabinet.lent.repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -162,9 +163,15 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * 여러 사물함들의 대여 기록을 모두 가져옵니다.
 	 *
 	 * @param cabinetIds 조회하고자 하는 사물함의 Id {@link List}
+	 * @param date       조회하고자 하는 날짜(시간 제외)
 	 * @return 조회하고자 하는 사물함들 {@link LentHistory}의 {@link List}
 	 */
-	List<LentHistory> findAllByCabinetIdIn(List<Long> cabinetIds);
+	@Query("SELECT lh "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.cabinetId IN :cabinetIds "
+			+ "AND DATE(lh.endedAt) >= DATE(:date)")
+	List<LentHistory> findAllByCabinetIdsAfterDate(@Param("date") LocalDate date,
+			@Param("cabinetIds") List<Long> cabinetIds);
 
 	/**
 	 * 연체되어 있는 사물함을 모두 가져옵니다.

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -20,12 +20,76 @@ import org.springframework.stereotype.Repository;
 public interface LentRepository extends JpaRepository<LentHistory, Long> {
 
 	/**
+	 * 유저가 지금까지 빌렸던 사물함의 개수를 가져옵니다.
+	 *
+	 * @param userId 찾으려는 user id
+	 * @return 유저가 빌렸던 사물함의 개수
+	 */
+	@Query("SELECT count(lh) "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.userId = :userId")
+	int countByUserId(@Param("userId") Long userId);
+
+	/**
+	 * 유저가 빌리고 있는 사물함의 개수를 가져옵니다.
+	 *
+	 * @param userId 찾으려는 user id
+	 * @return 유저가 빌리고 있는 사물함 개수
+	 */
+	@Query("SELECT count(lh) "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.endedAt = null and lh.userId = :userId")
+	int countByUserIdAndEndedAtIsNull(@Param("userId") Long userId);
+
+	/**
+	 * 사물함을 빌렸던 유저의 수를 가져옵니다.
+	 *
+	 * @param cabinetId 찾으려는 cabinet id
+	 * @return 사물함을 빌렸던 유저의 수
+	 */
+	@Query("SELECT count(lh)"
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.cabinetId = :cabinetId")
+	int countByCabinetId(@Param("cabinetId") Long cabinetId);
+
+	/**
+	 * 사물함을 빌리고 있는 유저의 수를 가져옵니다.
+	 *
+	 * @param cabinetId 찾으려는 cabinet id
+	 * @return 사물함을 빌리고 있는 유저의 수
+	 */
+	@Query("SELECT count(lh) "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.endedAt = null and lh.cabinetId = :cabinetId")
+	int countByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
+
+	@Query("SELECT count(lh) "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.startedAt < :endDate AND lh.startedAt >= :startDate")
+	int countLentByTimeDuration(@Param("startDate") LocalDateTime startDate,
+			@Param("endDate") LocalDateTime endDate);
+
+	@Query("SELECT count(lh) "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.endedAt < :endDate AND lh.endedAt >= :startDate")
+	int countReturnByTimeDuration(@Param("startDate") LocalDateTime startDate,
+			@Param("endDate") LocalDateTime endDate);
+
+	/**
 	 * 사물함을 기준으로 아직 반납하지 않은 {@link LentHistory}중 하나를 가져옵니다.
 	 *
 	 * @param cabinetId 찾으려는 cabinet id
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link Optional}
 	 */
-	Optional<LentHistory> findFirstByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
+	Optional<LentHistory> findByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
+
+	/***
+	 * 사물함을 기준으로 가장 최근에 반납한 {@link LentHistory} 를 가져옵니다.
+	 * @param cabinetId 찾으려는 cabinet id
+	 * @return 반납한 {@link LentHistory}의 {@link Optional}
+	 */
+	Optional<LentHistory> findByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(
+			@Param("cabinetId") Long cabinetId);
 
 	/**
 	 * 유저를 기준으로 아직 반납하지 않은 {@link LentHistory}중 하나를 가져옵니다.
@@ -33,7 +97,7 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param userId 찾으려는 user id
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link Optional}
 	 */
-	Optional<LentHistory> findFirstByUserIdAndEndedAtIsNull(@Param("userId") Long userId);
+	Optional<LentHistory> findByUserIdAndEndedAtIsNull(@Param("userId") Long userId);
 
 	/**
 	 * 유저를 기준으로 아직 반납하지 않은 {@link LentHistory}중 하나를 가져옵니다. X Lock을 걸어서 가져옵니다.
@@ -42,131 +106,65 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link Optional}
 	 */
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.userId = :userId AND lh.endedAt is null")
-	Optional<LentHistory> findFirstByUserIdAndEndedAtIsNullForUpdate(@Param("userId") Long userId);
-
+	@Query("SELECT lh "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.userId = :userId AND lh.endedAt is null")
+	Optional<LentHistory> findByUserIdAndEndedAtIsNullForUpdate(@Param("userId") Long userId);
 
 	/**
-	 * 유저가 지금까지 빌렸던 {@link LentHistory}들을 가져옵니다. {@link Pageable}이 적용되었습니다.
+	 * 사물함의 대여기록 {@link LentHistory}들을 모두 가져옵니다.
+	 * {@link Pageable}이 적용되었습니다.
+	 *
+	 * @param cabinetId   찾으려는 cabinet id
+	 * @param pageable pagination 정보
+	 * @return {@link LentHistory}의 {@link Page}
+	 */
+	Page<LentHistory> findPaginationByCabinetId(
+			@Param("cabinetId") Long cabinetId, Pageable pageable);
+
+	/**
+	 * 유저가 지금까지 빌렸던 {@link LentHistory}들을 모두 가져옵니다.
+	 * {@link Pageable}이 적용되었습니다.
 	 *
 	 * @param userId   찾으려는 user id
 	 * @param pageable pagination 정보
-	 * @return {@link LentHistory}들의 정보
+	 * @return {@link LentHistory}의 {@link Page}
 	 */
-	List<LentHistory> findByUserId(@Param("userId") Long userId, Pageable pageable);
+	Page<LentHistory> findPaginationByUserId(@Param("userId") Long userId, Pageable pageable);
 
 	/**
-	 * 유저가 지금까지 빌렸던 {@link LentHistory}들을 가져옵니다.(현재 빌리고 반납하지 않은 기록은 표시하지 않습니다.) {@link Pageable}이
-	 * 적용되었습니다.
+	 * 유저가 지금까지 빌렸던 {@link LentHistory}들을 가져옵니다.(현재 빌리고 반납하지 않은 기록은 표시하지 않습니다.)
+	 * {@link Pageable}이 적용되었습니다.
 	 *
 	 * @param userId   찾으려는 user id
 	 * @param pageable pagination 정보
-	 * @return
+	 * @return 반납했던 {@link LentHistory}의 {@link Page}
 	 */
-	List<LentHistory> findByUserIdAndEndedAtNotNull(@Param("userId") Long userId,
-			Pageable pageable);
+	Page<LentHistory> findPaginationByUserIdAndEndedAtNotNull(
+			@Param("userId") Long userId, Pageable pageable);
 
 	/**
-	 * 캐비넷의 {@link LentHistory}들을 가져옵니다. {@link Pageable}이 적용되었습니다.
-	 *
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @param pageable  pagination 정보
-	 * @return {@link LentHistory}들의 정보
-	 */
-	List<LentHistory> findByCabinetId(@Param("cabinetId") Long cabinetId, Pageable pageable);
-
-	/**
-	 * 캐비넷의 대여 중인 {@link LentHistory}들을 가져옵니다.(공유 사물함의 경우를 포함하여 리스트로 반환)
-	 *
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @return {@link LentHistory}들의 정보
-	 */
-	List<LentHistory> findLentHistoriesByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
-
-	/***
-	 * 사물함을 기준으로 가장 최근에 반납한 {@link LentHistory} 를 가져옵니다.
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @return 반납한 {@link LentHistory}의 {@link Optional}
-	 */
-	Optional<LentHistory> findFirstByCabinetIdAndEndedAtIsNotNullOrderByEndedAtDesc(
-			@Param("cabinetId") Long cabinetId);
-
-	/**
-	 * 유저가 빌리고 있는 사물함의 개수를 가져옵니다.
-	 *
-	 * @param userId 찾으려는 user id
-	 * @return 유저가 빌리고 있는 사물함 개수
-	 */
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.endedAt = null and lh.userId = :userId")
-	int countUserActiveLent(@Param("userId") Long userId);
-
-	/**
-	 * 사물함을 빌리고 있는 유저의 수를 가져옵니다.
-	 *
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @return 사물함을 빌리고 있는 유저의 수
-	 */
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.endedAt = null and lh.cabinetId = :cabinetId")
-	int countCabinetActiveLent(@Param("cabinetId") Long cabinetId);
-
-	/**
-	 * 유저가 지금까지 빌렸던 사물함의 개수를 가져옵니다.
-	 *
-	 * @param userId 찾으려는 user id
-	 * @return 유저가 빌렸던 사물함의 개수
-	 */
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.userId = :userId")
-	int countUserAllLent(@Param("userId") Long userId);
-
-	/**
-	 * 사물함을 빌렸던 유저의 수를 가져옵니다.
-	 *
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @return 사물함을 빌렸던 유저의 수
-	 */
-	@Query("SELECT count(lh)" +
-			"FROM LentHistory lh " +
-			"WHERE lh.cabinetId = :cabinetId")
-	int countCabinetAllLent(@Param("cabinetId") Long cabinetId);
-
-
-	/**
-	 * 사물함을 기준으로 아직 반납하지 않은 {@link LentHistory}를 모두 가져옵니다..
+	 * 사물함을 기준으로 아직 반납하지 않은 {@link LentHistory}를 모두 가져옵니다.
 	 *
 	 * @param cabinetId 찾으려는 cabinet id
 	 * @return 반납하지 않은 {@link LentHistory}의 {@link List}
 	 */
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.cabinetId = :cabinetId and lh.endedAt is null")
-	List<LentHistory> findAllActiveLentByCabinetId(@Param("cabinetId") Long cabinetId);
+	List<LentHistory> findAllByCabinetIdAndEndedAtIsNull(@Param("cabinetId") Long cabinetId);
 
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"LEFT JOIN FETCH lh.user " +
-			"WHERE lh.cabinetId = :cabinetId and lh.endedAt is null")
-	List<LentHistory> findActiveLentHistoriesByCabinetIdWithUser(
-			@Param("cabinetId") Long cabinetId);
+	/**
+	 * 대여 중인 사물함을 모두 가져옵니다.
+	 *
+	 * @return 연체되어 있는 {@link LentHistory}의 {@link List}
+	 */
+	List<LentHistory> findAllByEndedAtIsNull();
 
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.cabinetId = :cabinetId")
-	Page<LentHistory> findPaginationByCabinetId(@Param("cabinetId") Long cabinetId,
-			Pageable pageable);
-
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.userId = :userId")
-	Page<LentHistory> findPaginationByUserId(@Param("userId") Long userId,
-			Pageable pageable);
+	/**
+	 * 여러 사물함들의 대여 기록을 모두 가져옵니다.
+	 *
+	 * @param cabinetIds 조회하고자 하는 사물함의 Id {@link List}
+	 * @return 조회하고자 하는 사물함들 {@link LentHistory}의 {@link List}
+	 */
+	List<LentHistory> findAllByCabinetIdIn(List<Long> cabinetIds);
 
 	/**
 	 * 연체되어 있는 사물함을 모두 가져옵니다.
@@ -174,35 +172,11 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 	 * @param date 연체의 기준 날짜/시간
 	 * @return 연체되어 있는 {@link LentHistory}의 {@link List}
 	 */
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.expiredAt < :date " +
-			"AND YEAR(lh.expiredAt) <> 9999 " +
-			"AND lh.endedAt is null " +
-			"ORDER BY lh.expiredAt ASC")
-	List<LentHistory> findAllOverdueLent(@Param("date") LocalDateTime date, Pageable pageable);
-
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.startedAt < :endDate AND lh.startedAt >= :startDate")
-	Integer countLentByTimeDuration(@Param("startDate") LocalDateTime startDate,
-			@Param("endDate") LocalDateTime endDate);
-
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.endedAt < :endDate AND lh.endedAt >= :startDate")
-	Integer countReturnByTimeDuration(@Param("startDate") LocalDateTime startDate,
-			@Param("endDate") LocalDateTime endDate);
-
-	@Query("SELECT count(lh) " +
-			"FROM LentHistory lh " +
-			"WHERE lh.cabinetId = :cabinetId AND lh.endedAt IS NULL")
-	Integer countCabinetAllActiveLent(@Param("cabinetId") Long cabinetId);
-
-	@Query("SELECT lh " +
-			"FROM LentHistory lh " +
-			"WHERE lh.endedAt IS NULL")
-	List<LentHistory> findAllActiveLentHistories();
+	@Query("SELECT lh "
+			+ "FROM LentHistory lh "
+			+ "WHERE lh.expiredAt < :date AND lh.endedAt is null "
+			+ "ORDER BY lh.expiredAt ASC")
+	List<LentHistory> findAllOverdueLentHistories(@Param("date") LocalDateTime date, Pageable pageable);
 
 	@Query("SELECT lh "
 			+ "FROM LentHistory lh "
@@ -211,5 +185,4 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 			+ "IN (SELECT lh2.cabinetId "
 			+ "FROM LentHistory lh2 WHERE lh2.userId = :userId AND lh2.endedAt IS NULL)")
 	List<LentHistory> findAllActiveLentHistoriesByUserId(@Param("userId") Long userId);
-
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/repository/LentRepository.java
@@ -176,7 +176,8 @@ public interface LentRepository extends JpaRepository<LentHistory, Long> {
 			+ "FROM LentHistory lh "
 			+ "WHERE lh.expiredAt < :date AND lh.endedAt is null "
 			+ "ORDER BY lh.expiredAt ASC")
-	List<LentHistory> findAllOverdueLentHistories(@Param("date") LocalDateTime date, Pageable pageable);
+	List<LentHistory> findAllExpiredAtBeforeAndEndedAtIsNull(
+			@Param("date") LocalDateTime date, Pageable pageable);
 
 	@Query("SELECT lh "
 			+ "FROM LentHistory lh "

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeService.java
@@ -97,17 +97,6 @@ public interface LentFacadeService {
 	 */
 	LentHistoryPaginationDto getAllUserLentHistories(Long userId, Integer page, Integer size);
 
-	/**
-	 * 페이지네이션을 적용해서 지금까지 사물함의 모든 기록을 가져옵니다.
-	 *
-	 * @param cabinetId 찾으려는 cabinet id
-	 * @param page      페이지네이션 offset
-	 * @param size      페이지네이션 size
-	 * @return {@link LentHistoryPaginationDto}
-	 */
-	LentHistoryPaginationDto getAllCabinetLentHistories(Long cabinetId, Integer page,
-			Integer size);
-
 	MyCabinetResponseDto getMyLentInfo(UserSessionDto user);
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
@@ -13,7 +13,6 @@ import org.ftclub.cabinet.config.CabinetProperties;
 import org.ftclub.cabinet.dto.CabinetInfoRequestDto;
 import org.ftclub.cabinet.dto.LentDto;
 import org.ftclub.cabinet.dto.LentEndMemoDto;
-import org.ftclub.cabinet.dto.LentExtensionPaginationDto;
 import org.ftclub.cabinet.dto.LentHistoryDto;
 import org.ftclub.cabinet.dto.LentHistoryPaginationDto;
 import org.ftclub.cabinet.dto.MyCabinetResponseDto;
@@ -71,18 +70,6 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 	}
 
 	@Override
-	public LentHistoryPaginationDto getAllCabinetLentHistories(Long cabinetId, Integer page,
-			Integer size) {
-		log.debug("Called getAllCabinetLentHistories: {}", cabinetId);
-		cabinetOptionalFetcher.getCabinet(cabinetId);
-		PageRequest pageable = PageRequest.of(page, size, Sort.by("startedAt"));
-		Page<LentHistory> lentHistories = lentOptionalFetcher.findPaginationByCabinetId(cabinetId,
-				pageable);
-		return generateLentHistoryPaginationDto(lentHistories.toList(),
-				lentHistories.getTotalElements());
-	}
-
-	@Override
 	public List<LentDto> getLentDtoList(Long cabinetId) {
 		log.debug("Called getLentDtoList: {}", cabinetId);
 		cabinetOptionalFetcher.getCabinet(cabinetId);
@@ -131,9 +118,8 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 		log.debug("Called getMyLentLog: {}", user.getName());
 		PageRequest pageable = PageRequest.of(page, size,
 				Sort.by(Sort.Direction.DESC, "startedAt"));
-		List<LentHistory> myLentHistories = lentOptionalFetcher.findByUserIdAndEndedAtNotNull(
-				user.getUserId(),
-				pageable);
+		List<LentHistory> myLentHistories = lentOptionalFetcher.findAllByUserIdAndEndedAtNotNull(
+				user.getUserId(), pageable);
 		List<LentHistoryDto> result = myLentHistories.stream()
 				.map(lentHistory -> lentMapper.toLentHistoryDto(
 						lentHistory,
@@ -146,9 +132,7 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 	private LentHistoryPaginationDto generateLentHistoryPaginationDto(
 			List<LentHistory> lentHistories, Long totalLength) {
 		List<LentHistoryDto> lentHistoryDto = lentHistories.stream()
-				.map(e -> lentMapper.toLentHistoryDto(e,
-						e.getUser(),
-						e.getCabinet()))
+				.map(e -> lentMapper.toLentHistoryDto(e, e.getUser(), e.getCabinet()))
 				.collect(Collectors.toList());
 		return new LentHistoryPaginationDto(lentHistoryDto, totalLength);
 	}
@@ -269,7 +253,6 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 				cabinetInfoRequestDto.getTitle(),
 				cabinetInfoRequestDto.getMemo());
 	}
-
 
 	@Override
 	public void assignLent(Long userId, Long cabinetId) {

--- a/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/service/LentFacadeServiceImpl.java
@@ -149,10 +149,10 @@ public class LentFacadeServiceImpl implements LentFacadeService {
 		String previousUserName = lentRedis.getPreviousUserName(
 				myCabinet.getCabinetId().toString());
 		if (previousUserName == null) {
-			Optional<LentHistory> previousLentHistory = lentOptionalFetcher.findPreviousLentHistoryByCabinetId(
+			List<LentHistory> previousLentHistory = lentOptionalFetcher.findPreviousLentHistoryByCabinetId(
 					cabinetId);
-			if (previousLentHistory.isPresent()) {
-				previousUserName = previousLentHistory.get().getUser().getName();
+			if (!previousLentHistory.isEmpty()) {
+				previousUserName = previousLentHistory.get(0).getUser().getName();
 			}
 		}
 		return cabinetMapper.toMyCabinetResponseDto(myCabinet, lentDtoList,

--- a/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceImpl.java
@@ -42,7 +42,7 @@ public class StatisticsFacadeServiceImpl implements StatisticsFacadeService {
 			List<Long> availableCabinetsId = statisticsRepository.getAvailableCabinetsId(floor);
 			Integer unused = 0;
 			for (Long cabinetId : availableCabinetsId) {
-				if (lentRepository.countCabinetActiveLent(cabinetId) > 0) {
+				if (lentRepository.countByCabinetIdAndEndedAtIsNull(cabinetId) > 0) {
 					used++;
 				} else {
 					unused++;

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionServiceImpl.java
@@ -119,7 +119,7 @@ public class LentExtensionServiceImpl implements LentExtensionService {
 		}
 
 		Cabinet cabinet = cabinetOptionalFetcher.getLentCabinetByUserId(userId);
-		List<LentHistory> activeLentHistories = lentOptionalFetcher.findActiveLentHistoriesByCabinetId(
+		List<LentHistory> activeLentHistories = lentOptionalFetcher.findAllActiveLentHistoriesByCabinetId(
 				cabinet.getCabinetId());
 		lentExtensionPolicy.verifyLentExtension(cabinet, activeLentHistories);
 

--- a/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceUnitTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeServiceUnitTest.java
@@ -292,76 +292,76 @@ class CabinetFacadeServiceUnitTest {
 		assertEquals(0, result.getTotalLength());
 	}
 
-	@Test
-	@Disabled
-	@DisplayName("성공: building, floor로 캐비넷 section 과 정보 조회 - 결과 3개")
-	void 성공_simple_getCabinetsPerSection() {
-		String building = "새롬관";
-		Integer floor = 2;
-
-		List<String> sectionList = List.of("1클러스터끝", "오아시스", "2클러스터끝");
-		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
-				.willReturn(sectionList);
-
-		CabinetPreviewDto cabinetPreviewDto1 = mock(CabinetPreviewDto.class);
-		CabinetPreviewDto cabinetPreviewDto2 = mock(CabinetPreviewDto.class);
-		CabinetPreviewDto cabinetPreviewDto3 = mock(CabinetPreviewDto.class);
-		List<CabinetPreviewDto> cabinetPreviewDtoList1 = new ArrayList<>(
-				List.of(cabinetPreviewDto1, cabinetPreviewDto2, cabinetPreviewDto3));
-		List<CabinetPreviewDto> cabinetPreviewDtoList2 = new ArrayList<>(
-				List.of(cabinetPreviewDto2, cabinetPreviewDto1, cabinetPreviewDto3));
-		List<CabinetPreviewDto> cabinetPreviewDtoList3 = new ArrayList<>(
-				List.of(cabinetPreviewDto3, cabinetPreviewDto2, cabinetPreviewDto1));
-/*
-혹시 몰라서 작성 해놓은 mock
-		CabinetsPerSectionResponseDto mock1 = mock(CabinetsPerSectionResponseDto.class);
-		CabinetsPerSectionResponseDto mock2 = mock(CabinetsPerSectionResponseDto.class);
-		CabinetsPerSectionResponseDto mock3 = mock(CabinetsPerSectionResponseDto.class);
-
-		given(mock1.getCabinets()).willReturn(cabinetPreviewDtoList1);
-		given(mock2.getCabinets()).willReturn(cabinetPreviewDtoList2);
-		given(mock3.getCabinets()).willReturn(cabinetPreviewDtoList3);
-
-		given(mock1.getSection()).willReturn(sectionList.get(0));
-		given(mock2.getSection()).willReturn(sectionList.get(1));
-		given(mock3.getSection()).willReturn(sectionList.get(2));
-*/
-		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto1 = new CabinetsPerSectionResponseDto(
-				sectionList.get(0),
-				cabinetPreviewDtoList1);
-		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto2 = new CabinetsPerSectionResponseDto(
-				sectionList.get(1),
-				cabinetPreviewDtoList2);
-		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto3 = new CabinetsPerSectionResponseDto(
-				sectionList.get(2),
-				cabinetPreviewDtoList3);
-
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(0),
-				cabinetPreviewDtoList1)).willReturn(cabinetsPerSectionResponseDto1);
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(1),
-				cabinetPreviewDtoList2)).willReturn(cabinetsPerSectionResponseDto2);
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(2),
-				cabinetPreviewDtoList3)).willReturn(cabinetsPerSectionResponseDto3);
-
-		//when
-		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService.getCabinetsPerSection(
-				building, floor);
-
-		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
-		then(cabinetMapper).should(times(3)).toCabinetsPerSectionResponseDto(any(), any());
-		/*
-		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(0),
-				cabinetPreviewDtoList1);
-		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(1),
-				cabinetPreviewDtoList2);
-		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(2),
-				cabinetPreviewDtoList3);
-*/
-		assertEquals(3, result.size());
-		assertEquals(sectionList.get(0), result.get(0).getSection());
-		assertEquals(sectionList.get(1), result.get(1).getSection());
-		assertEquals(sectionList.get(2), result.get(2).getSection());
-	}
+//	@Test
+//	@Disabled
+//	@DisplayName("성공: building, floor로 캐비넷 section 과 정보 조회 - 결과 3개")
+//	void 성공_simple_getCabinetsPerSection() {
+//		String building = "새롬관";
+//		Integer floor = 2;
+//
+//		List<String> sectionList = List.of("1클러스터끝", "오아시스", "2클러스터끝");
+//		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
+//				.willReturn(sectionList);
+//
+//		CabinetPreviewDto cabinetPreviewDto1 = mock(CabinetPreviewDto.class);
+//		CabinetPreviewDto cabinetPreviewDto2 = mock(CabinetPreviewDto.class);
+//		CabinetPreviewDto cabinetPreviewDto3 = mock(CabinetPreviewDto.class);
+//		List<CabinetPreviewDto> cabinetPreviewDtoList1 = new ArrayList<>(
+//				List.of(cabinetPreviewDto1, cabinetPreviewDto2, cabinetPreviewDto3));
+//		List<CabinetPreviewDto> cabinetPreviewDtoList2 = new ArrayList<>(
+//				List.of(cabinetPreviewDto2, cabinetPreviewDto1, cabinetPreviewDto3));
+//		List<CabinetPreviewDto> cabinetPreviewDtoList3 = new ArrayList<>(
+//				List.of(cabinetPreviewDto3, cabinetPreviewDto2, cabinetPreviewDto1));
+///*
+//혹시 몰라서 작성 해놓은 mock
+//		CabinetsPerSectionResponseDto mock1 = mock(CabinetsPerSectionResponseDto.class);
+//		CabinetsPerSectionResponseDto mock2 = mock(CabinetsPerSectionResponseDto.class);
+//		CabinetsPerSectionResponseDto mock3 = mock(CabinetsPerSectionResponseDto.class);
+//
+//		given(mock1.getCabinets()).willReturn(cabinetPreviewDtoList1);
+//		given(mock2.getCabinets()).willReturn(cabinetPreviewDtoList2);
+//		given(mock3.getCabinets()).willReturn(cabinetPreviewDtoList3);
+//
+//		given(mock1.getSection()).willReturn(sectionList.get(0));
+//		given(mock2.getSection()).willReturn(sectionList.get(1));
+//		given(mock3.getSection()).willReturn(sectionList.get(2));
+//*/
+//		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto1 = new CabinetsPerSectionResponseDto(
+//				sectionList.get(0),
+//				cabinetPreviewDtoList1);
+//		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto2 = new CabinetsPerSectionResponseDto(
+//				sectionList.get(1),
+//				cabinetPreviewDtoList2);
+//		CabinetsPerSectionResponseDto cabinetsPerSectionResponseDto3 = new CabinetsPerSectionResponseDto(
+//				sectionList.get(2),
+//				cabinetPreviewDtoList3);
+//
+//		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(0),
+//				cabinetPreviewDtoList1)).willReturn(cabinetsPerSectionResponseDto1);
+//		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(1),
+//				cabinetPreviewDtoList2)).willReturn(cabinetsPerSectionResponseDto2);
+//		given(cabinetMapper.toCabinetsPerSectionResponseDto(sectionList.get(2),
+//				cabinetPreviewDtoList3)).willReturn(cabinetsPerSectionResponseDto3);
+//
+//		//when
+//		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService.getCabinetsPerSection(
+//				building, floor);
+//
+//		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
+//		then(cabinetMapper).should(times(3)).toCabinetsPerSectionResponseDto(any(), any());
+//		/*
+//		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(0),
+//				cabinetPreviewDtoList1);
+//		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(1),
+//				cabinetPreviewDtoList2);
+//		then(cabinetMapper).should().toCabinetsPerSectionResponseDto(sectionList.get(2),
+//				cabinetPreviewDtoList3);
+//*/
+//		assertEquals(3, result.size());
+//		assertEquals(sectionList.get(0), result.get(0).getSection());
+//		assertEquals(sectionList.get(1), result.get(1).getSection());
+//		assertEquals(sectionList.get(2), result.get(2).getSection());
+//	}
 
 	@Test
 	@DisplayName("성공: 빌딩, 층수로 section 별 캐비넷 정보 가져오기")
@@ -372,6 +372,8 @@ class CabinetFacadeServiceUnitTest {
 		String section1 = "1클러스터끝";
 		String section2 = "오아시스";
 		String section3 = "2클러스터끝";
+		String section4 = "테라스1";
+		String section5 = "테라스2";
 		String lentUserName1 = "제발 그만해";
 		String lentUserName2 = "이러다";
 		String lentUserName3 = "다 죽어";
@@ -382,16 +384,24 @@ class CabinetFacadeServiceUnitTest {
 		Cabinet cabinet1 = mock(Cabinet.class);
 		Cabinet cabinet2 = mock(Cabinet.class);
 		Cabinet cabinet3 = mock(Cabinet.class);
+		Cabinet cabinet4 = mock(Cabinet.class);
+		Cabinet cabinet5 = mock(Cabinet.class);
 
 		CabinetPlace cabinetPlace1 = mock(CabinetPlace.class);
 		CabinetPlace cabinetPlace2 = mock(CabinetPlace.class);
 		CabinetPlace cabinetPlace3 = mock(CabinetPlace.class);
+		CabinetPlace cabinetPlace4 = mock(CabinetPlace.class);
+		CabinetPlace cabinetPlace5 = mock(CabinetPlace.class);
 		given(cabinetPlace1.getLocation()).willReturn(Location.of(building, floor, section1));
 		given(cabinetPlace2.getLocation()).willReturn(Location.of(building, floor, section2));
 		given(cabinetPlace3.getLocation()).willReturn(Location.of(building, floor, section3));
+		given(cabinetPlace4.getLocation()).willReturn(Location.of(building, floor, section4));
+		given(cabinetPlace5.getLocation()).willReturn(Location.of(building, floor, section5));
 		given(cabinet1.getCabinetPlace()).willReturn(cabinetPlace1);
 		given(cabinet2.getCabinetPlace()).willReturn(cabinetPlace2);
 		given(cabinet3.getCabinetPlace()).willReturn(cabinetPlace3);
+		given(cabinet4.getCabinetPlace()).willReturn(cabinetPlace4);
+		given(cabinet5.getCabinetPlace()).willReturn(cabinetPlace5);
 
 		User user1 = mock(User.class);
 		User user2 = mock(User.class);
@@ -413,25 +423,32 @@ class CabinetFacadeServiceUnitTest {
 		ActiveCabinetInfoEntities info3 = new ActiveCabinetInfoEntities(cabinet3, lentHistory3, user3);
 		given(cabinetOptionalFetcher.findCabinetsActiveLentHistoriesByBuildingAndFloor(
 				building, floor)).willReturn(List.of(info1, info2, info3));
+		given(cabinetOptionalFetcher.findAllCabinetsByBuildingAndFloor(building, floor))
+				.willReturn(List.of(cabinet1, cabinet2, cabinet3, cabinet4, cabinet5));
 
 		given(cabinetMapper.toCabinetPreviewDto(eq(cabinet1), any(), any())).willReturn(mock(CabinetPreviewDto.class));
 		given(cabinetMapper.toCabinetPreviewDto(eq(cabinet2), any(), any())).willReturn(mock(CabinetPreviewDto.class));
 		given(cabinetMapper.toCabinetPreviewDto(eq(cabinet3), any(), any())).willReturn(mock(CabinetPreviewDto.class));
+		given(cabinetMapper.toCabinetPreviewDto(eq(cabinet4), any(), any())).willReturn(mock(CabinetPreviewDto.class));
+		given(cabinetMapper.toCabinetPreviewDto(eq(cabinet5), any(), any())).willReturn(mock(CabinetPreviewDto.class));
 
 		CabinetsPerSectionResponseDto result1 = mock(CabinetsPerSectionResponseDto.class);
 		CabinetsPerSectionResponseDto result2 = mock(CabinetsPerSectionResponseDto.class);
 		CabinetsPerSectionResponseDto result3 = mock(CabinetsPerSectionResponseDto.class);
+		CabinetsPerSectionResponseDto result4 = mock(CabinetsPerSectionResponseDto.class);
+		CabinetsPerSectionResponseDto result5 = mock(CabinetsPerSectionResponseDto.class);
 
 		given(result1.getSection()).willReturn(section1);
 		given(result2.getSection()).willReturn(section2);
 		given(result3.getSection()).willReturn(section3);
+		given(result4.getSection()).willReturn(section4);
+		given(result5.getSection()).willReturn(section5);
 
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section1), anyList()))
-				.willReturn(result1);
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section2), anyList()))
-				.willReturn(result2);
-		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section3), anyList()))
-				.willReturn(result3);
+		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section1), anyList())).willReturn(result1);
+		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section2), anyList())).willReturn(result2);
+		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section3), anyList())).willReturn(result3);
+		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section4), anyList())).willReturn(result4);
+		given(cabinetMapper.toCabinetsPerSectionResponseDto(eq(section5), anyList())).willReturn(result5);
 
 		//============================== WHEN ==============================
 		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService.getCabinetsPerSection(
@@ -441,6 +458,8 @@ class CabinetFacadeServiceUnitTest {
 		assertEquals(section1, result.get(0).getSection());
 		assertEquals(section2, result.get(1).getSection());
 		assertEquals(section3, result.get(2).getSection());
+		assertEquals(section4, result.get(3).getSection());
+		assertEquals(section5, result.get(4).getSection());
 	}
 
 
@@ -450,9 +469,12 @@ class CabinetFacadeServiceUnitTest {
 		String building = "유토피아";
 		Integer floor = 999;
 		List<ActiveCabinetInfoEntities> emptyList = new ArrayList<>();
+		List<Cabinet> emptyCabinetList = new ArrayList<>();
 
 		given(cabinetOptionalFetcher.findCabinetsActiveLentHistoriesByBuildingAndFloor(building, floor))
 				.willReturn(emptyList);
+		given(cabinetOptionalFetcher.findAllCabinetsByBuildingAndFloor(building, floor))
+				.willReturn(emptyCabinetList);
 
 		// when
 		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService
@@ -462,55 +484,55 @@ class CabinetFacadeServiceUnitTest {
 		assertTrue(result.isEmpty());
 	}
 
-	@Test
-	@Disabled("해당하는 Location이 없는 경우에 빈 배열을 받게 됨")
-	@DisplayName("성공: 해당하는 Location 없음 - 결과 null")
-	void 성공_NULL_getCabinetsPerSection() {
-		String building = "유토피아";
-		String section = "콜로라도";
-		Integer floor = 999;
+//	@Test
+//	@Disabled("해당하는 Location이 없는 경우에 빈 배열을 받게 됨")
+//	@DisplayName("성공: 해당하는 Location 없음 - 결과 null")
+//	void 성공_NULL_getCabinetsPerSection() {
+//		String building = "유토피아";
+//		String section = "콜로라도";
+//		Integer floor = 999;
+//
+//		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
+//				.willReturn(new ArrayList<String>(List.of(section)));
+//
+//		given(cabinetOptionalFetcher.findAllCabinetsByLocation(any()))
+//				.willReturn(new ArrayList<Cabinet>());
+//
+//		// when
+//		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService
+//				.getCabinetsPerSection(building, floor);
+//
+//		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
+//		then(cabinetOptionalFetcher).should().findAllCabinetsByLocation(any());
+//		assertNotNull(result);
+//	}
 
-		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
-				.willReturn(new ArrayList<String>(List.of(section)));
-
-		given(cabinetOptionalFetcher.findAllCabinetsByLocation(any()))
-				.willReturn(new ArrayList<Cabinet>());
-
-		// when
-		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService
-				.getCabinetsPerSection(building, floor);
-
-		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
-		then(cabinetOptionalFetcher).should().findAllCabinetsByLocation(any());
-		assertNotNull(result);
-	}
-
-	@Test
-	@Disabled("변경된 API에서는 반납하지 않은 캐비닛이 없는 경우는 가져오지 않음.")
-	@DisplayName("성공: 반납하지 않은 캐비넷이 없음 - 결과 null")
-	void 성공_findAllActiveLentByCabinetId_EMPTY_getCabinetsPerSection() {
-		String building = "유토피아";
-		String section = "콜로라도";
-		Integer floor = 999;
-
-		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
-				.willReturn(new ArrayList<String>(List.of(section)));
-
-		given(cabinetOptionalFetcher.findAllCabinetsByLocation(any()))
-				.willReturn(new ArrayList<Cabinet>(List.of(mock(Cabinet.class))));
-
-		given(lentOptionalFetcher.findAllActiveLentByCabinetId(any()))
-				.willReturn(new ArrayList<LentHistory>());
-		// when
-		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService
-				.getCabinetsPerSection(building, floor);
-
-		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
-		then(cabinetOptionalFetcher).should().findAllCabinetsByLocation(any());
-		then(lentOptionalFetcher).should().findAllActiveLentByCabinetId(any());
-
-		assertNotNull(result);
-	}
+//	@Test
+//	@Disabled("변경된 API에서는 반납하지 않은 캐비닛이 없는 경우는 가져오지 않음.")
+//	@DisplayName("성공: 반납하지 않은 캐비넷이 없음 - 결과 null")
+//	void 성공_findAllActiveLentByCabinetId_EMPTY_getCabinetsPerSection() {
+//		String building = "유토피아";
+//		String section = "콜로라도";
+//		Integer floor = 999;
+//
+//		given(cabinetOptionalFetcher.findAllSectionsByBuildingAndFloor(building, floor))
+//				.willReturn(new ArrayList<String>(List.of(section)));
+//
+//		given(cabinetOptionalFetcher.findAllCabinetsByLocation(any()))
+//				.willReturn(new ArrayList<Cabinet>(List.of(mock(Cabinet.class))));
+//
+//		given(lentOptionalFetcher.findAllActiveLentByCabinetId(any()))
+//				.willReturn(new ArrayList<LentHistory>());
+//		// when
+//		List<CabinetsPerSectionResponseDto> result = cabinetFacadeService
+//				.getCabinetsPerSection(building, floor);
+//
+//		then(cabinetOptionalFetcher).should().findAllSectionsByBuildingAndFloor(building, floor);
+//		then(cabinetOptionalFetcher).should().findAllCabinetsByLocation(any());
+//		then(lentOptionalFetcher).should().findAllActiveLentByCabinetId(any());
+//
+//		assertNotNull(result);
+//	}
 
 	@Test
 	@DisplayName("성공: 대여타입으로 캐비넷 정보 page로 가져오기 1페이지, 최대 10개 - 결과 3개 (개인 캐비넷)")

--- a/backend/src/test/java/org/ftclub/cabinet/lent/repository/LentRepositoryTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/repository/LentRepositoryTest.java
@@ -28,14 +28,14 @@ class LentRepositoryTest {
 		// 빌리고 있는 유저가 없는 cabinet id
 		Long cabinetId = 2L;
 
-		Optional<LentHistory> ent = lentRepository.findFirstByCabinetIdAndEndedAtIsNull(cabinetId);
+		Optional<LentHistory> ent = lentRepository.findByCabinetIdAndEndedAtIsNull(cabinetId);
 		assertTrue(ent.isEmpty());
 
 		LentHistory lentHistory =
 				LentHistory.of(now, now.plusDays(3), 1L, cabinetId);
 
 		LentHistory saved = lentRepository.save(lentHistory);
-		ent = lentRepository.findFirstByCabinetIdAndEndedAtIsNull(cabinetId);
+		ent = lentRepository.findByCabinetIdAndEndedAtIsNull(cabinetId);
 		assertTrue(ent.isPresent());
 		assertEquals(saved, ent.get());
 	}
@@ -46,14 +46,14 @@ class LentRepositoryTest {
 		// 빌리고 있는 사물함이 없는 user id
 		Long userId = 1L;
 
-		Optional<LentHistory> ent = lentRepository.findFirstByUserIdAndEndedAtIsNull(userId);
+		Optional<LentHistory> ent = lentRepository.findByUserIdAndEndedAtIsNull(userId);
 		assertTrue(ent.isEmpty());
 
 		LentHistory lentHistory =
 				LentHistory.of(now, now.plusDays(3), userId, 1L);
 
 		LentHistory saved = lentRepository.save(lentHistory);
-		ent = lentRepository.findFirstByUserIdAndEndedAtIsNull(userId);
+		ent = lentRepository.findByUserIdAndEndedAtIsNull(userId);
 		assertTrue(ent.isPresent());
 		assertEquals(saved, ent.get());
 	}
@@ -62,12 +62,14 @@ class LentRepositoryTest {
 	void findByUserId() {
 		// 빌린 기록이 없는 user id
 		long userId = 18L;
-		List<LentHistory> lentHistories = lentRepository.findByUserId(userId, PageRequest.of(0, 1));
+		List<LentHistory> lentHistories = lentRepository.findPaginationByUserId(userId,
+				PageRequest.of(0, 1)).toList();
 		assertTrue(lentHistories.isEmpty());
 
 		// 빌린 기록이 12개 있는 user id
 		userId = 5L;
-		lentHistories = lentRepository.findByUserId(userId, PageRequest.of(0, 20));
+		lentHistories = lentRepository.findPaginationByUserId(userId,
+				PageRequest.of(0, 20)).toList();
 		assertEquals(12, lentHistories.size());
 	}
 
@@ -75,13 +77,14 @@ class LentRepositoryTest {
 	void findByCabinetId() {
 		// 빌린 기록이 없는 cabinet id
 		long cabinetId = 1L;
-		List<LentHistory> lentHistories = lentRepository.findByCabinetId(cabinetId,
-				PageRequest.of(0, 1));
+		List<LentHistory> lentHistories = lentRepository.findPaginationByCabinetId(cabinetId,
+				PageRequest.of(0, 1)).toList();
 		assertTrue(lentHistories.isEmpty());
 
 		// 빌린 기록이 6개 있는 cabinet id
 		cabinetId = 3L;
-		lentHistories = lentRepository.findByCabinetId(cabinetId, PageRequest.of(0, 20));
+		lentHistories = lentRepository.findPaginationByCabinetId(cabinetId,
+				PageRequest.of(0, 20)).toList();
 		assertEquals(6, lentHistories.size());
 	}
 
@@ -89,7 +92,7 @@ class LentRepositoryTest {
 	void countUserActiveLent() {
 		// 빌리고 잇는 기록이 1개인 user id
 		Long userId = 5L;
-		int count = lentRepository.countUserActiveLent(userId);
+		int count = lentRepository.countByUserIdAndEndedAtIsNull(userId);
 		assertEquals(1, count);
 	}
 
@@ -97,7 +100,7 @@ class LentRepositoryTest {
 	void countCabinetActiveLent() {
 		// 빌리고 있는 기록이 3개 있는 cabinet id
 		Long cabinetId = 4L;
-		int count = lentRepository.countCabinetActiveLent(cabinetId);
+		int count = lentRepository.countByCabinetIdAndEndedAtIsNull(cabinetId);
 		assertEquals(3, count);
 	}
 
@@ -105,7 +108,7 @@ class LentRepositoryTest {
 	void countUserAllLent() {
 		// 빌린 기록이 12개 있는 user id
 		Long userId = 5L;
-		int count = lentRepository.countUserAllLent(userId);
+		int count = lentRepository.countByUserId(userId);
 		assertEquals(12, count);
 	}
 
@@ -113,7 +116,7 @@ class LentRepositoryTest {
 	void countCabinetAllLent() {
 		// 빌린 기록이 6개 있는 cabinet id
 		Long cabinetId = 3L;
-		int count = lentRepository.countCabinetAllLent(cabinetId);
+		int count = lentRepository.countByCabinetId(cabinetId);
 		assertEquals(6, count);
 	}
 
@@ -121,10 +124,10 @@ class LentRepositoryTest {
 	void findAllActiveLentByCabinetId() {
 		// 빌리고 있는 기록이 3개 있는 cabinet id
 		long cabinetId = 4L;
-		List<LentHistory> lentHistories = lentRepository.findAllActiveLentByCabinetId(cabinetId);
+		List<LentHistory> lentHistories = lentRepository.findAllByCabinetIdAndEndedAtIsNull(cabinetId);
 		assertEquals(3, lentHistories.size());
 		cabinetId = 2L;
-		lentHistories = lentRepository.findAllActiveLentByCabinetId(cabinetId);
+		lentHistories = lentRepository.findAllByCabinetIdAndEndedAtIsNull(cabinetId);
 		assertTrue(lentHistories.isEmpty());
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/lent/service/LentServiceImplTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/service/LentServiceImplTest.java
@@ -157,18 +157,18 @@ class LentServiceImplTest {
 	@DisplayName("사물함 대여 가능한 사용자는 available, limited_available 상태의 사물함을 빌릴 수 있습니다 ")
 	void generalLentSituation() {
 		// given
-		int lentCountBefore = lentRepository.countUserActiveLent(normalUser1.getUserId());
+		int lentCountBefore = lentRepository.countByUserIdAndEndedAtIsNull(normalUser1.getUserId());
 		// when
 		lentService.startLentCabinet(normalUser1.getUserId(),
 				privateAvailableCabinet1.getCabinetId());
 		// then
-		int lentCountAfter = lentRepository.countUserActiveLent(normalUser1.getUserId());
-		LentHistory lentHistory = lentRepository.findFirstByUserIdAndEndedAtIsNull(
+		int lentCountAfter = lentRepository.countByUserIdAndEndedAtIsNull(normalUser1.getUserId());
+		LentHistory lentHistory = lentRepository.findByUserIdAndEndedAtIsNull(
 				normalUser1.getUserId()).orElseThrow(() -> new RuntimeException());
 		Assertions.assertEquals(lentCountAfter, lentCountBefore + 1L);
 		Assertions.assertEquals(CabinetStatus.FULL, privateAvailableCabinet1.getStatus());
 		Assertions.assertNotNull(
-				lentRepository.findFirstByUserIdAndEndedAtIsNull(normalUser1.getUserId())
+				lentRepository.findByUserIdAndEndedAtIsNull(normalUser1.getUserId())
 						.orElse(null));
 	}
 
@@ -246,7 +246,7 @@ class LentServiceImplTest {
 		// when
 		lentService.startLentCabinet(userId1, cabinetId);
 		assertEquals(CabinetStatus.AVAILABLE, cabinet.getStatus());
-		List<LentHistory> activeLentHistory = lentRepository.findAllActiveLentByCabinetId(
+		List<LentHistory> activeLentHistory = lentRepository.findAllByCabinetIdAndEndedAtIsNull(
 				cabinetId);
 		for (LentHistory lentHistory : activeLentHistory) {
 			assertEquals(DateUtil.getInfinityDate(), lentHistory.getExpiredAt());
@@ -259,7 +259,7 @@ class LentServiceImplTest {
 
 		lentService.startLentCabinet(userId3, cabinetId);
 		assertEquals(CabinetStatus.FULL, cabinet.getStatus());
-		activeLentHistory = lentRepository.findAllActiveLentByCabinetId(cabinetId);
+		activeLentHistory = lentRepository.findAllByCabinetIdAndEndedAtIsNull(cabinetId);
 		// then
 		for (LentHistory lentHistory : activeLentHistory) {
 			assertNotEquals(DateUtil.getInfinityDate(), lentHistory.getExpiredAt());
@@ -282,7 +282,7 @@ class LentServiceImplTest {
 		lentService.startLentCabinet(userId2, cabinetId);
 		lentService.startLentCabinet(userId3, cabinetId);
 		assertEquals(CabinetStatus.FULL, cabinet.getStatus());
-		List<LentHistory> activeLentHistory = lentRepository.findAllActiveLentByCabinetId(
+		List<LentHistory> activeLentHistory = lentRepository.findAllByCabinetIdAndEndedAtIsNull(
 				cabinetId);
 		for (LentHistory lentHistory : activeLentHistory) {
 			assertNotEquals(DateUtil.getInfinityDate(), lentHistory.getExpiredAt());
@@ -293,9 +293,9 @@ class LentServiceImplTest {
 
 		lentService.startLentCabinet(userId4, cabinetId);
 		assertEquals(CabinetStatus.FULL, cabinet.getStatus());
-		LentHistory latestLentHistory = lentRepository.findFirstByCabinetIdAndEndedAtIsNull(
+		LentHistory latestLentHistory = lentRepository.findByCabinetIdAndEndedAtIsNull(
 				cabinetId).orElse(null);
-		activeLentHistory = lentRepository.findAllActiveLentByCabinetId(cabinetId);
+		activeLentHistory = lentRepository.findAllByCabinetIdAndEndedAtIsNull(cabinetId);
 		for (LentHistory lentHistory : activeLentHistory) {
 			assertEquals(latestLentHistory.getExpiredAt(), lentHistory.getExpiredAt());
 		}

--- a/backend/src/test/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceUnitTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/statistics/service/StatisticsFacadeServiceUnitTest.java
@@ -57,7 +57,7 @@ class StatisticsFacadeServiceUnitTest {
 				.willReturn(floors);
 		given(statisticsRepository.getAvailableCabinetsId(any()))
 				.willReturn(availableCabinetsId);
-		given(lentRepository.countCabinetActiveLent(cabinetId))
+		given(lentRepository.countByCabinetIdAndEndedAtIsNull(cabinetId))
 				.willReturn(activeUserCount);
 		List<CabinetFloorStatisticsResponseDto> cabinetFloorStatisticsResponseDtosOrigin = new ArrayList<>();
 		for (Integer i = 2; i <= 5; i++) {

--- a/backend/src/test/java/org/ftclub/cabinet/user/service/LentExtensionServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/service/LentExtensionServiceTest.java
@@ -41,24 +41,5 @@ public class LentExtensionServiceTest {
 			em.persist(sanan);
 			em.persist(jpark2);
 		}
-
-		@Test
-		@DisplayName("현재 시간을 기준으로 만료된 연장권들을 soft delete한다.")
-		void 삭제() {
-			LentExtension expired = LentExtension.of("extension", 31, now.minusDays(1), LentExtensionType.ALL, sanan.getUserId());
-			LentExtension valid = LentExtension.of("extension", 31, now.plusDays(1), LentExtensionType.ALL, jpark2.getUserId());
-			em.persist(expired);
-			em.persist(valid);
-			em.flush();
-			em.clear();
-
-			lentExtensionService.deleteExpiredExtensions();
-
-			LentExtension mustDeleted = lentExtensionRepository.findById(expired.getLentExtensionId()).get();
-			LentExtension mustValid = lentExtensionRepository.findById(valid.getLentExtensionId()).get();
-			assertThat(mustDeleted.getDeletedAt()).isNotNull();
-			assertThat(mustValid.getDeletedAt()).isNull();
-		}
-
 	}
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

수정사항
1. cabinet pending 사물함 조회 로직 수정
2. Cabinet, LentHistory 리팩토링 
   - repository 이름 통일 - 단건 조회 find, 다건 조회 findAll
   - 층 전체 조회 로직 가독성 개선
   - 미사용 코드 삭제
3. 로컬에서 테스트 돌리면 FCM Initializer 때문에 동작 안되는 현상 임시 해결(추후 리팩토링 필요)