### PR TITLE
[FE] FEAT: 개인 사물함도 title 을 변경할 수 있도록 기능 추가 #1428

### DIFF
--- a/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
+++ b/frontend/src/components/CabinetList/CabinetListItem/CabinetListItem.tsx
@@ -60,12 +60,12 @@ const CabinetListItem = (props: CabinetPreviewInfo): JSX.Element => {
     props.status != "IN_SESSION" &&
     props.status != "PENDING"
   ) {
-    if (props.lentType === "PRIVATE") cabinetLabelText = props.name;
-    else if (props.lentType === "SHARE") {
-      cabinetLabelText =
-        !!props.title
-          ? props.title
-          : `${props.userCount} / ${props.maxUser}`;
+    if (props.lentType === "PRIVATE") {
+      cabinetLabelText = !!props.title ? props.title : props.name;
+    } else if (props.lentType === "SHARE") {
+      cabinetLabelText = !!props.title
+        ? props.title
+        : `${props.userCount} / ${props.maxUser}`;
     } else if (props.lentType === "CLUB")
       cabinetLabelText = props.title ? props.title : "동아리";
   } else {

--- a/frontend/src/components/Modals/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/Modals/MemoModal/MemoModal.tsx
@@ -29,9 +29,7 @@ const MemoModal = ({
   const newMemo = useRef<HTMLInputElement>(null);
   const handleClickWriteMode = (e: any) => {
     setMode("write");
-    if (cabinetType === "PRIVATE" && newMemo.current) {
-      newMemo.current.select();
-    } else if (newTitle.current) {
+    if (newTitle.current) {
       newTitle.current.select();
     }
   };
@@ -39,13 +37,14 @@ const MemoModal = ({
     //사물함 제목, 사물함 비밀메모 update api 호출
     // onClose(e);
     document.getElementById("unselect-input")?.focus();
-    if (cabinetType === "SHARE" && newTitle.current!.value) {
+    if (newTitle.current!.value) {
       onSave(newTitle.current!.value, newMemo.current!.value);
     } else {
       onSave(null, newMemo.current!.value);
     }
     setMode("read");
   };
+
   return (
     <ModalPortal>
       <BackgroundStyled onClick={onClose} />
@@ -56,7 +55,7 @@ const MemoModal = ({
         <H2Styled>메모 관리</H2Styled>
         <ContentSectionStyled>
           <ContentItemSectionStyled>
-            <ContentItemWrapperStyled isVisible={cabinetType !== "PRIVATE"}>
+            <ContentItemWrapperStyled>
               <ContentItemTitleStyled>사물함 이름</ContentItemTitleStyled>
               <ContentItemInputStyled
                 onKeyUp={(e: any) => {
@@ -72,7 +71,7 @@ const MemoModal = ({
                 maxLength={MAX_INPUT_LENGTH}
               />
             </ContentItemWrapperStyled>
-            <ContentItemWrapperStyled isVisible={true}>
+            <ContentItemWrapperStyled>
               <ContentItemTitleStyled>비밀 메모</ContentItemTitleStyled>
               <ContentItemInputStyled
                 onKeyUp={(e: any) => {
@@ -157,8 +156,8 @@ const ContentItemSectionStyled = styled.div`
   width: 100%;
 `;
 
-const ContentItemWrapperStyled = styled.div<{ isVisible: boolean }>`
-  display: ${({ isVisible }) => (isVisible ? "flex" : "none")};
+const ContentItemWrapperStyled = styled.div`
+  display: flex;
   flex-direction: column;
   align-items: flex-start;
   margin-bottom: 25px;

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -44,35 +44,16 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
   const [myCabinetInfo, setMyCabinetInfo] = useRecoilState(myCabinetInfoState);
   const { pathname } = useLocation();
   const navigator = useNavigate();
-  const defaultCabinetInfo = getDefaultCabinetInfo();
-  const resetCabinetInfo = () => {
-    setMyCabinetInfo({
-      ...defaultCabinetInfo,
-      memo: "",
-      shareCode: 0,
-      previousUserName: "",
-    });
-    setTargetCabinetInfo(defaultCabinetInfo);
-    setCurrentCabinetId(0);
-  };
+
   async function setTargetCabinetInfoToMyCabinet() {
-    if (myInfo.cabinetId === null && !myCabinetInfo?.cabinetId) {
-      resetCabinetInfo();
-    } else setCurrentCabinetId(myInfo.cabinetId);
+    setCurrentCabinetId(myInfo.cabinetId);
     setMyInfo((prev) => ({ ...prev, cabinetId: null }));
     try {
       if (!myCabinetInfo?.cabinetId) return;
       const { data } = await axiosCabinetById(myCabinetInfo.cabinetId);
       if (data.lents.length === 0 && myInfo.cabinetId !== null) {
-        resetCabinetInfo();
         setMyInfo((prev) => ({ ...prev, cabinetId: null }));
       } else {
-        setMyCabinetInfo((prev) => ({
-          ...data,
-          memo: "",
-          shareCode: prev.shareCode,
-          previousUserName: prev.previousUserName,
-        }));
         const doesNameExist = data.lents.some(
           (lent: LentDto) => lent.name === myInfo.name
         );
@@ -80,7 +61,7 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
           setTargetCabinetInfo(data);
           setCurrentCabinetId(data.cabinetId);
           setMyInfo((prev) => ({ ...prev, cabinetId: data.cabinetId }));
-        } else resetCabinetInfo();
+        }
       }
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1428
- 개인 사물함도 title 변경이 가능하도록 기능을 수정하였습니다. 
- 기존에 공유 사물함과 title 로직이 있었고, 개인 사물함이면 title을 변경할 수 있는 부분을 보이지 않게만 해놓은 상태였기에 이 부분을 지워서 개인 사물함도 title변경이 가능하도록 수정하였습니다.
- top에 있는 내 사물함을 눌렀을 때 memo를 초기화하던 코드가 남아있어서 이 부분도 지워서 memo가 잘 남도록 하였습니다.
 